### PR TITLE
fix: multiple HLE OS problems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.0.0"
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +181,7 @@ dependencies = [
 name = "os"
 version = "0.1.0"
 dependencies = [
+ "blake3",
  "common",
  "cpu",
  "device",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.94"
 [workspace.dependencies]
 # Internal dependencies
 audio_engine = { path = "crates/audio_engine" }
+blake3 = { path = "crates/blake3" }
 common = { path = "crates/common" }
 cpu = { path = "crates/cpu" }
 device = { path = "crates/device" }
@@ -76,6 +77,10 @@ opt-level = 3
 codegen-units = 1
 
 [profile.dev.package.audio_engine]
+opt-level = 3
+codegen-units = 1
+
+[profile.dev.package.blake3]
 opt-level = 3
 codegen-units = 1
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ For example, if your global config sets `machine = PC9801RA` and you run
 | GUI + Alt + F9     | Open floppy selector for drive 1 |
 | GUI + Alt + F10    | Open floppy selector for drive 2 |
 | GUI + Alt + F11    | Open CD-ROM selector             |
+| GUI + Alt + F12    | Log HLE DOS memory overview      |
 
 (GUI is the Windows / Command key)
 

--- a/crates/blake3/Cargo.toml
+++ b/crates/blake3/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "blake3"
+version = "1.0.0"
+authors = ["Jack O'Connor <oconnor663@gmail.com>", "Samuel Neves"]
+description = "The portable reference implementation of the BLAKE3 hash function"
+license = "CC0-1"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[features]
+
+[dependencies]

--- a/crates/blake3/LICENSE
+++ b/crates/blake3/LICENSE
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/crates/blake3/src/lib.rs
+++ b/crates/blake3/src/lib.rs
@@ -1,0 +1,433 @@
+//! This BLAKE3 implementation is based on the portable code of the reference implementation.
+//!
+//! # Example
+//!
+//! ```
+//! let mut hasher = blake3::Hasher::new();
+//! hasher.update(b"abc");
+//! hasher.update(b"def");
+//! let mut hash = [0; 32];
+//! hasher.finalize(&mut hash);
+//! let mut extended_hash = [0; 500];
+//! hasher.finalize(&mut extended_hash);
+//! assert_eq!(hash, extended_hash[..32]);
+//! ```
+
+use core::cmp::min;
+
+const OUT_LEN: usize = 32;
+const KEY_LEN: usize = 32;
+const BLOCK_LEN: usize = 64;
+const CHUNK_LEN: usize = 1024;
+
+const CHUNK_START: u32 = 1 << 0;
+const CHUNK_END: u32 = 1 << 1;
+const PARENT: u32 = 1 << 2;
+const ROOT: u32 = 1 << 3;
+const KEYED_HASH: u32 = 1 << 4;
+const DERIVE_KEY_CONTEXT: u32 = 1 << 5;
+const DERIVE_KEY_MATERIAL: u32 = 1 << 6;
+
+const IV: [u32; 8] = [
+    0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
+];
+
+#[rustfmt::skip]
+const MSG_SCHEDULE: [[usize; 16]; 7] = [
+    [0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15],
+    [2,  6,  3,  10, 7,  0,  4,  13, 1,  11, 12, 5,  9,  14, 15, 8 ],
+    [3,  4,  10, 12, 13, 2,  7,  14, 6,  5,  9,  0,  11, 15, 8,  1 ],
+    [10, 7,  12, 9,  14, 3,  13, 15, 4,  0,  11, 2,  5,  8,  1,  6 ],
+    [12, 13, 9,  11, 15, 10, 14, 8,  7,  2,  5,  3,  0,  1,  6,  4 ],
+    [9,  14, 11, 5,  8,  12, 15, 1,  13, 3,  0,  10, 2,  6,  4,  7 ],
+    [11, 15, 5,  0,  1,  9,  8,  6,  14, 10, 2,  12, 3,  4,  7,  13],
+];
+
+#[inline(always)]
+fn g(state: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, mx: u32, my: u32) {
+    state[a] = state[a].wrapping_add(state[b]).wrapping_add(mx);
+    state[d] = (state[d] ^ state[a]).rotate_right(16);
+    state[c] = state[c].wrapping_add(state[d]);
+    state[b] = (state[b] ^ state[c]).rotate_right(12);
+    state[a] = state[a].wrapping_add(state[b]).wrapping_add(my);
+    state[d] = (state[d] ^ state[a]).rotate_right(8);
+    state[c] = state[c].wrapping_add(state[d]);
+    state[b] = (state[b] ^ state[c]).rotate_right(7);
+}
+
+#[inline(always)]
+fn round(state: &mut [u32; 16], m: &[u32; 16], round: usize) {
+    let s = MSG_SCHEDULE[round];
+    // Mix the columns.
+    g(state, 0, 4, 8, 12, m[s[0]], m[s[1]]);
+    g(state, 1, 5, 9, 13, m[s[2]], m[s[3]]);
+    g(state, 2, 6, 10, 14, m[s[4]], m[s[5]]);
+    g(state, 3, 7, 11, 15, m[s[6]], m[s[7]]);
+    // Mix the diagonals.
+    g(state, 0, 5, 10, 15, m[s[8]], m[s[9]]);
+    g(state, 1, 6, 11, 12, m[s[10]], m[s[11]]);
+    g(state, 2, 7, 8, 13, m[s[12]], m[s[13]]);
+    g(state, 3, 4, 9, 14, m[s[14]], m[s[15]]);
+}
+
+#[inline(always)]
+fn compress(
+    chaining_value: &[u32; 8],
+    block_words: &[u32; 16],
+    counter: u64,
+    block_len: u32,
+    flags: u32,
+) -> [u32; 16] {
+    let counter_low = counter as u32;
+    let counter_high = (counter >> 32) as u32;
+
+    #[rustfmt::skip]
+    let mut state = [
+        chaining_value[0], chaining_value[1], chaining_value[2], chaining_value[3],
+        chaining_value[4], chaining_value[5], chaining_value[6], chaining_value[7],
+        IV[0],             IV[1],             IV[2],             IV[3],
+        counter_low,       counter_high,      block_len,         flags,
+    ];
+
+    round(&mut state, block_words, 0);
+    round(&mut state, block_words, 1);
+    round(&mut state, block_words, 2);
+    round(&mut state, block_words, 3);
+    round(&mut state, block_words, 4);
+    round(&mut state, block_words, 5);
+    round(&mut state, block_words, 6);
+
+    state[0] ^= state[8];
+    state[1] ^= state[9];
+    state[2] ^= state[10];
+    state[3] ^= state[11];
+    state[4] ^= state[12];
+    state[5] ^= state[13];
+    state[6] ^= state[14];
+    state[7] ^= state[15];
+    state[8] ^= chaining_value[0];
+    state[9] ^= chaining_value[1];
+    state[10] ^= chaining_value[2];
+    state[11] ^= chaining_value[3];
+    state[12] ^= chaining_value[4];
+    state[13] ^= chaining_value[5];
+    state[14] ^= chaining_value[6];
+    state[15] ^= chaining_value[7];
+    state
+}
+
+fn first_8_words(compression_output: [u32; 16]) -> [u32; 8] {
+    compression_output[0..8].try_into().unwrap()
+}
+
+fn words_from_little_endian_bytes(bytes: &[u8], words: &mut [u32]) {
+    debug_assert_eq!(bytes.len(), 4 * words.len());
+    for (four_bytes, word) in bytes.chunks_exact(4).zip(words) {
+        *word = u32::from_le_bytes(four_bytes.try_into().unwrap());
+    }
+}
+
+/// Each chunk or parent node can produce either an 8-word chaining value or, by
+/// setting the ROOT flag, any number of final output bytes. The Output struct
+/// captures the state just prior to choosing between those two possibilities.
+struct Output {
+    input_chaining_value: [u32; 8],
+    block_words: [u32; 16],
+    counter: u64,
+    block_len: u32,
+    flags: u32,
+}
+
+impl Output {
+    fn chaining_value(&self) -> [u32; 8] {
+        first_8_words(compress(
+            &self.input_chaining_value,
+            &self.block_words,
+            self.counter,
+            self.block_len,
+            self.flags,
+        ))
+    }
+
+    fn root_output_bytes(&self, out_slice: &mut [u8]) {
+        for (output_block_counter, out_block) in out_slice.chunks_mut(2 * OUT_LEN).enumerate() {
+            let words = compress(
+                &self.input_chaining_value,
+                &self.block_words,
+                output_block_counter as u64,
+                self.block_len,
+                self.flags | ROOT,
+            );
+            // The output length might not be a multiple of 4.
+            for (word, out_word) in words.iter().zip(out_block.chunks_mut(4)) {
+                out_word.copy_from_slice(&word.to_le_bytes()[..out_word.len()]);
+            }
+        }
+    }
+}
+
+struct ChunkState {
+    chaining_value: [u32; 8],
+    chunk_counter: u64,
+    block: [u8; BLOCK_LEN],
+    block_len: u8,
+    blocks_compressed: u8,
+    flags: u32,
+}
+
+impl ChunkState {
+    fn new(key_words: [u32; 8], chunk_counter: u64, flags: u32) -> Self {
+        Self {
+            chaining_value: key_words,
+            chunk_counter,
+            block: [0; BLOCK_LEN],
+            block_len: 0,
+            blocks_compressed: 0,
+            flags,
+        }
+    }
+
+    fn len(&self) -> usize {
+        BLOCK_LEN * self.blocks_compressed as usize + self.block_len as usize
+    }
+
+    fn start_flag(&self) -> u32 {
+        if self.blocks_compressed == 0 {
+            CHUNK_START
+        } else {
+            0
+        }
+    }
+
+    fn update(&mut self, mut input: &[u8]) {
+        while !input.is_empty() {
+            // If the block buffer is full, compress it and clear it. More
+            // input is coming, so this compression is not CHUNK_END.
+            if self.block_len as usize == BLOCK_LEN {
+                let mut block_words = [0; 16];
+                words_from_little_endian_bytes(&self.block, &mut block_words);
+                self.chaining_value = first_8_words(compress(
+                    &self.chaining_value,
+                    &block_words,
+                    self.chunk_counter,
+                    BLOCK_LEN as u32,
+                    self.flags | self.start_flag(),
+                ));
+                self.blocks_compressed += 1;
+                self.block = [0; BLOCK_LEN];
+                self.block_len = 0;
+            }
+
+            // Copy input bytes into the block buffer.
+            let want = BLOCK_LEN - self.block_len as usize;
+            let take = min(want, input.len());
+            self.block[self.block_len as usize..][..take].copy_from_slice(&input[..take]);
+            self.block_len += take as u8;
+            input = &input[take..];
+        }
+    }
+
+    fn output(&self) -> Output {
+        let mut block_words = [0; 16];
+        words_from_little_endian_bytes(&self.block, &mut block_words);
+        Output {
+            input_chaining_value: self.chaining_value,
+            block_words,
+            counter: self.chunk_counter,
+            block_len: self.block_len as u32,
+            flags: self.flags | self.start_flag() | CHUNK_END,
+        }
+    }
+}
+
+fn parent_output(
+    left_child_cv: [u32; 8],
+    right_child_cv: [u32; 8],
+    key_words: [u32; 8],
+    flags: u32,
+) -> Output {
+    let mut block_words = [0; 16];
+    block_words[..8].copy_from_slice(&left_child_cv);
+    block_words[8..].copy_from_slice(&right_child_cv);
+    Output {
+        input_chaining_value: key_words,
+        block_words,
+        counter: 0,                  // Always 0 for parent nodes.
+        block_len: BLOCK_LEN as u32, // Always BLOCK_LEN (64) for parent nodes.
+        flags: PARENT | flags,
+    }
+}
+
+fn parent_cv(
+    left_child_cv: [u32; 8],
+    right_child_cv: [u32; 8],
+    key_words: [u32; 8],
+    flags: u32,
+) -> [u32; 8] {
+    parent_output(left_child_cv, right_child_cv, key_words, flags).chaining_value()
+}
+
+/// An incremental hasher that can accept any number of writes.
+pub struct Hasher {
+    chunk_state: ChunkState,
+    key_words: [u32; 8],
+    cv_stack: [[u32; 8]; 54], // Space for 54 subtree chaining values:
+    cv_stack_len: u8,         // 2^54 * CHUNK_LEN = 2^64
+    flags: u32,
+}
+
+impl Default for Hasher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Hasher {
+    fn new_internal(key_words: [u32; 8], flags: u32) -> Self {
+        Self {
+            chunk_state: ChunkState::new(key_words, 0, flags),
+            key_words,
+            cv_stack: [[0; 8]; 54],
+            cv_stack_len: 0,
+            flags,
+        }
+    }
+
+    /// Construct a new `Hasher` for the regular hash function.
+    pub fn new() -> Self {
+        Self::new_internal(IV, 0)
+    }
+
+    /// Construct a new `Hasher` for the keyed hash function.
+    pub fn new_keyed(key: &[u8; KEY_LEN]) -> Self {
+        let mut key_words = [0; 8];
+        words_from_little_endian_bytes(key, &mut key_words);
+        Self::new_internal(key_words, KEYED_HASH)
+    }
+
+    /// Construct a new `Hasher` for the key derivation function. The context
+    /// string should be hardcoded, globally unique, and application-specific.
+    pub fn new_derive_key(context: &str) -> Self {
+        let mut context_hasher = Self::new_internal(IV, DERIVE_KEY_CONTEXT);
+        context_hasher.update(context.as_bytes());
+        let mut context_key = [0; KEY_LEN];
+        context_hasher.finalize(&mut context_key);
+        let mut context_key_words = [0; 8];
+        words_from_little_endian_bytes(&context_key, &mut context_key_words);
+        Self::new_internal(context_key_words, DERIVE_KEY_MATERIAL)
+    }
+
+    fn push_stack(&mut self, cv: [u32; 8]) {
+        self.cv_stack[self.cv_stack_len as usize] = cv;
+        self.cv_stack_len += 1;
+    }
+
+    fn pop_stack(&mut self) -> [u32; 8] {
+        self.cv_stack_len -= 1;
+        self.cv_stack[self.cv_stack_len as usize]
+    }
+
+    // Section 5.1.2 of the BLAKE3 spec explains this algorithm in more detail.
+    fn add_chunk_chaining_value(&mut self, mut new_cv: [u32; 8], mut total_chunks: u64) {
+        // This chunk might complete some subtrees. For each completed subtree,
+        // its left child will be the current top entry in the CV stack, and
+        // its right child will be the current value of `new_cv`. Pop each left
+        // child off the stack, merge it with `new_cv`, and overwrite `new_cv`
+        // with the result. After all these merges, push the final value of
+        // `new_cv` onto the stack. The number of completed subtrees is given
+        // by the number of trailing 0-bits in the new total number of chunks.
+        while total_chunks & 1 == 0 {
+            new_cv = parent_cv(self.pop_stack(), new_cv, self.key_words, self.flags);
+            total_chunks >>= 1;
+        }
+        self.push_stack(new_cv);
+    }
+
+    /// Add input to the hash state. This can be called any number of times.
+    pub fn update(&mut self, mut input: &[u8]) {
+        while !input.is_empty() {
+            // If the current chunk is complete, finalize it and reset the
+            // chunk state. More input is coming, so this chunk is not ROOT.
+            if self.chunk_state.len() == CHUNK_LEN {
+                let chunk_cv = self.chunk_state.output().chaining_value();
+                let total_chunks = self.chunk_state.chunk_counter + 1;
+                self.add_chunk_chaining_value(chunk_cv, total_chunks);
+                self.chunk_state = ChunkState::new(self.key_words, total_chunks, self.flags);
+            }
+
+            // Compress input bytes into the current chunk state.
+            let want = CHUNK_LEN - self.chunk_state.len();
+            let take = min(want, input.len());
+            self.chunk_state.update(&input[..take]);
+            input = &input[take..];
+        }
+    }
+
+    /// Finalize the hash and write any number of output bytes.
+    pub fn finalize(&self, out_slice: &mut [u8]) {
+        // Starting with the Output from the current chunk, compute all the
+        // parent chaining values along the right edge of the tree, until we
+        // have the root Output.
+        let mut output = self.chunk_state.output();
+        let mut parent_nodes_remaining = self.cv_stack_len as usize;
+        while parent_nodes_remaining > 0 {
+            parent_nodes_remaining -= 1;
+            output = parent_output(
+                self.cv_stack[parent_nodes_remaining],
+                output.chaining_value(),
+                self.key_words,
+                self.flags,
+            );
+        }
+        output.root_output_bytes(out_slice);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_known_vectors() {
+        // Empty input
+        let mut hasher = Hasher::new();
+        hasher.update(b"");
+        let mut hash = [0u8; 32];
+        hasher.finalize(&mut hash);
+        assert_eq!(
+            hash,
+            [
+                0xAF, 0x13, 0x49, 0xB9, 0xF5, 0xF9, 0xA1, 0xA6, 0xA0, 0x40, 0x4D, 0xEA, 0x36, 0xDC,
+                0xC9, 0x49, 0x9B, 0xCB, 0x25, 0xC9, 0xAD, 0xC1, 0x12, 0xB7, 0xCC, 0x9A, 0x93, 0xCA,
+                0xE4, 0x1F, 0x32, 0x62,
+            ],
+        );
+
+        // 3-byte input "abc"
+        let mut hasher = Hasher::new();
+        hasher.update(b"abc");
+        let mut hash = [0u8; 32];
+        hasher.finalize(&mut hash);
+        let expected_hex = "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85";
+        let expected: Vec<u8> = (0..32)
+            .map(|i| u8::from_str_radix(&expected_hex[i * 2..i * 2 + 2], 16).unwrap())
+            .collect();
+        assert_eq!(hash, expected.as_slice());
+
+        // Multi-chunk input (>1024 bytes) to exercise the tree structure
+        let mut hasher = Hasher::new();
+        let input: Vec<u8> = (0..2048).map(|i| (i % 251) as u8).collect();
+        hasher.update(&input);
+        let mut hash_whole = [0u8; 32];
+        hasher.finalize(&mut hash_whole);
+
+        // Same input fed in small chunks must produce same hash
+        let mut hasher2 = Hasher::new();
+        for chunk in input.chunks(13) {
+            hasher2.update(chunk);
+        }
+        let mut hash_chunked = [0u8; 32];
+        hasher2.finalize(&mut hash_chunked);
+        assert_eq!(hash_whole, hash_chunked);
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -24,7 +24,7 @@ pub use error::{Context, ContextError, OptionContext, StringError};
 pub use jis::{JisChar, char_to_jis, jis_slice_to_string, jis_to_char, str_to_jis};
 pub use os::{
     AudioChannelInfo, CdAudioState, CdAudioStatus, CdromIo, CdromTrackInfo, CdromTrackType,
-    ConsoleIo, CpuAccess, DiskIo, MemoryAccess,
+    ConsoleIo, CpuAccess, DiskIo, DriveIo, MemoryAccess,
 };
 pub use stack_vec::StackVec;
 pub use trace::{NoTracing, OsBootStage, Tracing};

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -912,6 +912,11 @@ pub trait Machine {
 
     /// Flushes the printer output file, if attached.
     fn flush_printer(&mut self);
+
+    /// Returns a host-formatted overview of current HLE DOS memory usage.
+    ///
+    /// Returns `None` when HLE DOS is not active.
+    fn debug_memory_overview(&mut self) -> Option<Vec<String>>;
 }
 
 /// Kinds of scheduled events.

--- a/crates/common/src/os.rs
+++ b/crates/common/src/os.rs
@@ -150,6 +150,11 @@ pub trait CdromIo {
     fn set_audio_channel_info(&mut self, info: &AudioChannelInfo);
 }
 
+/// Combined disk and CD-ROM access for mixed-media filesystem operations.
+pub trait DriveIo: DiskIo + CdromIo {}
+
+impl<T: DiskIo + CdromIo + ?Sized> DriveIo for T {}
+
 /// Track metadata returned by `CdromIo::track_info`.
 pub struct CdromTrackInfo {
     /// LBA of the track start.

--- a/crates/machine/src/bus.rs
+++ b/crates/machine/src/bus.rs
@@ -452,6 +452,10 @@ impl<T: Tracing> Pc9801Bus<T> {
     /// Inserts a floppy disk image into the specified drive (0-3).
     pub fn insert_floppy(&mut self, drive: usize, image: FloppyImage, path: Option<PathBuf>) {
         self.floppy.insert_drive(drive, image, path);
+        if let Some(os) = self.os.as_mut() {
+            let memory = os_adapter::OsMemoryAccess(&mut self.memory);
+            os.invalidate_drive_caches(&memory, 0x90 | drive as u8);
+        }
     }
 
     /// Returns a reference to the disk image in the given drive, if present.
@@ -467,6 +471,10 @@ impl<T: Tracing> Pc9801Bus<T> {
     /// Ejects the floppy disk from the specified drive, flushing if dirty.
     pub fn eject_floppy(&mut self, drive: usize) {
         self.floppy.eject_drive(drive);
+        if let Some(os) = self.os.as_mut() {
+            let memory = os_adapter::OsMemoryAccess(&mut self.memory);
+            os.invalidate_drive_caches(&memory, 0x90 | drive as u8);
+        }
     }
 
     /// Writes the floppy image back to its file if it has been modified.
@@ -495,6 +503,10 @@ impl<T: Tracing> Pc9801Bus<T> {
                     self.sdip.set_front_bank_bit(0, 6, false);
                 }
             }
+        }
+        if let Some(os) = self.os.as_mut() {
+            let memory = os_adapter::OsMemoryAccess(&mut self.memory);
+            os.invalidate_drive_caches(&memory, 0x80 | drive as u8);
         }
     }
 

--- a/crates/machine/src/bus.rs
+++ b/crates/machine/src/bus.rs
@@ -801,6 +801,13 @@ impl<T: Tracing> Pc9801Bus<T> {
         self.scheduler.next_event_cycle()
     }
 
+    /// Returns a host-formatted overview of current HLE DOS memory usage.
+    pub fn debug_memory_overview_lines(&mut self) -> Option<Vec<String>> {
+        let os = self.os.as_ref()?;
+        let memory = os_adapter::OsMemoryAccess(&mut self.memory);
+        Some(os.debug_memory_overview_lines(&memory))
+    }
+
     fn update_plane_e_mapping(&mut self) {
         if self.pegc.is_256_color_active() {
             self.memory.set_e_plane_enabled(false);

--- a/crates/machine/src/machine.rs
+++ b/crates/machine/src/machine.rs
@@ -286,6 +286,10 @@ impl<T: Tracing> common::Machine for Machine<cpu::V30, T> {
     fn flush_printer(&mut self) {
         self.bus.flush_printer();
     }
+
+    fn debug_memory_overview(&mut self) -> Option<Vec<String>> {
+        self.bus.debug_memory_overview_lines()
+    }
 }
 
 impl<T: Tracing> common::Machine for Machine<cpu::I286, T> {
@@ -360,6 +364,10 @@ impl<T: Tracing> common::Machine for Machine<cpu::I286, T> {
     fn flush_printer(&mut self) {
         self.bus.flush_printer();
     }
+
+    fn debug_memory_overview(&mut self) -> Option<Vec<String>> {
+        self.bus.debug_memory_overview_lines()
+    }
 }
 
 impl<const CPU_MODEL: u8, T: Tracing> common::Machine for Machine<cpu::I386<CPU_MODEL>, T> {
@@ -433,5 +441,9 @@ impl<const CPU_MODEL: u8, T: Tracing> common::Machine for Machine<cpu::I386<CPU_
 
     fn flush_printer(&mut self) {
         self.bus.flush_printer();
+    }
+
+    fn debug_memory_overview(&mut self) -> Option<Vec<String>> {
+        self.bus.debug_memory_overview_lines()
     }
 }

--- a/crates/os/Cargo.toml
+++ b/crates/os/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+blake3 = { workspace = true }
 common = { workspace = true }
 
 [dev-dependencies]

--- a/crates/os/src/commands.rs
+++ b/crates/os/src/commands.rs
@@ -5,6 +5,7 @@
 //! instances (RunningCommand). The shell calls step() once per INT 21h AH=FFh
 //! dispatch - commands must return quickly and never block.
 
+pub mod b3sum;
 pub mod cd;
 pub mod cls;
 pub mod copy;

--- a/crates/os/src/commands.rs
+++ b/crates/os/src/commands.rs
@@ -27,7 +27,7 @@ pub mod type_cmd;
 pub mod ver;
 pub mod xcopy;
 
-use crate::{DiskIo, IoAccess, OsState};
+use crate::{DriveIo, IoAccess, OsState};
 
 pub(crate) enum StepResult {
     /// Command completed with the given exit code.
@@ -57,8 +57,12 @@ pub(crate) trait RunningCommand {
     /// Must return quickly - never block.
     /// Simple commands (CLS, VER) return Done on the first call.
     /// Long commands (COPY, FORMAT) process one chunk and return Continue.
-    fn step(&mut self, state: &mut OsState, io: &mut IoAccess, disk: &mut dyn DiskIo)
-    -> StepResult;
+    fn step(
+        &mut self,
+        state: &mut OsState,
+        io: &mut IoAccess,
+        disk: &mut dyn DriveIo,
+    ) -> StepResult;
 }
 
 pub(crate) fn is_help_request(args: &[u8]) -> bool {

--- a/crates/os/src/commands.rs
+++ b/crates/os/src/commands.rs
@@ -13,6 +13,7 @@ pub mod date;
 pub mod del;
 pub mod dir;
 pub mod diskcopy;
+pub mod dosmock;
 pub mod echo;
 pub mod format;
 pub mod md;

--- a/crates/os/src/commands/b3sum.rs
+++ b/crates/os/src/commands/b3sum.rs
@@ -3,7 +3,7 @@
 use blake3::Hasher;
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DiskIo, DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     dos,
     filesystem::{fat_dir, fat_file::FatFileCursor},
@@ -63,7 +63,7 @@ impl RunningB3sum {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let args = self.args.trim_ascii();
         if args.is_empty() || is_help_request(args) {
@@ -88,7 +88,7 @@ impl RunningB3sum {
         mut b3sum_state: B3sumState,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if b3sum_state.current_argument >= b3sum_state.arguments.len() {
             return StepResult::Done(0);
@@ -185,7 +185,7 @@ impl RunningB3sum {
         mut file_hash_state: Box<FileHashState>,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let volume = match state.fat_volumes[file_hash_state.drive_index as usize].as_ref() {
             Some(volume) => volume,
@@ -229,7 +229,7 @@ impl RunningCommand for RunningB3sum {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let phase = std::mem::replace(&mut self.phase, B3sumPhase::Init);
         match phase {

--- a/crates/os/src/commands/b3sum.rs
+++ b/crates/os/src/commands/b3sum.rs
@@ -6,7 +6,7 @@ use crate::{
     DiskIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     dos,
-    filesystem::fat_dir,
+    filesystem::{fat_dir, fat_file::FatFileCursor},
 };
 
 pub(crate) struct B3sum;
@@ -42,8 +42,7 @@ struct ArgumentState {
 
 struct FileHashState {
     drive_index: u8,
-    current_cluster: u16,
-    remaining: u32,
+    cursor: FatFileCursor,
     display_path: Vec<u8>,
     hasher: Hasher,
 }
@@ -156,8 +155,7 @@ impl RunningB3sum {
                     b3sum_state,
                     Box::new(FileHashState {
                         drive_index,
-                        current_cluster: entry.start_cluster,
-                        remaining: entry.file_size,
+                        cursor: FatFileCursor::new(&entry),
                         display_path,
                         hasher,
                     }),
@@ -189,11 +187,6 @@ impl RunningB3sum {
         io: &mut IoAccess,
         disk: &mut dyn DiskIo,
     ) -> StepResult {
-        if file_hash_state.current_cluster < 2 {
-            io.println(b"Read error");
-            return StepResult::Done(1);
-        }
-
         let volume = match state.fat_volumes[file_hash_state.drive_index as usize].as_ref() {
             Some(volume) => volume,
             None => {
@@ -202,7 +195,11 @@ impl RunningB3sum {
             }
         };
 
-        let cluster_data = match volume.read_cluster(file_hash_state.current_cluster, disk) {
+        let cluster_data = match file_hash_state.cursor.read_chunk(
+            volume,
+            disk,
+            volume.bpb.cluster_size() as usize,
+        ) {
             Ok(cluster_data) => cluster_data,
             Err(_) => {
                 io.println(b"Read error");
@@ -210,13 +207,7 @@ impl RunningB3sum {
             }
         };
 
-        let bytes_in_cluster = cluster_data.len().min(file_hash_state.remaining as usize);
-        file_hash_state
-            .hasher
-            .update(&cluster_data[..bytes_in_cluster]);
-        file_hash_state.remaining -= bytes_in_cluster as u32;
-
-        if file_hash_state.remaining == 0 {
+        if cluster_data.is_empty() {
             let current_argument = &mut b3sum_state.arguments[b3sum_state.current_argument];
             current_argument.matched_any = true;
             print_digest(io, &file_hash_state.hasher, &file_hash_state.display_path);
@@ -227,15 +218,7 @@ impl RunningB3sum {
             return StepResult::Continue;
         }
 
-        let next_cluster = volume
-            .next_cluster(file_hash_state.current_cluster)
-            .unwrap_or(0);
-        if next_cluster < 2 {
-            io.println(b"Read error");
-            return StepResult::Done(1);
-        }
-
-        file_hash_state.current_cluster = next_cluster;
+        file_hash_state.hasher.update(&cluster_data);
         self.phase = B3sumPhase::Hashing(b3sum_state, file_hash_state);
         StepResult::Continue
     }

--- a/crates/os/src/commands/b3sum.rs
+++ b/crates/os/src/commands/b3sum.rs
@@ -1,0 +1,344 @@
+//! B3SUM command.
+
+use blake3::Hasher;
+
+use crate::{
+    DiskIo, IoAccess, OsState,
+    commands::{Command, RunningCommand, StepResult, is_help_request},
+    dos,
+    filesystem::fat_dir,
+};
+
+pub(crate) struct B3sum;
+
+impl Command for B3sum {
+    fn name(&self) -> &'static str {
+        "B3SUM"
+    }
+
+    fn start(&self, args: &[u8]) -> Box<dyn RunningCommand> {
+        Box::new(RunningB3sum {
+            args: args.to_vec(),
+            phase: B3sumPhase::Init,
+        })
+    }
+}
+
+struct B3sumState {
+    arguments: Vec<ArgumentState>,
+    current_argument: usize,
+}
+
+struct ArgumentState {
+    display_path: Vec<u8>,
+    wildcard_prefix: Vec<u8>,
+    drive_index: u8,
+    dir_cluster: u16,
+    pattern: [u8; 11],
+    has_wildcard: bool,
+    search_index: u16,
+    matched_any: bool,
+}
+
+struct FileHashState {
+    drive_index: u8,
+    current_cluster: u16,
+    remaining: u32,
+    display_path: Vec<u8>,
+    hasher: Hasher,
+}
+
+enum B3sumPhase {
+    Init,
+    FindNext(B3sumState),
+    Hashing(B3sumState, Box<FileHashState>),
+}
+
+struct RunningB3sum {
+    args: Vec<u8>,
+    phase: B3sumPhase,
+}
+
+impl RunningB3sum {
+    fn step_init(
+        &mut self,
+        state: &mut OsState,
+        io: &mut IoAccess,
+        disk: &mut dyn DiskIo,
+    ) -> StepResult {
+        let args = self.args.trim_ascii();
+        if args.is_empty() || is_help_request(args) {
+            print_help(io);
+            return StepResult::Done(0);
+        }
+
+        match init_b3sum_state(state, io, disk, args) {
+            Ok(b3sum_state) => {
+                self.phase = B3sumPhase::FindNext(b3sum_state);
+                StepResult::Continue
+            }
+            Err(message) => {
+                io.print(message);
+                StepResult::Done(1)
+            }
+        }
+    }
+
+    fn step_find_next(
+        &mut self,
+        mut b3sum_state: B3sumState,
+        state: &mut OsState,
+        io: &mut IoAccess,
+        disk: &mut dyn DiskIo,
+    ) -> StepResult {
+        if b3sum_state.current_argument >= b3sum_state.arguments.len() {
+            return StepResult::Done(0);
+        }
+
+        let argument = &mut b3sum_state.arguments[b3sum_state.current_argument];
+        if argument.drive_index == 25 {
+            io.println(b"Access denied");
+            return StepResult::Done(1);
+        }
+
+        let volume = match state.fat_volumes[argument.drive_index as usize].as_ref() {
+            Some(volume) => volume,
+            None => {
+                io.println(b"Invalid drive");
+                return StepResult::Done(1);
+            }
+        };
+
+        match fat_dir::find_matching(
+            volume,
+            argument.dir_cluster,
+            &argument.pattern,
+            0,
+            argument.search_index,
+            disk,
+        ) {
+            Ok(Some((entry, next_index))) => {
+                argument.search_index = next_index;
+
+                if entry.attribute & fat_dir::ATTR_DIRECTORY != 0 {
+                    io.println(b"Access denied");
+                    return StepResult::Done(1);
+                }
+
+                let display_path = if argument.has_wildcard {
+                    let mut display_path = argument.wildcard_prefix.clone();
+                    display_path.extend_from_slice(&fat_dir::fcb_to_display_name(&entry.name));
+                    display_path
+                } else {
+                    argument.display_path.clone()
+                };
+
+                let drive_index = argument.drive_index;
+                let has_wildcard = argument.has_wildcard;
+                let hasher = Hasher::new();
+
+                if entry.file_size == 0 {
+                    argument.matched_any = true;
+                    print_digest(io, &hasher, &display_path);
+                    if !has_wildcard {
+                        b3sum_state.current_argument += 1;
+                    }
+                    self.phase = B3sumPhase::FindNext(b3sum_state);
+                    return StepResult::Continue;
+                }
+
+                if entry.start_cluster < 2 {
+                    io.println(b"Read error");
+                    return StepResult::Done(1);
+                }
+
+                self.phase = B3sumPhase::Hashing(
+                    b3sum_state,
+                    Box::new(FileHashState {
+                        drive_index,
+                        current_cluster: entry.start_cluster,
+                        remaining: entry.file_size,
+                        display_path,
+                        hasher,
+                    }),
+                );
+                StepResult::Continue
+            }
+            Ok(None) => {
+                if !argument.matched_any {
+                    io.println(b"File not found");
+                    return StepResult::Done(1);
+                }
+
+                b3sum_state.current_argument += 1;
+                self.phase = B3sumPhase::FindNext(b3sum_state);
+                StepResult::Continue
+            }
+            Err(_) => {
+                io.println(b"File not found");
+                StepResult::Done(1)
+            }
+        }
+    }
+
+    fn step_hashing(
+        &mut self,
+        mut b3sum_state: B3sumState,
+        mut file_hash_state: Box<FileHashState>,
+        state: &mut OsState,
+        io: &mut IoAccess,
+        disk: &mut dyn DiskIo,
+    ) -> StepResult {
+        if file_hash_state.current_cluster < 2 {
+            io.println(b"Read error");
+            return StepResult::Done(1);
+        }
+
+        let volume = match state.fat_volumes[file_hash_state.drive_index as usize].as_ref() {
+            Some(volume) => volume,
+            None => {
+                io.println(b"Invalid drive");
+                return StepResult::Done(1);
+            }
+        };
+
+        let cluster_data = match volume.read_cluster(file_hash_state.current_cluster, disk) {
+            Ok(cluster_data) => cluster_data,
+            Err(_) => {
+                io.println(b"Read error");
+                return StepResult::Done(1);
+            }
+        };
+
+        let bytes_in_cluster = cluster_data.len().min(file_hash_state.remaining as usize);
+        file_hash_state
+            .hasher
+            .update(&cluster_data[..bytes_in_cluster]);
+        file_hash_state.remaining -= bytes_in_cluster as u32;
+
+        if file_hash_state.remaining == 0 {
+            let current_argument = &mut b3sum_state.arguments[b3sum_state.current_argument];
+            current_argument.matched_any = true;
+            print_digest(io, &file_hash_state.hasher, &file_hash_state.display_path);
+            if !current_argument.has_wildcard {
+                b3sum_state.current_argument += 1;
+            }
+            self.phase = B3sumPhase::FindNext(b3sum_state);
+            return StepResult::Continue;
+        }
+
+        let next_cluster = volume
+            .next_cluster(file_hash_state.current_cluster)
+            .unwrap_or(0);
+        if next_cluster < 2 {
+            io.println(b"Read error");
+            return StepResult::Done(1);
+        }
+
+        file_hash_state.current_cluster = next_cluster;
+        self.phase = B3sumPhase::Hashing(b3sum_state, file_hash_state);
+        StepResult::Continue
+    }
+}
+
+impl RunningCommand for RunningB3sum {
+    fn step(
+        &mut self,
+        state: &mut OsState,
+        io: &mut IoAccess,
+        disk: &mut dyn DiskIo,
+    ) -> StepResult {
+        let phase = std::mem::replace(&mut self.phase, B3sumPhase::Init);
+        match phase {
+            B3sumPhase::Init => self.step_init(state, io, disk),
+            B3sumPhase::FindNext(b3sum_state) => self.step_find_next(b3sum_state, state, io, disk),
+            B3sumPhase::Hashing(b3sum_state, file_hash_state) => {
+                self.step_hashing(b3sum_state, file_hash_state, state, io, disk)
+            }
+        }
+    }
+}
+
+fn print_help(io: &mut IoAccess) {
+    io.println(b"Computes BLAKE3 hashes of files.");
+    io.println(b"");
+    io.println(b"B3SUM [drive:][path]filename [...]");
+    io.println(b"");
+    io.println(b"  filename  Specifies one or more files to hash.");
+}
+
+fn init_b3sum_state(
+    state: &mut OsState,
+    io: &mut IoAccess,
+    disk: &mut dyn DiskIo,
+    args: &[u8],
+) -> Result<B3sumState, &'static [u8]> {
+    let mut arguments = Vec::new();
+
+    for part in args.split(|&byte| byte == b' ' || byte == b'\t') {
+        if part.is_empty() {
+            continue;
+        }
+
+        let normalized_path = dos::normalize_path(part);
+        let has_wildcard = normalized_path.contains(&b'*') || normalized_path.contains(&b'?');
+        let (drive_index, dir_cluster, pattern) = state
+            .resolve_file_path(&normalized_path, io.memory, disk)
+            .map_err(|_| &b"File not found\r\n"[..])?;
+
+        arguments.push(ArgumentState {
+            display_path: normalized_path.clone(),
+            wildcard_prefix: wildcard_display_prefix(&normalized_path),
+            drive_index,
+            dir_cluster,
+            pattern,
+            has_wildcard,
+            search_index: 0,
+            matched_any: false,
+        });
+    }
+
+    if arguments.is_empty() {
+        return Err(b"Required parameter missing\r\n");
+    }
+
+    Ok(B3sumState {
+        arguments,
+        current_argument: 0,
+    })
+}
+
+fn wildcard_display_prefix(path: &[u8]) -> Vec<u8> {
+    if let Some(position) = path.iter().rposition(|&byte| byte == b'\\') {
+        return path[..=position].to_vec();
+    }
+    if path.len() >= 2 && path[1] == b':' {
+        return path[..2].to_vec();
+    }
+    Vec::new()
+}
+
+fn print_digest(io: &mut IoAccess, hasher: &Hasher, display_path: &[u8]) {
+    let mut digest = [0u8; 32];
+    let mut line = Vec::with_capacity(64 + 2 + display_path.len() + 2);
+    hasher.finalize(&mut digest);
+    push_digest_hex(&mut line, &digest);
+    line.extend_from_slice(b"  ");
+    line.extend_from_slice(display_path);
+    line.extend_from_slice(b"\r\n");
+    io.print(&line);
+}
+
+fn push_digest_hex(out: &mut Vec<u8>, digest: &[u8; 32]) {
+    for &byte in digest {
+        out.push(nibble_to_hex(byte >> 4));
+        out.push(nibble_to_hex(byte & 0x0F));
+    }
+}
+
+fn nibble_to_hex(nibble: u8) -> u8 {
+    match nibble {
+        0..=9 => b'0' + nibble,
+        _ => b'a' + (nibble - 10),
+    }
+}

--- a/crates/os/src/commands/cd.rs
+++ b/crates/os/src/commands/cd.rs
@@ -1,7 +1,7 @@
 //! CD / CHDIR command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     tables,
 };
@@ -33,7 +33,7 @@ impl RunningCommand for RunningCd {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let args = self.args.trim_ascii();
 

--- a/crates/os/src/commands/cls.rs
+++ b/crates/os/src/commands/cls.rs
@@ -1,7 +1,7 @@
 //! CLS command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
 };
 
@@ -28,7 +28,7 @@ impl RunningCommand for RunningCls {
         &mut self,
         _state: &mut OsState,
         io: &mut IoAccess,
-        _disk: &mut dyn DiskIo,
+        _disk: &mut dyn DriveIo,
     ) -> StepResult {
         if is_help_request(&self.args) {
             print_help(io);

--- a/crates/os/src/commands/copy.rs
+++ b/crates/os/src/commands/copy.rs
@@ -3,7 +3,7 @@
 use crate::{
     DiskIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
-    filesystem::fat_dir,
+    filesystem::{fat_dir, fat_file::FatFileCursor},
 };
 
 pub(crate) struct Copy;
@@ -44,10 +44,7 @@ struct SourceSpec {
 
 struct FileCopyState {
     src_drive: u8,
-    src_cluster: u16,
-    src_remaining: u32,
-    src_buffer: Vec<u8>,
-    src_buffer_pos: usize,
+    src_cursor: FatFileCursor,
     src_entry: fat_dir::DirEntry,
     dst_drive: u8,
     dst_dir_cluster: u16,
@@ -163,10 +160,7 @@ impl RunningCopy {
 
                 let file_state = FileCopyState {
                     src_drive: copy_state.sources[copy_state.current_source].drive,
-                    src_cluster: entry.start_cluster,
-                    src_remaining: entry.file_size,
-                    src_buffer: Vec::new(),
-                    src_buffer_pos: 0,
+                    src_cursor: FatFileCursor::new(&entry),
                     src_entry: entry,
                     dst_drive: copy_state.dst_drive,
                     dst_dir_cluster: copy_state.dst_dir_cluster,
@@ -198,7 +192,7 @@ impl RunningCopy {
                     }
                 }
 
-                if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+                if file_state.src_entry.file_size == 0 {
                     self.phase = CopyPhase::FinishFile(copy_state, file_state);
                 } else {
                     self.phase = CopyPhase::ReadChunk(copy_state, file_state);
@@ -243,7 +237,7 @@ impl RunningCopy {
 
         match key.to_ascii_uppercase() {
             b'Y' => {
-                if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+                if file_state.src_entry.file_size == 0 {
                     self.phase = CopyPhase::FinishFile(copy_state, file_state);
                 } else {
                     self.phase = CopyPhase::ReadChunk(copy_state, file_state);
@@ -251,7 +245,7 @@ impl RunningCopy {
             }
             b'A' => {
                 copy_state.overwrite_all = true;
-                if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+                if file_state.src_entry.file_size == 0 {
                     self.phase = CopyPhase::FinishFile(copy_state, file_state);
                 } else {
                     self.phase = CopyPhase::ReadChunk(copy_state, file_state);
@@ -273,8 +267,7 @@ impl RunningCopy {
         io: &mut IoAccess,
         disk: &mut dyn DiskIo,
     ) -> StepResult {
-        if file_state.src_remaining == 0 && file_state.src_buffer_pos >= file_state.src_buffer.len()
-        {
+        if file_state.src_cursor.remaining() == 0 {
             if copy_state.concatenating {
                 self.phase = CopyPhase::ConcatNextSource(copy_state, file_state);
             } else {
@@ -287,51 +280,20 @@ impl RunningCopy {
             Some(v) => v.bpb.cluster_size() as usize,
             None => return StepResult::Done(1),
         };
-        let mut write_data = Vec::with_capacity(dst_cluster_size);
-
-        while write_data.len() < dst_cluster_size {
-            if file_state.src_buffer_pos >= file_state.src_buffer.len() {
-                if file_state.src_remaining == 0 {
-                    break;
-                }
-                if file_state.src_cluster < 2 {
-                    io.println(b"Read error");
-                    return StepResult::Done(1);
-                }
-
-                let vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
-                    Some(v) => v,
-                    None => return StepResult::Done(1),
-                };
-
-                let cluster_data = match vol.read_cluster(file_state.src_cluster, disk) {
-                    Ok(d) => d,
-                    Err(_) => {
-                        io.println(b"Read error");
-                        return StepResult::Done(1);
-                    }
-                };
-
-                let bytes_in_cluster = cluster_data.len().min(file_state.src_remaining as usize);
-                file_state.src_remaining -= bytes_in_cluster as u32;
-                file_state.src_buffer = cluster_data[..bytes_in_cluster].to_vec();
-                file_state.src_buffer_pos = 0;
-                file_state.src_cluster = vol.next_cluster(file_state.src_cluster).unwrap_or(0);
+        let src_vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
+            Some(v) => v,
+            None => return StepResult::Done(1),
+        };
+        let write_data = match file_state
+            .src_cursor
+            .read_chunk(src_vol, disk, dst_cluster_size)
+        {
+            Ok(data) => data,
+            Err(_) => {
+                io.println(b"Read error");
+                return StepResult::Done(1);
             }
-
-            if file_state.src_buffer_pos >= file_state.src_buffer.len() {
-                break;
-            }
-
-            let available = file_state.src_buffer.len() - file_state.src_buffer_pos;
-            let needed = dst_cluster_size - write_data.len();
-            let bytes_to_take = available.min(needed);
-            write_data.extend_from_slice(
-                &file_state.src_buffer
-                    [file_state.src_buffer_pos..file_state.src_buffer_pos + bytes_to_take],
-            );
-            file_state.src_buffer_pos += bytes_to_take;
-        }
+        };
 
         if write_data.is_empty() {
             if copy_state.concatenating {
@@ -516,12 +478,9 @@ impl RunningCopy {
         io.println(b"");
 
         file_state.src_drive = src.drive;
-        file_state.src_cluster = entry.start_cluster;
-        file_state.src_remaining = entry.file_size;
-        file_state.src_buffer.clear();
-        file_state.src_buffer_pos = 0;
+        file_state.src_cursor = FatFileCursor::new(&entry);
 
-        if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+        if entry.file_size == 0 {
             self.phase = CopyPhase::ConcatNextSource(copy_state, file_state);
         } else {
             self.phase = CopyPhase::ConcatRead(copy_state, file_state);
@@ -537,8 +496,7 @@ impl RunningCopy {
         io: &mut IoAccess,
         disk: &mut dyn DiskIo,
     ) -> StepResult {
-        if file_state.src_remaining == 0 && file_state.src_buffer_pos >= file_state.src_buffer.len()
-        {
+        if file_state.src_cursor.remaining() == 0 {
             self.phase = CopyPhase::ConcatNextSource(copy_state, file_state);
             return StepResult::Continue;
         }
@@ -547,51 +505,20 @@ impl RunningCopy {
             Some(v) => v.bpb.cluster_size() as usize,
             None => return StepResult::Done(1),
         };
-        let mut write_data = Vec::with_capacity(dst_cluster_size);
-
-        while write_data.len() < dst_cluster_size {
-            if file_state.src_buffer_pos >= file_state.src_buffer.len() {
-                if file_state.src_remaining == 0 {
-                    break;
-                }
-                if file_state.src_cluster < 2 {
-                    io.println(b"Read error");
-                    return StepResult::Done(1);
-                }
-
-                let vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
-                    Some(v) => v,
-                    None => return StepResult::Done(1),
-                };
-
-                let cluster_data = match vol.read_cluster(file_state.src_cluster, disk) {
-                    Ok(d) => d,
-                    Err(_) => {
-                        io.println(b"Read error");
-                        return StepResult::Done(1);
-                    }
-                };
-
-                let bytes_in_cluster = cluster_data.len().min(file_state.src_remaining as usize);
-                file_state.src_remaining -= bytes_in_cluster as u32;
-                file_state.src_buffer = cluster_data[..bytes_in_cluster].to_vec();
-                file_state.src_buffer_pos = 0;
-                file_state.src_cluster = vol.next_cluster(file_state.src_cluster).unwrap_or(0);
+        let src_vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
+            Some(v) => v,
+            None => return StepResult::Done(1),
+        };
+        let write_data = match file_state
+            .src_cursor
+            .read_chunk(src_vol, disk, dst_cluster_size)
+        {
+            Ok(data) => data,
+            Err(_) => {
+                io.println(b"Read error");
+                return StepResult::Done(1);
             }
-
-            if file_state.src_buffer_pos >= file_state.src_buffer.len() {
-                break;
-            }
-
-            let available = file_state.src_buffer.len() - file_state.src_buffer_pos;
-            let needed = dst_cluster_size - write_data.len();
-            let bytes_to_take = available.min(needed);
-            write_data.extend_from_slice(
-                &file_state.src_buffer
-                    [file_state.src_buffer_pos..file_state.src_buffer_pos + bytes_to_take],
-            );
-            file_state.src_buffer_pos += bytes_to_take;
-        }
+        };
 
         if write_data.is_empty() {
             self.phase = CopyPhase::ConcatNextSource(copy_state, file_state);

--- a/crates/os/src/commands/copy.rs
+++ b/crates/os/src/commands/copy.rs
@@ -79,6 +79,12 @@ struct RunningCopy {
     phase: CopyPhase,
 }
 
+fn destination_fcb_name(dst_path: &[u8]) -> [u8; 11] {
+    let (_, components, _) = crate::filesystem::split_path(dst_path);
+    let name = components.last().copied().unwrap_or(dst_path);
+    fat_dir::name_to_fcb(name)
+}
+
 impl RunningCopy {
     fn step_init(
         &mut self,
@@ -146,7 +152,7 @@ impl RunningCopy {
                 let dst_fcb_name = if copy_state.dst_is_dir {
                     entry.name
                 } else {
-                    fat_dir::name_to_fcb(&copy_state.dst_path)
+                    destination_fcb_name(&copy_state.dst_path)
                 };
 
                 let display_name = fat_dir::fcb_to_display_name(&entry.name);
@@ -285,8 +291,12 @@ impl RunningCopy {
 
         while write_data.len() < dst_cluster_size {
             if file_state.src_buffer_pos >= file_state.src_buffer.len() {
-                if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+                if file_state.src_remaining == 0 {
                     break;
+                }
+                if file_state.src_cluster < 2 {
+                    io.println(b"Read error");
+                    return StepResult::Done(1);
                 }
 
                 let vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
@@ -541,8 +551,12 @@ impl RunningCopy {
 
         while write_data.len() < dst_cluster_size {
             if file_state.src_buffer_pos >= file_state.src_buffer.len() {
-                if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+                if file_state.src_remaining == 0 {
                     break;
+                }
+                if file_state.src_cluster < 2 {
+                    io.println(b"Read error");
+                    return StepResult::Done(1);
                 }
 
                 let vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {

--- a/crates/os/src/commands/copy.rs
+++ b/crates/os/src/commands/copy.rs
@@ -46,6 +46,8 @@ struct FileCopyState {
     src_drive: u8,
     src_cluster: u16,
     src_remaining: u32,
+    src_buffer: Vec<u8>,
+    src_buffer_pos: usize,
     src_entry: fat_dir::DirEntry,
     dst_drive: u8,
     dst_dir_cluster: u16,
@@ -157,6 +159,8 @@ impl RunningCopy {
                     src_drive: copy_state.sources[copy_state.current_source].drive,
                     src_cluster: entry.start_cluster,
                     src_remaining: entry.file_size,
+                    src_buffer: Vec::new(),
+                    src_buffer_pos: 0,
                     src_entry: entry,
                     dst_drive: copy_state.dst_drive,
                     dst_dir_cluster: copy_state.dst_dir_cluster,
@@ -258,12 +262,13 @@ impl RunningCopy {
     fn step_read_chunk(
         &mut self,
         copy_state: CopyState,
-        file_state: FileCopyState,
+        mut file_state: FileCopyState,
         state: &mut OsState,
         io: &mut IoAccess,
         disk: &mut dyn DiskIo,
     ) -> StepResult {
-        if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+        if file_state.src_remaining == 0 && file_state.src_buffer_pos >= file_state.src_buffer.len()
+        {
             if copy_state.concatenating {
                 self.phase = CopyPhase::ConcatNextSource(copy_state, file_state);
             } else {
@@ -272,20 +277,62 @@ impl RunningCopy {
             return StepResult::Continue;
         }
 
-        let vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
-            Some(v) => v,
+        let dst_cluster_size = match state.fat_volumes[file_state.dst_drive as usize].as_ref() {
+            Some(v) => v.bpb.cluster_size() as usize,
             None => return StepResult::Done(1),
         };
+        let mut write_data = Vec::with_capacity(dst_cluster_size);
 
-        let cluster_data = match vol.read_cluster(file_state.src_cluster, disk) {
-            Ok(d) => d,
-            Err(_) => {
-                io.println(b"Read error");
-                return StepResult::Done(1);
+        while write_data.len() < dst_cluster_size {
+            if file_state.src_buffer_pos >= file_state.src_buffer.len() {
+                if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+                    break;
+                }
+
+                let vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
+                    Some(v) => v,
+                    None => return StepResult::Done(1),
+                };
+
+                let cluster_data = match vol.read_cluster(file_state.src_cluster, disk) {
+                    Ok(d) => d,
+                    Err(_) => {
+                        io.println(b"Read error");
+                        return StepResult::Done(1);
+                    }
+                };
+
+                let bytes_in_cluster = cluster_data.len().min(file_state.src_remaining as usize);
+                file_state.src_remaining -= bytes_in_cluster as u32;
+                file_state.src_buffer = cluster_data[..bytes_in_cluster].to_vec();
+                file_state.src_buffer_pos = 0;
+                file_state.src_cluster = vol.next_cluster(file_state.src_cluster).unwrap_or(0);
             }
-        };
 
-        self.phase = CopyPhase::WriteChunk(copy_state, file_state, cluster_data);
+            if file_state.src_buffer_pos >= file_state.src_buffer.len() {
+                break;
+            }
+
+            let available = file_state.src_buffer.len() - file_state.src_buffer_pos;
+            let needed = dst_cluster_size - write_data.len();
+            let bytes_to_take = available.min(needed);
+            write_data.extend_from_slice(
+                &file_state.src_buffer
+                    [file_state.src_buffer_pos..file_state.src_buffer_pos + bytes_to_take],
+            );
+            file_state.src_buffer_pos += bytes_to_take;
+        }
+
+        if write_data.is_empty() {
+            if copy_state.concatenating {
+                self.phase = CopyPhase::ConcatNextSource(copy_state, file_state);
+            } else {
+                self.phase = CopyPhase::FinishFile(copy_state, file_state);
+            }
+            return StepResult::Continue;
+        }
+
+        self.phase = CopyPhase::WriteChunk(copy_state, file_state, write_data);
         StepResult::Continue
     }
 
@@ -316,9 +363,8 @@ impl RunningCopy {
         }
         file_state.dst_last_cluster = new_cluster;
 
-        let cluster_size = vol.bpb.sectors_per_cluster as usize * vol.bpb.bytes_per_sector as usize;
-        let bytes_to_write = cluster_size.min(file_state.src_remaining as usize);
-
+        let bytes_to_write = data.len();
+        let cluster_size = vol.bpb.cluster_size() as usize;
         let mut write_data = data.clone();
         write_data.resize(cluster_size, 0);
 
@@ -328,13 +374,6 @@ impl RunningCopy {
         }
 
         file_state.dst_total_written += bytes_to_write as u32;
-        file_state.src_remaining -= bytes_to_write as u32;
-
-        let src_vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
-            Some(v) => v,
-            None => return StepResult::Done(1),
-        };
-        file_state.src_cluster = src_vol.next_cluster(file_state.src_cluster).unwrap_or(0);
 
         if copy_state.verify {
             self.phase = CopyPhase::VerifyChunk(copy_state, file_state, new_cluster, data);
@@ -369,8 +408,7 @@ impl RunningCopy {
             }
         };
 
-        let cluster_size = vol.bpb.sectors_per_cluster as usize * vol.bpb.bytes_per_sector as usize;
-        let compare_len = cluster_size.min(original_data.len());
+        let compare_len = original_data.len();
         if readback[..compare_len] != original_data[..compare_len] {
             io.println(b"Verify error");
             return StepResult::Done(1);
@@ -470,6 +508,8 @@ impl RunningCopy {
         file_state.src_drive = src.drive;
         file_state.src_cluster = entry.start_cluster;
         file_state.src_remaining = entry.file_size;
+        file_state.src_buffer.clear();
+        file_state.src_buffer_pos = 0;
 
         if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
             self.phase = CopyPhase::ConcatNextSource(copy_state, file_state);
@@ -482,30 +522,69 @@ impl RunningCopy {
     fn step_concat_read(
         &mut self,
         copy_state: CopyState,
-        file_state: FileCopyState,
+        mut file_state: FileCopyState,
         state: &mut OsState,
         io: &mut IoAccess,
         disk: &mut dyn DiskIo,
     ) -> StepResult {
-        if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+        if file_state.src_remaining == 0 && file_state.src_buffer_pos >= file_state.src_buffer.len()
+        {
             self.phase = CopyPhase::ConcatNextSource(copy_state, file_state);
             return StepResult::Continue;
         }
 
-        let vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
-            Some(v) => v,
+        let dst_cluster_size = match state.fat_volumes[file_state.dst_drive as usize].as_ref() {
+            Some(v) => v.bpb.cluster_size() as usize,
             None => return StepResult::Done(1),
         };
+        let mut write_data = Vec::with_capacity(dst_cluster_size);
 
-        let cluster_data = match vol.read_cluster(file_state.src_cluster, disk) {
-            Ok(d) => d,
-            Err(_) => {
-                io.println(b"Read error");
-                return StepResult::Done(1);
+        while write_data.len() < dst_cluster_size {
+            if file_state.src_buffer_pos >= file_state.src_buffer.len() {
+                if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+                    break;
+                }
+
+                let vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
+                    Some(v) => v,
+                    None => return StepResult::Done(1),
+                };
+
+                let cluster_data = match vol.read_cluster(file_state.src_cluster, disk) {
+                    Ok(d) => d,
+                    Err(_) => {
+                        io.println(b"Read error");
+                        return StepResult::Done(1);
+                    }
+                };
+
+                let bytes_in_cluster = cluster_data.len().min(file_state.src_remaining as usize);
+                file_state.src_remaining -= bytes_in_cluster as u32;
+                file_state.src_buffer = cluster_data[..bytes_in_cluster].to_vec();
+                file_state.src_buffer_pos = 0;
+                file_state.src_cluster = vol.next_cluster(file_state.src_cluster).unwrap_or(0);
             }
-        };
 
-        self.phase = CopyPhase::ConcatWrite(copy_state, file_state, cluster_data);
+            if file_state.src_buffer_pos >= file_state.src_buffer.len() {
+                break;
+            }
+
+            let available = file_state.src_buffer.len() - file_state.src_buffer_pos;
+            let needed = dst_cluster_size - write_data.len();
+            let bytes_to_take = available.min(needed);
+            write_data.extend_from_slice(
+                &file_state.src_buffer
+                    [file_state.src_buffer_pos..file_state.src_buffer_pos + bytes_to_take],
+            );
+            file_state.src_buffer_pos += bytes_to_take;
+        }
+
+        if write_data.is_empty() {
+            self.phase = CopyPhase::ConcatNextSource(copy_state, file_state);
+            return StepResult::Continue;
+        }
+
+        self.phase = CopyPhase::ConcatWrite(copy_state, file_state, write_data);
         StepResult::Continue
     }
 
@@ -536,9 +615,8 @@ impl RunningCopy {
         }
         file_state.dst_last_cluster = new_cluster;
 
-        let cluster_size = vol.bpb.sectors_per_cluster as usize * vol.bpb.bytes_per_sector as usize;
-        let bytes_to_write = cluster_size.min(file_state.src_remaining as usize);
-
+        let bytes_to_write = data.len();
+        let cluster_size = vol.bpb.cluster_size() as usize;
         let mut write_data = data;
         write_data.resize(cluster_size, 0);
 
@@ -548,13 +626,6 @@ impl RunningCopy {
         }
 
         file_state.dst_total_written += bytes_to_write as u32;
-        file_state.src_remaining -= bytes_to_write as u32;
-
-        let src_vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
-            Some(v) => v,
-            None => return StepResult::Done(1),
-        };
-        file_state.src_cluster = src_vol.next_cluster(file_state.src_cluster).unwrap_or(0);
 
         self.phase = CopyPhase::ConcatRead(copy_state, file_state);
         StepResult::Continue

--- a/crates/os/src/commands/copy.rs
+++ b/crates/os/src/commands/copy.rs
@@ -1,8 +1,9 @@
 //! COPY command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DiskIo, DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
+    filesystem,
     filesystem::{fat_dir, fat_file::FatFileCursor},
 };
 
@@ -77,7 +78,7 @@ struct RunningCopy {
 }
 
 fn destination_fcb_name(dst_path: &[u8]) -> [u8; 11] {
-    let (_, components, _) = crate::filesystem::split_path(dst_path);
+    let (_, components, _) = filesystem::split_path(dst_path);
     let name = components.last().copied().unwrap_or(dst_path);
     fat_dir::name_to_fcb(name)
 }
@@ -87,7 +88,7 @@ impl RunningCopy {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if is_help_request(&self.args) || self.args.trim_ascii().is_empty() {
             print_help(io);
@@ -110,7 +111,7 @@ impl RunningCopy {
         mut copy_state: CopyState,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if copy_state.current_source >= copy_state.sources.len() {
             if copy_state.files_copied == 0 {
@@ -265,7 +266,7 @@ impl RunningCopy {
         mut file_state: FileCopyState,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if file_state.src_cursor.remaining() == 0 {
             if copy_state.concatenating {
@@ -578,7 +579,7 @@ impl RunningCommand for RunningCopy {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let phase = std::mem::replace(&mut self.phase, CopyPhase::Init);
         match phase {

--- a/crates/os/src/commands/date.rs
+++ b/crates/os/src/commands/date.rs
@@ -1,7 +1,7 @@
 //! DATE command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
 };
 
@@ -28,7 +28,7 @@ impl RunningCommand for RunningDate {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        _disk: &mut dyn DiskIo,
+        _disk: &mut dyn DriveIo,
     ) -> StepResult {
         if is_help_request(&self.args) {
             print_help(io);

--- a/crates/os/src/commands/del.rs
+++ b/crates/os/src/commands/del.rs
@@ -1,7 +1,7 @@
 //! DEL / ERASE command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DiskIo, DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     filesystem::fat_dir,
 };
@@ -54,7 +54,7 @@ impl RunningDel {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let args = self.args.trim_ascii().to_vec();
         if is_help_request(&args) || args.is_empty() {
@@ -126,7 +126,7 @@ impl RunningDel {
         mut del_state: DelState,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let vol = match state.fat_volumes[del_state.drive_index as usize].as_ref() {
             Some(v) => v,
@@ -199,7 +199,7 @@ impl RunningDel {
         entry: fat_dir::DirEntry,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if io.memory.read_byte(KB_BUF_COUNT) == 0 {
             self.phase = DelPhase::PromptFile(del_state, entry);
@@ -245,7 +245,7 @@ impl RunningCommand for RunningDel {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let phase = std::mem::replace(&mut self.phase, DelPhase::Init);
         match phase {

--- a/crates/os/src/commands/dir.rs
+++ b/crates/os/src/commands/dir.rs
@@ -852,14 +852,9 @@ fn calculate_free_space(state: &OsState, drive_index: u8) -> u64 {
     };
 
     let mut free_clusters = 0u64;
-    let max = vol.data_cluster_count as u16 + 2;
-    for cluster in 2..max {
-        if vol.read_fat_entry(cluster) == 0 {
-            free_clusters += 1;
-        }
-    }
+    free_clusters += vol.free_cluster_count() as u64;
 
-    let cluster_size = vol.bpb.sectors_per_cluster as u64 * vol.bpb.bytes_per_sector as u64;
+    let cluster_size = vol.sectors_per_cluster() as u64 * vol.bytes_per_sector() as u64;
     free_clusters * cluster_size
 }
 

--- a/crates/os/src/commands/dir.rs
+++ b/crates/os/src/commands/dir.rs
@@ -1,9 +1,9 @@
 //! DIR command.
 
 use crate::{
-    DiskIo, IoAccess, MemoryAccess, OsState,
+    DriveIo, IoAccess, MemoryAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
-    filesystem::fat_dir,
+    filesystem::{self, ReadDirEntry, ReadDirectory, fat_dir, find_matching_read_entry},
     tables,
 };
 
@@ -60,7 +60,7 @@ impl Default for AttrFilter {
 
 struct DirState {
     drive_index: u8,
-    dir_cluster: u16,
+    directory: ReadDirectory,
     pattern: [u8; 11],
     wide: bool,
     bare: bool,
@@ -72,11 +72,9 @@ struct DirState {
     total_bytes: u64,
     lines_shown: u16,
     wide_col: u8,
-    // For sorted or recursive: collected entries
-    entries: Vec<fat_dir::DirEntry>,
+    entries: Vec<ReadDirEntry>,
     entry_index: usize,
-    // For /S recursive traversal
-    dir_stack: Vec<(u16, Vec<u8>)>, // (cluster, path)
+    dir_stack: Vec<(ReadDirectory, Vec<u8>)>,
     current_path: Vec<u8>,
 }
 
@@ -100,7 +98,7 @@ impl RunningDir {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if is_help_request(&self.args) {
             print_help(io);
@@ -122,7 +120,7 @@ impl RunningDir {
         &mut self,
         mut dir_state: DirState,
         state: &mut OsState,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         dir_state.entries.clear();
         dir_state.entry_index = 0;
@@ -138,15 +136,22 @@ impl RunningDir {
                     .virtual_drive
                     .find_matching(&dir_state.pattern, attr_mask, start_index)
             {
-                let entry = fat_dir::DirEntry {
+                let entry = ReadDirEntry {
                     name: ventry.name,
                     attribute: ventry.attribute,
                     time: ventry.time,
                     date: ventry.date,
-                    start_cluster: 0,
                     file_size: ventry.file_size,
-                    dir_sector: 0,
-                    dir_offset: 0,
+                    source: filesystem::ReadDirEntrySource::Fat(fat_dir::DirEntry {
+                        name: ventry.name,
+                        attribute: ventry.attribute,
+                        time: ventry.time,
+                        date: ventry.date,
+                        start_cluster: 0,
+                        file_size: ventry.file_size,
+                        dir_sector: 0,
+                        dir_offset: 0,
+                    }),
                 };
                 if should_show_entry(&entry, &dir_state.attr_filter) {
                     dir_state.entries.push(entry);
@@ -154,11 +159,6 @@ impl RunningDir {
                 start_index = next_index;
             }
         } else {
-            let vol = match state.fat_volumes[dir_state.drive_index as usize].as_ref() {
-                Some(v) => v,
-                None => return StepResult::Done(1),
-            };
-
             let mut start_index = 0u16;
             let attr_mask = fat_dir::ATTR_HIDDEN
                 | fat_dir::ATTR_SYSTEM
@@ -166,9 +166,10 @@ impl RunningDir {
                 | fat_dir::ATTR_READ_ONLY;
 
             loop {
-                let result = fat_dir::find_matching(
-                    vol,
-                    dir_state.dir_cluster,
+                let result = find_matching_read_entry(
+                    state,
+                    dir_state.drive_index,
+                    &dir_state.directory,
                     &dir_state.pattern,
                     attr_mask,
                     start_index,
@@ -200,11 +201,11 @@ impl RunningDir {
         dir_state: DirState,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if !dir_state.bare {
             let drive_letter = (b'A' + dir_state.drive_index) as char;
-            let label = get_volume_label(state, dir_state.drive_index, disk);
+            let label = get_volume_label(state, dir_state.drive_index, &dir_state.directory, disk);
             if let Some(label) = label {
                 let msg = format!(" Volume in drive {} is {}\r\n", drive_letter, label);
                 io.print(msg.as_bytes());
@@ -310,7 +311,7 @@ impl RunningDir {
         mut dir_state: DirState,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         // /S: find subdirectories in the entries we just listed and push them
         // We need to scan current entries for directories, excluding "." and ".."
@@ -322,20 +323,16 @@ impl RunningDir {
             self.phase = DirPhase::Footer(dir_state);
             return StepResult::Continue;
         }
-        let vol = match state.fat_volumes[dir_state.drive_index as usize].as_ref() {
-            Some(v) => v,
-            None => return StepResult::Done(1),
-        };
-
         // Collect subdirectories from current dir (not from filtered entries)
         if dir_state.dir_stack.is_empty() {
             let all_pattern = [b'?'; 11];
             let mut si = 0u16;
             let attr_mask = fat_dir::ATTR_HIDDEN | fat_dir::ATTR_SYSTEM | fat_dir::ATTR_DIRECTORY;
             loop {
-                let result = fat_dir::find_matching(
-                    vol,
-                    dir_state.dir_cluster,
+                let result = find_matching_read_entry(
+                    state,
+                    dir_state.drive_index,
+                    &dir_state.directory,
                     &all_pattern,
                     attr_mask,
                     si,
@@ -346,7 +343,6 @@ impl RunningDir {
                         if entry.attribute & fat_dir::ATTR_DIRECTORY != 0
                             && entry.name != *b".          "
                             && entry.name != *b"..         "
-                            && entry.start_cluster >= 2
                         {
                             let mut subpath = if dir_state.current_path.is_empty() {
                                 let cds_path =
@@ -360,7 +356,19 @@ impl RunningDir {
                             }
                             let name = fat_dir::fcb_to_display_name(&entry.name);
                             subpath.extend_from_slice(&name);
-                            dir_state.dir_stack.push((entry.start_cluster, subpath));
+                            let directory = match entry.source {
+                                filesystem::ReadDirEntrySource::Fat(entry) => {
+                                    ReadDirectory::Fat(entry.start_cluster)
+                                }
+                                filesystem::ReadDirEntrySource::Iso(entry) => {
+                                    let Some(directory) = entry.directory else {
+                                        si = next_index;
+                                        continue;
+                                    };
+                                    ReadDirectory::Iso(directory)
+                                }
+                            };
+                            dir_state.dir_stack.push((directory, subpath));
                         }
                         si = next_index;
                     }
@@ -370,8 +378,8 @@ impl RunningDir {
         }
 
         // Pop next subdir from stack
-        if let Some((cluster, path)) = dir_state.dir_stack.pop() {
-            dir_state.dir_cluster = cluster;
+        if let Some((directory, path)) = dir_state.dir_stack.pop() {
+            dir_state.directory = directory;
             dir_state.current_path = path;
             if !dir_state.bare {
                 io.println(b"");
@@ -394,7 +402,7 @@ impl RunningCommand for RunningDir {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let phase = std::mem::replace(&mut self.phase, DirPhase::Init);
         match phase {
@@ -426,7 +434,7 @@ fn print_help(io: &mut IoAccess) {
     io.println(b"          H hidden, S system, D directories, R read-only.");
 }
 
-fn should_show_entry(entry: &fat_dir::DirEntry, filter: &AttrFilter) -> bool {
+fn should_show_entry(entry: &ReadDirEntry, filter: &AttrFilter) -> bool {
     // Never show volume ID
     if entry.attribute & fat_dir::ATTR_VOLUME_ID != 0 {
         return false;
@@ -450,7 +458,7 @@ fn should_show_entry(entry: &fat_dir::DirEntry, filter: &AttrFilter) -> bool {
     true
 }
 
-fn sort_entries(entries: &mut [fat_dir::DirEntry], order: SortOrder) {
+fn sort_entries(entries: &mut [ReadDirEntry], order: SortOrder) {
     entries.sort_by(|a, b| match order {
         SortOrder::Name => a.name.cmp(&b.name),
         SortOrder::NameDesc => b.name.cmp(&a.name),
@@ -483,7 +491,7 @@ fn sort_entries(entries: &mut [fat_dir::DirEntry], order: SortOrder) {
 fn init_dir(
     state: &mut OsState,
     io: &mut IoAccess,
-    disk: &mut dyn DiskIo,
+    disk: &mut dyn DriveIo,
     args: &[u8],
 ) -> Result<DirState, &'static [u8]> {
     let args = args.trim_ascii();
@@ -542,13 +550,13 @@ fn init_dir(
     let has_wildcard = path.contains(&b'*') || path.contains(&b'?');
 
     if has_wildcard {
-        let (drive_index, dir_cluster, fcb_pattern) = state
-            .resolve_file_path(path, io.memory, disk)
+        let read_path = state
+            .resolve_read_file_path(path, io.memory, disk)
             .map_err(|_| &b"File Not Found\r\n"[..])?;
         Ok(DirState {
-            drive_index,
-            dir_cluster,
-            pattern: fcb_pattern,
+            drive_index: read_path.drive_index,
+            directory: read_path.directory,
+            pattern: read_path.name,
             wide,
             bare,
             paged,
@@ -565,10 +573,10 @@ fn init_dir(
             current_path: Vec::new(),
         })
     } else {
-        match state.resolve_dir_path(path, io.memory, disk) {
-            Ok((drive_index, dir_cluster)) => Ok(DirState {
-                drive_index,
-                dir_cluster,
+        match state.resolve_read_dir_path(path, io.memory, disk) {
+            Ok(read_path) => Ok(DirState {
+                drive_index: read_path.drive_index,
+                directory: read_path.directory,
                 pattern: [b'?'; 11],
                 wide,
                 bare,
@@ -586,13 +594,13 @@ fn init_dir(
                 current_path: Vec::new(),
             }),
             Err(_) => {
-                let (drive_index, dir_cluster, fcb_pattern) = state
-                    .resolve_file_path(path, io.memory, disk)
+                let read_path = state
+                    .resolve_read_file_path(path, io.memory, disk)
                     .map_err(|_| &b"File Not Found\r\n"[..])?;
                 Ok(DirState {
-                    drive_index,
-                    dir_cluster,
-                    pattern: fcb_pattern,
+                    drive_index: read_path.drive_index,
+                    directory: read_path.directory,
+                    pattern: read_path.name,
                     wide,
                     bare,
                     paged,
@@ -690,7 +698,7 @@ fn parse_attr_filter(spec: &[u8]) -> AttrFilter {
     filter
 }
 
-fn format_standard(entry: &fat_dir::DirEntry, io: &mut IoAccess) {
+fn format_standard(entry: &ReadDirEntry, io: &mut IoAccess) {
     // Format: "FILENAME EXT    <size>  <date>  <time>"
     // Base name (left-justified, 8 chars)
     let base_end = entry.name[..8]
@@ -744,7 +752,7 @@ fn format_standard(entry: &fat_dir::DirEntry, io: &mut IoAccess) {
     io.println(b"");
 }
 
-fn format_bare(entry: &fat_dir::DirEntry, io: &mut IoAccess) {
+fn format_bare(entry: &ReadDirEntry, io: &mut IoAccess) {
     let display_name = fat_dir::fcb_to_display_name(&entry.name);
     for &byte in &display_name {
         io.output_byte(byte);
@@ -752,7 +760,7 @@ fn format_bare(entry: &fat_dir::DirEntry, io: &mut IoAccess) {
     io.println(b"");
 }
 
-fn format_wide(entry: &fat_dir::DirEntry, dir_state: &mut DirState, io: &mut IoAccess) {
+fn format_wide(entry: &ReadDirEntry, dir_state: &mut DirState, io: &mut IoAccess) {
     let display_name = fat_dir::fcb_to_display_name(&entry.name);
 
     if entry.attribute & fat_dir::ATTR_DIRECTORY != 0 {
@@ -782,10 +790,23 @@ fn format_wide(entry: &fat_dir::DirEntry, dir_state: &mut DirState, io: &mut IoA
     }
 }
 
-fn get_volume_label(state: &OsState, drive_index: u8, disk: &mut dyn DiskIo) -> Option<String> {
+fn get_volume_label(
+    state: &OsState,
+    drive_index: u8,
+    directory: &ReadDirectory,
+    disk: &mut dyn DriveIo,
+) -> Option<String> {
     if drive_index == 25 {
         return None;
     }
+    if matches!(directory, ReadDirectory::Iso(_)) {
+        let volume = filesystem::iso9660::IsoVolume::mount(disk).ok()?;
+        if volume.volume_label.is_empty() {
+            return None;
+        }
+        return Some(String::from_utf8_lossy(&volume.volume_label).into_owned());
+    }
+
     let vol = state.fat_volumes[drive_index as usize].as_ref()?;
     let pattern = [b'?'; 11];
     let mut start_index = 0u16;

--- a/crates/os/src/commands/diskcopy.rs
+++ b/crates/os/src/commands/diskcopy.rs
@@ -1,7 +1,7 @@
 //! DISKCOPY command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DiskIo, DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     filesystem, tables,
 };
@@ -104,7 +104,7 @@ impl RunningDiskcopy {
         &mut self,
         mut diskcopy_state: DiskcopyState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if diskcopy_state.current_track >= diskcopy_state.total_tracks {
             if diskcopy_state.same_drive {
@@ -165,7 +165,7 @@ impl RunningDiskcopy {
         &mut self,
         mut diskcopy_state: DiskcopyState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if diskcopy_state.current_track >= diskcopy_state.total_tracks {
             if diskcopy_state.verify {
@@ -202,7 +202,7 @@ impl RunningDiskcopy {
         &mut self,
         mut diskcopy_state: DiskcopyState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if diskcopy_state.current_track >= diskcopy_state.total_tracks {
             self.phase = DiskcopyPhase::Summary(diskcopy_state);
@@ -295,7 +295,7 @@ impl RunningCommand for RunningDiskcopy {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let phase = std::mem::replace(&mut self.phase, DiskcopyPhase::Init);
         match phase {

--- a/crates/os/src/commands/dosmock.rs
+++ b/crates/os/src/commands/dosmock.rs
@@ -1,0 +1,194 @@
+//! DOSMOCK command.
+
+use crate::{
+    DiskIo, DriveIo, IoAccess, OsState,
+    commands::{Command, RunningCommand, StepResult, is_help_request},
+    filesystem::{fat_dir, fat_file},
+    process::COMMAND_COM_STUB,
+    tables,
+};
+
+pub(crate) struct Dosmock;
+
+impl Command for Dosmock {
+    fn name(&self) -> &'static str {
+        "DOSMOCK"
+    }
+
+    fn start(&self, args: &[u8]) -> Box<dyn RunningCommand> {
+        Box::new(RunningDosmock {
+            args: args.to_vec(),
+        })
+    }
+}
+
+struct RunningDosmock {
+    args: Vec<u8>,
+}
+
+impl RunningCommand for RunningDosmock {
+    fn step(
+        &mut self,
+        state: &mut OsState,
+        io: &mut IoAccess,
+        disk: &mut dyn DriveIo,
+    ) -> StepResult {
+        let args = self.args.trim_ascii();
+        if is_help_request(&self.args) {
+            print_help(io);
+            return StepResult::Done(0);
+        }
+
+        let Some(drive_index) = parse_drive_arg(args) else {
+            print_help(io);
+            return StepResult::Done(1);
+        };
+
+        match create_dos_mock_files(state, io, disk, drive_index) {
+            Ok(()) => {
+                io.print(b"DOS mock files created\r\n");
+                StepResult::Done(0)
+            }
+            Err(message) => {
+                io.print(message);
+                StepResult::Done(1)
+            }
+        }
+    }
+}
+
+fn print_help(io: &mut IoAccess) {
+    io.println(b"Creates minimal DOS marker files on a drive root.");
+    io.println(b"");
+    io.println(b"DOSMOCK drive:");
+    io.println(b"");
+    io.println(b"  drive:  Specifies the target drive root (for example A:).");
+}
+
+fn parse_drive_arg(args: &[u8]) -> Option<u8> {
+    if args.len() != 2 && args.len() != 3 {
+        return None;
+    }
+    if args[1] != b':' {
+        return None;
+    }
+    if args.len() == 3 && args[2] != b'\\' && args[2] != b'/' {
+        return None;
+    }
+    let drive_letter = args[0].to_ascii_uppercase();
+    if !drive_letter.is_ascii_uppercase() {
+        return None;
+    }
+    Some(drive_letter - b'A')
+}
+
+fn create_dos_mock_files(
+    state: &mut OsState,
+    io: &mut IoAccess,
+    disk: &mut dyn DiskIo,
+    drive_index: u8,
+) -> Result<(), &'static [u8]> {
+    if drive_index == 25 {
+        return Err(b"Target drive is not writable\r\n");
+    }
+
+    let cds_addr = tables::CDS_BASE + (drive_index as u32) * tables::CDS_ENTRY_SIZE;
+    let cds_flags = io.memory.read_word(cds_addr + tables::CDS_OFF_FLAGS);
+    if cds_flags == 0 {
+        return Err(b"Unable to access target drive\r\n");
+    }
+
+    if state.mscdex.drive_letter == drive_index && cds_flags & tables::CDS_FLAG_PHYSICAL == 0 {
+        return Err(b"Target drive is not writable\r\n");
+    }
+
+    if state
+        .ensure_volume_mounted(drive_index, io.memory, disk)
+        .is_err()
+    {
+        return Err(b"Unable to access target drive\r\n");
+    }
+
+    let (time, date) = state.dos_timestamp_now();
+
+    let volume = state.fat_volumes[drive_index as usize]
+        .as_mut()
+        .ok_or(&b"Unable to access target drive\r\n"[..])?;
+
+    let io_sys = fat_dir::name_to_fcb(b"IO.SYS");
+    let msdos_sys = fat_dir::name_to_fcb(b"MSDOS.SYS");
+    let command_com = fat_dir::name_to_fcb(b"COMMAND.COM");
+
+    for name in [io_sys, msdos_sys, command_com] {
+        if fat_dir::find_entry(volume, 0, &name, disk)
+            .map_err(|_| &b"Unable to access target drive\r\n"[..])?
+            .is_some()
+        {
+            return Err(b"DOS mock files already exist\r\n");
+        }
+    }
+
+    let mut created = Vec::new();
+    let files = [
+        (
+            io_sys,
+            &[][..],
+            fat_dir::ATTR_READ_ONLY | fat_dir::ATTR_HIDDEN | fat_dir::ATTR_SYSTEM,
+        ),
+        (
+            msdos_sys,
+            &[][..],
+            fat_dir::ATTR_READ_ONLY | fat_dir::ATTR_HIDDEN | fat_dir::ATTR_SYSTEM,
+        ),
+        (
+            command_com,
+            COMMAND_COM_STUB,
+            fat_dir::ATTR_READ_ONLY | fat_dir::ATTR_ARCHIVE,
+        ),
+    ];
+
+    for (name, content, attributes) in files {
+        if fat_file::create_or_replace_file(
+            volume,
+            0,
+            &name,
+            content,
+            fat_file::FileCreateOptions {
+                attributes,
+                time,
+                date,
+            },
+            disk,
+        )
+        .is_err()
+        {
+            rollback_created_files(volume, disk, &created);
+            let _ = volume.flush_fat(disk);
+            return Err(b"Unable to create DOS mock files\r\n");
+        }
+        created.push(name);
+    }
+
+    if volume.flush_fat(disk).is_err() {
+        rollback_created_files(volume, disk, &created);
+        let _ = volume.flush_fat(disk);
+        return Err(b"Unable to create DOS mock files\r\n");
+    }
+
+    Ok(())
+}
+
+fn rollback_created_files(
+    volume: &mut crate::filesystem::fat::FatVolume,
+    disk: &mut dyn DiskIo,
+    created: &[[u8; 11]],
+) {
+    for name in created {
+        if let Ok(Some(entry)) = fat_dir::find_entry(volume, 0, name, disk) {
+            if entry.start_cluster >= 2 {
+                volume.free_chain(entry.start_cluster);
+            }
+            let _ = fat_dir::delete_entry(volume, &entry, disk);
+        }
+    }
+}

--- a/crates/os/src/commands/echo.rs
+++ b/crates/os/src/commands/echo.rs
@@ -1,7 +1,7 @@
 //! ECHO command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult},
 };
 
@@ -38,7 +38,7 @@ impl RunningCommand for RunningEcho {
         &mut self,
         _state: &mut OsState,
         io: &mut IoAccess,
-        _disk: &mut dyn DiskIo,
+        _disk: &mut dyn DriveIo,
     ) -> StepResult {
         if self.text.trim_ascii() == b"/?" {
             print_help(io);

--- a/crates/os/src/commands/format.rs
+++ b/crates/os/src/commands/format.rs
@@ -44,6 +44,7 @@ struct BpbParams {
     root_entry_count: u16,
     media_descriptor: u8,
     sectors_per_fat: u16,
+    is_fat16: bool,
 }
 
 fn floppy_bpb_params(da_type: u8) -> BpbParams {
@@ -56,6 +57,7 @@ fn floppy_bpb_params(da_type: u8) -> BpbParams {
             root_entry_count: 192,
             media_descriptor: 0xFE,
             sectors_per_fat: 2,
+            is_fat16: false,
         },
         0x70 => BpbParams {
             bytes_per_sector: 512,
@@ -65,8 +67,43 @@ fn floppy_bpb_params(da_type: u8) -> BpbParams {
             root_entry_count: 112,
             media_descriptor: 0xFE,
             sectors_per_fat: 3,
+            is_fat16: false,
         },
         _ => panic!("unsupported floppy DA type {:#04X}", da_type),
+    }
+}
+
+fn fat_sectors_for(cluster_count: u32, bytes_per_sector: u16, is_fat16: bool) -> u16 {
+    let fat_bytes = if is_fat16 {
+        (cluster_count as u64 + 2) * 2
+    } else {
+        ((cluster_count as u64 + 2) * 3).div_ceil(2)
+    };
+    fat_bytes.div_ceil(bytes_per_sector as u64) as u16
+}
+
+fn solve_hdd_fat_layout(
+    partition_sectors: u32,
+    bytes_per_sector: u16,
+    sectors_per_cluster: u8,
+    reserved_sectors: u16,
+    num_fats: u8,
+    root_entry_count: u16,
+    is_fat16: bool,
+) -> (u32, u16) {
+    let root_dir_sectors = (root_entry_count as u32 * 32).div_ceil(bytes_per_sector as u32);
+    let mut sectors_per_fat = 1u16;
+
+    loop {
+        let system_sectors =
+            reserved_sectors as u32 + num_fats as u32 * sectors_per_fat as u32 + root_dir_sectors;
+        let data_sectors = partition_sectors.saturating_sub(system_sectors);
+        let cluster_count = data_sectors / sectors_per_cluster as u32;
+        let needed = fat_sectors_for(cluster_count, bytes_per_sector, is_fat16);
+        if needed == sectors_per_fat {
+            return (cluster_count, sectors_per_fat);
+        }
+        sectors_per_fat = needed;
     }
 }
 
@@ -101,13 +138,29 @@ fn hdd_bpb_params(sector_size: u16, partition_sectors: u32) -> BpbParams {
         }
     };
 
-    let root_dir_sectors = (root_entry_count as u32 * 32).div_ceil(bytes_per_sector as u32);
-    let overhead = reserved_sectors as u32 + root_dir_sectors;
-    let usable = partition_sectors.saturating_sub(overhead);
-    // Upper-bound estimate: assume FAT takes zero sectors, compute max clusters,
-    // then derive sectors_per_fat from that.
-    let max_clusters = usable / sectors_per_cluster as u32;
-    let sectors_per_fat = ((max_clusters + 2) as u64 * 2).div_ceil(bytes_per_sector as u64) as u16;
+    let (fat12_clusters, fat12_sectors_per_fat) = solve_hdd_fat_layout(
+        partition_sectors,
+        bytes_per_sector,
+        sectors_per_cluster,
+        reserved_sectors,
+        num_fats,
+        root_entry_count,
+        false,
+    );
+    let (is_fat16, sectors_per_fat) = if fat12_clusters >= 4085 {
+        let (_, fat16_sectors_per_fat) = solve_hdd_fat_layout(
+            partition_sectors,
+            bytes_per_sector,
+            sectors_per_cluster,
+            reserved_sectors,
+            num_fats,
+            root_entry_count,
+            true,
+        );
+        (true, fat16_sectors_per_fat)
+    } else {
+        (false, fat12_sectors_per_fat)
+    };
 
     BpbParams {
         bytes_per_sector,
@@ -117,6 +170,7 @@ fn hdd_bpb_params(sector_size: u16, partition_sectors: u32) -> BpbParams {
         root_entry_count,
         media_descriptor: 0xF8,
         sectors_per_fat,
+        is_fat16,
     }
 }
 
@@ -375,7 +429,7 @@ impl RunningFormat {
         let fat_size = bpb.sectors_per_fat as usize * format_state.sector_size as usize;
         let mut fat_data = vec![0u8; fat_size];
 
-        if format_state.is_hdd {
+        if bpb.is_fat16 {
             // FAT16 reserved entries: 0xFFF8, 0xFFFF
             fat_data[0] = bpb.media_descriptor;
             fat_data[1] = 0xFF;

--- a/crates/os/src/commands/format.rs
+++ b/crates/os/src/commands/format.rs
@@ -1,7 +1,7 @@
 //! FORMAT command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DiskIo, DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     filesystem, tables,
 };
@@ -198,7 +198,7 @@ impl RunningFormat {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if is_help_request(&self.args) || self.args.trim_ascii().is_empty() {
             print_help(io);
@@ -252,7 +252,7 @@ impl RunningFormat {
         &mut self,
         mut format_state: FormatState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if format_state.current_track >= format_state.total_tracks {
             self.phase = FormatPhase::WriteBootSector(format_state);
@@ -281,7 +281,7 @@ impl RunningFormat {
         &mut self,
         format_state: FormatState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let ss = format_state.sector_size as usize;
 
@@ -577,7 +577,7 @@ impl RunningCommand for RunningFormat {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let phase = std::mem::replace(&mut self.phase, FormatPhase::Init);
         match phase {

--- a/crates/os/src/commands/md.rs
+++ b/crates/os/src/commands/md.rs
@@ -1,7 +1,7 @@
 //! MD / MKDIR command.
 
 use crate::{
-    DiskIo, DriveIo, IoAccess, OsState,
+    DiskIo, DriveIo, IoAccess, MemoryAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     filesystem::fat_dir,
 };
@@ -41,10 +41,10 @@ impl RunningCommand for RunningMd {
             return StepResult::Done(0);
         }
 
-        match create_directory(state, io, disk, args) {
+        match create_directory(state, io.memory, disk, args) {
             Ok(()) => StepResult::Done(0),
-            Err(msg) => {
-                io.print(msg);
+            Err(error) => {
+                io.print(error_message(error));
                 StepResult::Done(1)
             }
         }
@@ -60,46 +60,40 @@ fn print_help(io: &mut IoAccess) {
     io.println(b"  path  Specifies the directory to create.");
 }
 
-fn create_directory(
+pub(crate) fn create_directory(
     state: &mut OsState,
-    io: &mut IoAccess,
+    memory: &dyn MemoryAccess,
     disk: &mut dyn DiskIo,
     path: &[u8],
-) -> Result<(), &'static [u8]> {
-    let (drive_index, parent_cluster, fcb_name) = state
-        .resolve_file_path(path, io.memory, disk)
-        .map_err(|_| &b"Unable to create directory\r\n"[..])?;
+) -> Result<(), u16> {
+    let (drive_index, parent_cluster, fcb_name) = state.resolve_file_path(path, memory, disk)?;
 
     if drive_index == 25 {
-        return Err(b"Access denied\r\n");
+        return Err(0x0005);
     }
 
     let (time, date) = state.dos_timestamp_now();
 
     let vol = state.fat_volumes[drive_index as usize]
         .as_mut()
-        .ok_or(&b"Invalid drive\r\n"[..])?;
+        .ok_or(0x000Fu16)?;
 
-    // Check if entry already exists
     if fat_dir::find_entry(vol, parent_cluster, &fcb_name, disk)
-        .map_err(|_| &b"Unable to create directory\r\n"[..])?
+        .map_err(|_| 0x001Fu16)?
         .is_some()
     {
-        return Err(b"Unable to create directory\r\n");
+        return Err(0x0005);
     }
 
-    // Allocate a cluster for the new directory
-    let new_cluster = vol
-        .allocate_cluster(0)
-        .ok_or(&b"Unable to create directory\r\n"[..])?;
+    let new_cluster = vol.allocate_cluster(0).ok_or(0x0005u16)?;
 
-    // Zero-fill the new cluster
-    let cluster_size = vol.bpb.sectors_per_cluster as usize * vol.bpb.bytes_per_sector as usize;
+    let cluster_size = vol.sectors_per_cluster() as usize * vol.bytes_per_sector() as usize;
     let zeros = vec![0u8; cluster_size];
-    vol.write_cluster(new_cluster, &zeros, disk)
-        .map_err(|_| &b"Unable to create directory\r\n"[..])?;
+    vol.write_cluster(new_cluster, &zeros, disk).map_err(|_| {
+        vol.free_chain(new_cluster);
+        0x001Fu16
+    })?;
 
-    // Write "." entry (points to self)
     let dot_entry = fat_dir::DirEntry {
         name: *b".          ",
         attribute: fat_dir::ATTR_DIRECTORY,
@@ -110,10 +104,12 @@ fn create_directory(
         dir_sector: 0,
         dir_offset: 0,
     };
-    fat_dir::create_entry(vol, new_cluster, &dot_entry, disk)
-        .map_err(|_| &b"Unable to create directory\r\n"[..])?;
+    if let Err(error) = fat_dir::create_entry(vol, new_cluster, &dot_entry, disk) {
+        vol.free_chain(new_cluster);
+        let _ = vol.flush_fat(disk);
+        return Err(error);
+    }
 
-    // Write ".." entry (points to parent, 0 if parent is root)
     let dotdot_entry = fat_dir::DirEntry {
         name: *b"..         ",
         attribute: fat_dir::ATTR_DIRECTORY,
@@ -124,10 +120,12 @@ fn create_directory(
         dir_sector: 0,
         dir_offset: 0,
     };
-    fat_dir::create_entry(vol, new_cluster, &dotdot_entry, disk)
-        .map_err(|_| &b"Unable to create directory\r\n"[..])?;
+    if let Err(error) = fat_dir::create_entry(vol, new_cluster, &dotdot_entry, disk) {
+        vol.free_chain(new_cluster);
+        let _ = vol.flush_fat(disk);
+        return Err(error);
+    }
 
-    // Create directory entry in parent
     let dir_entry = fat_dir::DirEntry {
         name: fcb_name,
         attribute: fat_dir::ATTR_DIRECTORY,
@@ -138,11 +136,21 @@ fn create_directory(
         dir_sector: 0,
         dir_offset: 0,
     };
-    fat_dir::create_entry(vol, parent_cluster, &dir_entry, disk)
-        .map_err(|_| &b"Unable to create directory\r\n"[..])?;
+    if let Err(error) = fat_dir::create_entry(vol, parent_cluster, &dir_entry, disk) {
+        vol.free_chain(new_cluster);
+        let _ = vol.flush_fat(disk);
+        return Err(error);
+    }
 
-    vol.flush_fat(disk)
-        .map_err(|_| &b"Unable to create directory\r\n"[..])?;
+    vol.flush_fat(disk).map_err(|_| 0x001Fu16)?;
 
     Ok(())
+}
+
+fn error_message(error: u16) -> &'static [u8] {
+    match error {
+        0x0005 => b"Access denied\r\n",
+        0x000Fu16 => b"Invalid drive\r\n",
+        _ => b"Unable to create directory\r\n",
+    }
 }

--- a/crates/os/src/commands/md.rs
+++ b/crates/os/src/commands/md.rs
@@ -1,7 +1,7 @@
 //! MD / MKDIR command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DiskIo, DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     filesystem::fat_dir,
 };
@@ -33,7 +33,7 @@ impl RunningCommand for RunningMd {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let args = self.args.trim_ascii();
         if is_help_request(&self.args) || args.is_empty() {

--- a/crates/os/src/commands/mem.rs
+++ b/crates/os/src/commands/mem.rs
@@ -1,7 +1,7 @@
 //! MEM command - displays memory usage information.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     memory::collect_memory_overview,
 };
@@ -73,7 +73,7 @@ impl RunningCommand for RunningMem {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        _disk: &mut dyn DiskIo,
+        _disk: &mut dyn DriveIo,
     ) -> StepResult {
         if is_help_request(&self.args) {
             io.println(b"Displays the amount of used and free memory in your system.");

--- a/crates/os/src/commands/mem.rs
+++ b/crates/os/src/commands/mem.rs
@@ -3,7 +3,7 @@
 use crate::{
     DiskIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
-    tables::*,
+    memory::collect_memory_overview,
 };
 
 pub(crate) struct Mem;
@@ -22,63 +22,6 @@ impl Command for Mem {
 
 struct RunningMem {
     args: Vec<u8>,
-}
-
-fn read_mcb_owner(mem: &dyn crate::MemoryAccess, segment: u16) -> u16 {
-    mem.read_word((segment as u32) * 16 + MCB_OFF_OWNER)
-}
-
-fn read_mcb_size(mem: &dyn crate::MemoryAccess, segment: u16) -> u16 {
-    mem.read_word((segment as u32) * 16 + MCB_OFF_SIZE)
-}
-
-fn read_mcb_type(mem: &dyn crate::MemoryAccess, segment: u16) -> u8 {
-    mem.read_byte((segment as u32) * 16 + MCB_OFF_TYPE)
-}
-
-fn walk_mcb_chain(mem: &dyn crate::MemoryAccess, first_segment: u16) -> (u32, u32) {
-    let mut used_paragraphs: u32 = 0;
-    let mut free_paragraphs: u32 = 0;
-    let mut current = first_segment;
-    for _ in 0..4096 {
-        let block_type = read_mcb_type(mem, current);
-        if block_type != 0x4D && block_type != 0x5A {
-            break;
-        }
-        let owner = read_mcb_owner(mem, current);
-        let size = read_mcb_size(mem, current) as u32;
-        if owner == MCB_OWNER_FREE {
-            free_paragraphs += size;
-        } else {
-            used_paragraphs += size;
-        }
-        if block_type == 0x5A {
-            break;
-        }
-        current = current + size as u16 + 1;
-    }
-    (used_paragraphs, free_paragraphs)
-}
-
-fn largest_free_block(mem: &dyn crate::MemoryAccess, first_segment: u16) -> u32 {
-    let mut largest: u32 = 0;
-    let mut current = first_segment;
-    for _ in 0..4096 {
-        let block_type = read_mcb_type(mem, current);
-        if block_type != 0x4D && block_type != 0x5A {
-            break;
-        }
-        let owner = read_mcb_owner(mem, current);
-        let size = read_mcb_size(mem, current) as u32;
-        if owner == MCB_OWNER_FREE && size > largest {
-            largest = size;
-        }
-        if block_type == 0x5A {
-            break;
-        }
-        current = current + size as u16 + 1;
-    }
-    largest
 }
 
 fn format_row(label: &str, total: u32, used: u32, free: u32) -> String {
@@ -121,6 +64,10 @@ fn format_number(n: u32) -> String {
     result.chars().rev().collect()
 }
 
+fn bytes_to_kb_ceil(bytes: u32) -> u32 {
+    bytes.div_ceil(1024)
+}
+
 impl RunningCommand for RunningMem {
     fn step(
         &mut self,
@@ -135,37 +82,18 @@ impl RunningCommand for RunningMem {
             return StepResult::Done(0);
         }
 
-        let conv_total_kb: u32 = 640;
-        let (conv_used_para, _) = walk_mcb_chain(io.memory, FIRST_MCB_SEGMENT);
-        let conv_used_kb = (conv_used_para * 16).div_ceil(1024);
-        let conv_free_kb = conv_total_kb.saturating_sub(conv_used_kb);
-
+        let overview = collect_memory_overview(state, io.memory);
         let mm = state.memory_manager.as_ref();
 
-        let umb_total_kb: u32;
-        let umb_used_kb: u32;
-        let umb_free_kb: u32;
-        if let Some(manager) = mm {
-            if manager.is_umb_enabled() {
-                let (umb_used_para, umb_free_para) =
-                    walk_mcb_chain(io.memory, UMB_FIRST_MCB_SEGMENT);
-                umb_total_kb = ((umb_used_para + umb_free_para) * 16).div_ceil(1024);
-                umb_used_kb = (umb_used_para * 16).div_ceil(1024);
-                umb_free_kb = umb_total_kb.saturating_sub(umb_used_kb);
-            } else {
-                umb_total_kb = 0;
-                umb_used_kb = 0;
-                umb_free_kb = 0;
-            }
-        } else {
-            umb_total_kb = 0;
-            umb_used_kb = 0;
-            umb_free_kb = 0;
-        }
-
-        let xms_total_kb = mm.map_or(0, |m| m.xms_total_kb());
-        let xms_free_kb = mm.map_or(0, |m| m.xms_free_kb());
-        let xms_used_kb = xms_total_kb.saturating_sub(xms_free_kb);
+        let conv_total_kb = bytes_to_kb_ceil(overview.conventional.total_bytes);
+        let conv_used_kb = bytes_to_kb_ceil(overview.conventional.used_bytes);
+        let conv_free_kb = bytes_to_kb_ceil(overview.conventional.free_bytes);
+        let umb_total_kb = bytes_to_kb_ceil(overview.umb.total_bytes);
+        let umb_used_kb = bytes_to_kb_ceil(overview.umb.used_bytes);
+        let umb_free_kb = bytes_to_kb_ceil(overview.umb.free_bytes);
+        let xms_total_kb = bytes_to_kb_ceil(overview.xms.total_bytes);
+        let xms_used_kb = bytes_to_kb_ceil(overview.xms.used_bytes);
+        let xms_free_kb = bytes_to_kb_ceil(overview.xms.free_bytes);
 
         let total_total = conv_total_kb + umb_total_kb + xms_total_kb;
         let total_used = conv_used_kb + umb_used_kb + xms_used_kb;
@@ -218,8 +146,7 @@ impl RunningCommand for RunningMem {
         }
 
         io.println(b"");
-        let largest_conv = largest_free_block(io.memory, FIRST_MCB_SEGMENT);
-        let largest_conv_bytes = largest_conv * 16;
+        let largest_conv_bytes = overview.largest_conventional_free_bytes;
         let largest_conv_kb = largest_conv_bytes / 1024;
         let line = format_largest_line(
             "Largest executable program size",
@@ -229,8 +156,7 @@ impl RunningCommand for RunningMem {
         io.println(line.as_bytes());
 
         if umb_total_kb > 0 {
-            let largest_umb = largest_free_block(io.memory, UMB_FIRST_MCB_SEGMENT);
-            let largest_umb_bytes = largest_umb * 16;
+            let largest_umb_bytes = overview.largest_umb_free_bytes;
             let largest_umb_kb = largest_umb_bytes / 1024;
             let line = format_largest_line(
                 "Largest free upper memory block",

--- a/crates/os/src/commands/more.rs
+++ b/crates/os/src/commands/more.rs
@@ -3,7 +3,7 @@
 use crate::{
     DiskIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
-    filesystem::fat_dir,
+    filesystem::{fat_dir, fat_file},
 };
 
 pub(crate) struct More;
@@ -25,11 +25,8 @@ const LINES_PER_PAGE: u16 = 24;
 const KB_BUF_COUNT: u32 = 0x0528;
 
 struct ReadState {
-    drive_index: u8,
-    current_cluster: u16,
-    cluster_data: Vec<u8>,
+    data: Vec<u8>,
     offset: usize,
-    remaining: u32,
 }
 
 enum MorePhase {
@@ -46,63 +43,28 @@ struct RunningMore {
 impl RunningMore {
     fn do_output(
         &mut self,
-        state: &mut OsState,
+        _state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        _disk: &mut dyn DiskIo,
         mut read: ReadState,
         mut lines_shown: u16,
     ) -> StepResult {
-        let vol = match state.fat_volumes[read.drive_index as usize].as_ref() {
-            Some(v) => v,
-            None => return StepResult::Done(1),
-        };
-
-        let cluster_size = vol.bpb.sectors_per_cluster as usize * vol.bpb.bytes_per_sector as usize;
-        let end = cluster_size.min(read.remaining as usize + read.offset);
-
-        while read.offset < end && read.remaining > 0 {
-            if read.offset < read.cluster_data.len() {
-                let byte = read.cluster_data[read.offset];
-                io.output_byte(byte);
-                if byte == b'\n' {
-                    lines_shown += 1;
-                    if lines_shown >= LINES_PER_PAGE {
-                        io.print(b"-- More --");
-                        read.offset += 1;
-                        read.remaining -= 1;
-                        self.phase = MorePhase::WaitKey(read);
-                        return StepResult::Continue;
-                    }
+        while read.offset < read.data.len() {
+            let byte = read.data[read.offset];
+            io.output_byte(byte);
+            if byte == b'\n' {
+                lines_shown += 1;
+                if lines_shown >= LINES_PER_PAGE {
+                    io.print(b"-- More --");
+                    read.offset += 1;
+                    self.phase = MorePhase::WaitKey(read);
+                    return StepResult::Continue;
                 }
             }
             read.offset += 1;
-            read.remaining -= 1;
         }
 
-        if read.remaining == 0 {
-            return StepResult::Done(0);
-        }
-
-        match vol.next_cluster(read.current_cluster) {
-            Some(next) => {
-                let next_data = match vol.read_cluster(next, disk) {
-                    Ok(d) => d,
-                    Err(_) => return StepResult::Done(1),
-                };
-                self.phase = MorePhase::Outputting {
-                    read: ReadState {
-                        drive_index: read.drive_index,
-                        current_cluster: next,
-                        cluster_data: next_data,
-                        offset: 0,
-                        remaining: read.remaining,
-                    },
-                    lines_shown,
-                };
-                StepResult::Continue
-            }
-            None => StepResult::Done(0),
-        }
+        StepResult::Done(0)
     }
 }
 
@@ -203,22 +165,14 @@ fn init_more(
         return Err(b"Access denied\r\n");
     }
 
-    if entry.file_size == 0 || entry.start_cluster < 2 {
+    if entry.file_size == 0 {
         return Ok(MorePhase::Init);
     }
 
-    let cluster_data = vol
-        .read_cluster(entry.start_cluster, disk)
-        .map_err(|_| &b"Read error\r\n"[..])?;
+    let data = fat_file::read_all(vol, &entry, disk).map_err(|_| &b"Read error\r\n"[..])?;
 
     Ok(MorePhase::Outputting {
-        read: ReadState {
-            drive_index,
-            current_cluster: entry.start_cluster,
-            cluster_data,
-            offset: 0,
-            remaining: entry.file_size,
-        },
+        read: ReadState { data, offset: 0 },
         lines_shown: 0,
     })
 }

--- a/crates/os/src/commands/more.rs
+++ b/crates/os/src/commands/more.rs
@@ -1,7 +1,7 @@
 //! MORE command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DiskIo, DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     filesystem::{fat_dir, fat_file},
 };
@@ -45,7 +45,7 @@ impl RunningMore {
         &mut self,
         _state: &mut OsState,
         io: &mut IoAccess,
-        _disk: &mut dyn DiskIo,
+        _disk: &mut dyn DriveIo,
         mut read: ReadState,
         mut lines_shown: u16,
     ) -> StepResult {
@@ -73,7 +73,7 @@ impl RunningMore {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let args = self.args.trim_ascii();
         if is_help_request(&self.args) || args.is_empty() {
@@ -118,7 +118,7 @@ impl RunningCommand for RunningMore {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let phase = std::mem::replace(&mut self.phase, MorePhase::Init);
         match phase {

--- a/crates/os/src/commands/rd.rs
+++ b/crates/os/src/commands/rd.rs
@@ -1,9 +1,9 @@
 //! RD / RMDIR command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DiskIo, DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
-    filesystem::fat_dir,
+    filesystem::{fat::FatVolume, fat_dir},
 };
 
 pub(crate) struct Rd;
@@ -33,7 +33,7 @@ impl RunningCommand for RunningRd {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let args = self.args.trim_ascii();
         if is_help_request(&self.args) || args.is_empty() {
@@ -105,7 +105,7 @@ fn remove_directory(
 
 /// Returns true if a directory contains only "." and ".." entries.
 fn is_directory_empty(
-    vol: &crate::filesystem::fat::FatVolume,
+    vol: &FatVolume,
     dir_cluster: u16,
     disk: &mut dyn DiskIo,
 ) -> Result<bool, u16> {

--- a/crates/os/src/commands/rem.rs
+++ b/crates/os/src/commands/rem.rs
@@ -1,7 +1,7 @@
 //! REM command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
 };
 
@@ -28,7 +28,7 @@ impl RunningCommand for RunningRem {
         &mut self,
         _state: &mut OsState,
         io: &mut IoAccess,
-        _disk: &mut dyn DiskIo,
+        _disk: &mut dyn DriveIo,
     ) -> StepResult {
         if is_help_request(&self.args) {
             print_help(io);

--- a/crates/os/src/commands/ren.rs
+++ b/crates/os/src/commands/ren.rs
@@ -1,7 +1,7 @@
 //! REN / RENAME command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DiskIo, DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     filesystem::fat_dir,
 };
@@ -33,7 +33,7 @@ impl RunningCommand for RunningRen {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let args = self.args.trim_ascii();
         if is_help_request(&self.args) || args.is_empty() {

--- a/crates/os/src/commands/set.rs
+++ b/crates/os/src/commands/set.rs
@@ -1,7 +1,7 @@
 //! SET command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     tables,
 };
@@ -29,7 +29,7 @@ impl RunningCommand for RunningSet {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        _disk: &mut dyn DiskIo,
+        _disk: &mut dyn DriveIo,
     ) -> StepResult {
         let args = self.args.trim_ascii();
 

--- a/crates/os/src/commands/time.rs
+++ b/crates/os/src/commands/time.rs
@@ -1,7 +1,7 @@
 //! TIME command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
 };
 
@@ -28,7 +28,7 @@ impl RunningCommand for RunningTime {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        _disk: &mut dyn DiskIo,
+        _disk: &mut dyn DriveIo,
     ) -> StepResult {
         if is_help_request(&self.args) {
             print_help(io);

--- a/crates/os/src/commands/type_cmd.rs
+++ b/crates/os/src/commands/type_cmd.rs
@@ -1,7 +1,7 @@
 //! TYPE command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DiskIo, DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
     filesystem::{fat_dir, fat_file},
 };
@@ -41,7 +41,7 @@ impl RunningType {
         &mut self,
         _state: &mut OsState,
         io: &mut IoAccess,
-        _disk: &mut dyn DiskIo,
+        _disk: &mut dyn DriveIo,
         read: ReadState,
     ) -> StepResult {
         let chunk_end = (read.offset + 4096).min(read.data.len());
@@ -66,7 +66,7 @@ impl RunningCommand for RunningType {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let phase = std::mem::replace(&mut self.phase, TypePhase::Init);
         match phase {

--- a/crates/os/src/commands/type_cmd.rs
+++ b/crates/os/src/commands/type_cmd.rs
@@ -3,7 +3,7 @@
 use crate::{
     DiskIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
-    filesystem::fat_dir,
+    filesystem::{fat_dir, fat_file},
 };
 
 pub(crate) struct TypeCmd;
@@ -22,11 +22,8 @@ impl Command for TypeCmd {
 }
 
 struct ReadState {
-    drive_index: u8,
-    current_cluster: u16,
-    cluster_data: Vec<u8>,
+    data: Vec<u8>,
     offset: usize,
-    remaining: u32,
 }
 
 enum TypePhase {
@@ -42,48 +39,25 @@ struct RunningType {
 impl RunningType {
     fn do_output(
         &mut self,
-        state: &mut OsState,
+        _state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        _disk: &mut dyn DiskIo,
         read: ReadState,
     ) -> StepResult {
-        let vol = match state.fat_volumes[read.drive_index as usize].as_ref() {
-            Some(v) => v,
-            None => return StepResult::Done(1),
-        };
-
-        let cluster_size = vol.bpb.sectors_per_cluster as usize * vol.bpb.bytes_per_sector as usize;
-        let bytes_in_cluster = cluster_size.min(read.remaining as usize);
-        let end = read.offset + (bytes_in_cluster - read.offset).min(bytes_in_cluster);
-
-        for i in read.offset..end {
-            if i < read.cluster_data.len() {
-                io.output_byte(read.cluster_data[i]);
-            }
+        let chunk_end = (read.offset + 4096).min(read.data.len());
+        for &byte in &read.data[read.offset..chunk_end] {
+            io.output_byte(byte);
         }
 
-        let new_remaining = read.remaining - (end - read.offset) as u32;
-        if new_remaining == 0 {
+        if chunk_end >= read.data.len() {
             return StepResult::Done(0);
         }
 
-        match vol.next_cluster(read.current_cluster) {
-            Some(next) => {
-                let next_data = match vol.read_cluster(next, disk) {
-                    Ok(d) => d,
-                    Err(_) => return StepResult::Done(1),
-                };
-                self.phase = TypePhase::Outputting(ReadState {
-                    drive_index: read.drive_index,
-                    current_cluster: next,
-                    cluster_data: next_data,
-                    offset: 0,
-                    remaining: new_remaining,
-                });
-                StepResult::Continue
-            }
-            None => StepResult::Done(0),
-        }
+        self.phase = TypePhase::Outputting(ReadState {
+            data: read.data,
+            offset: chunk_end,
+        });
+        StepResult::Continue
     }
 }
 
@@ -153,19 +127,11 @@ fn init_type(
         return Err(b"Access denied\r\n");
     }
 
-    if entry.file_size == 0 || entry.start_cluster < 2 {
+    if entry.file_size == 0 {
         return Ok(TypePhase::Init);
     }
 
-    let cluster_data = vol
-        .read_cluster(entry.start_cluster, disk)
-        .map_err(|_| &b"Read error\r\n"[..])?;
+    let data = fat_file::read_all(vol, &entry, disk).map_err(|_| &b"Read error\r\n"[..])?;
 
-    Ok(TypePhase::Outputting(ReadState {
-        drive_index,
-        current_cluster: entry.start_cluster,
-        cluster_data,
-        offset: 0,
-        remaining: entry.file_size,
-    }))
+    Ok(TypePhase::Outputting(ReadState { data, offset: 0 }))
 }

--- a/crates/os/src/commands/ver.rs
+++ b/crates/os/src/commands/ver.rs
@@ -1,7 +1,7 @@
 //! VER command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
 };
 
@@ -28,7 +28,7 @@ impl RunningCommand for RunningVer {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        _disk: &mut dyn DiskIo,
+        _disk: &mut dyn DriveIo,
     ) -> StepResult {
         if is_help_request(&self.args) {
             print_help(io);

--- a/crates/os/src/commands/ver.rs
+++ b/crates/os/src/commands/ver.rs
@@ -36,7 +36,7 @@ impl RunningCommand for RunningVer {
         }
 
         let (major, minor) = state.version;
-        let msg = format!("Neetan OS Version {}.{}\r\n\r\n", major, minor);
+        let msg = format!("Neetan DOS {}.{}\r\n\r\n", major, minor);
         for &byte in msg.as_bytes() {
             io.output_byte(byte);
         }

--- a/crates/os/src/commands/xcopy.rs
+++ b/crates/os/src/commands/xcopy.rs
@@ -42,6 +42,8 @@ struct FileCopyState {
     src_drive: u8,
     src_cluster: u16,
     src_remaining: u32,
+    src_buffer: Vec<u8>,
+    src_buffer_pos: usize,
     src_entry: fat_dir::DirEntry,
     dst_drive: u8,
     dst_dir_cluster: u16,
@@ -178,30 +180,69 @@ impl RunningXcopy {
     fn step_read_chunk(
         &mut self,
         xcopy_state: XcopyState,
-        file_state: FileCopyState,
+        mut file_state: FileCopyState,
         state: &mut OsState,
         io: &mut IoAccess,
         disk: &mut dyn DiskIo,
     ) -> StepResult {
-        if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+        if file_state.src_remaining == 0 && file_state.src_buffer_pos >= file_state.src_buffer.len()
+        {
             self.phase = XcopyPhase::FinishFile(xcopy_state, file_state);
             return StepResult::Continue;
         }
 
-        let vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
-            Some(v) => v,
+        let dst_cluster_size = match state.fat_volumes[file_state.dst_drive as usize].as_ref() {
+            Some(v) => v.bpb.cluster_size() as usize,
             None => return StepResult::Done(1),
         };
+        let mut write_data = Vec::with_capacity(dst_cluster_size);
 
-        let cluster_data = match vol.read_cluster(file_state.src_cluster, disk) {
-            Ok(d) => d,
-            Err(_) => {
-                io.println(b"Read error");
-                return StepResult::Done(1);
+        while write_data.len() < dst_cluster_size {
+            if file_state.src_buffer_pos >= file_state.src_buffer.len() {
+                if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+                    break;
+                }
+
+                let vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
+                    Some(v) => v,
+                    None => return StepResult::Done(1),
+                };
+
+                let cluster_data = match vol.read_cluster(file_state.src_cluster, disk) {
+                    Ok(d) => d,
+                    Err(_) => {
+                        io.println(b"Read error");
+                        return StepResult::Done(1);
+                    }
+                };
+
+                let bytes_in_cluster = cluster_data.len().min(file_state.src_remaining as usize);
+                file_state.src_remaining -= bytes_in_cluster as u32;
+                file_state.src_buffer = cluster_data[..bytes_in_cluster].to_vec();
+                file_state.src_buffer_pos = 0;
+                file_state.src_cluster = vol.next_cluster(file_state.src_cluster).unwrap_or(0);
             }
-        };
 
-        self.phase = XcopyPhase::WriteChunk(xcopy_state, file_state, cluster_data);
+            if file_state.src_buffer_pos >= file_state.src_buffer.len() {
+                break;
+            }
+
+            let available = file_state.src_buffer.len() - file_state.src_buffer_pos;
+            let needed = dst_cluster_size - write_data.len();
+            let bytes_to_take = available.min(needed);
+            write_data.extend_from_slice(
+                &file_state.src_buffer
+                    [file_state.src_buffer_pos..file_state.src_buffer_pos + bytes_to_take],
+            );
+            file_state.src_buffer_pos += bytes_to_take;
+        }
+
+        if write_data.is_empty() {
+            self.phase = XcopyPhase::FinishFile(xcopy_state, file_state);
+            return StepResult::Continue;
+        }
+
+        self.phase = XcopyPhase::WriteChunk(xcopy_state, file_state, write_data);
         StepResult::Continue
     }
 
@@ -232,9 +273,7 @@ impl RunningXcopy {
         }
         file_state.dst_last_cluster = new_cluster;
 
-        let cluster_size = vol.bpb.sectors_per_cluster as usize * vol.bpb.bytes_per_sector as usize;
-        let bytes_to_write = cluster_size.min(file_state.src_remaining as usize);
-
+        let cluster_size = vol.bpb.cluster_size() as usize;
         let mut write_data = data;
         write_data.resize(cluster_size, 0);
 
@@ -242,14 +281,6 @@ impl RunningXcopy {
             io.println(b"Write error");
             return StepResult::Done(1);
         }
-
-        file_state.src_remaining -= bytes_to_write as u32;
-
-        let src_vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
-            Some(v) => v,
-            None => return StepResult::Done(1),
-        };
-        file_state.src_cluster = src_vol.next_cluster(file_state.src_cluster).unwrap_or(0);
 
         self.phase = XcopyPhase::ReadChunk(xcopy_state, file_state);
         StepResult::Continue
@@ -475,6 +506,8 @@ impl RunningXcopy {
             src_drive: xcopy_state.src_drive,
             src_cluster: entry.start_cluster,
             src_remaining: entry.file_size,
+            src_buffer: Vec::new(),
+            src_buffer_pos: 0,
             src_entry: entry,
             dst_drive: xcopy_state.dst_drive,
             dst_dir_cluster: xcopy_state.dst_dir_cluster,

--- a/crates/os/src/commands/xcopy.rs
+++ b/crates/os/src/commands/xcopy.rs
@@ -1,9 +1,9 @@
 //! XCOPY command.
 
 use crate::{
-    DiskIo, IoAccess, OsState,
+    DiskIo, DriveIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
-    filesystem::{fat_dir, fat_file::FatFileCursor},
+    filesystem::{fat::FatVolume, fat_dir, fat_file::FatFileCursor},
 };
 
 pub(crate) struct Xcopy;
@@ -71,7 +71,7 @@ impl RunningXcopy {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if is_help_request(&self.args) || self.args.trim_ascii().is_empty() {
             print_help(io);
@@ -94,7 +94,7 @@ impl RunningXcopy {
         mut xcopy_state: XcopyState,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let vol = match state.fat_volumes[xcopy_state.src_drive as usize].as_ref() {
             Some(v) => v,
@@ -181,7 +181,7 @@ impl RunningXcopy {
         mut file_state: FileCopyState,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         if file_state.src_cursor.remaining() == 0 {
             self.phase = XcopyPhase::FinishFile(xcopy_state, file_state);
@@ -451,7 +451,7 @@ impl RunningCommand for RunningXcopy {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> StepResult {
         let phase = std::mem::replace(&mut self.phase, XcopyPhase::Init);
         match phase {
@@ -530,11 +530,7 @@ fn print_help(io: &mut IoAccess) {
     io.println(b"  /P           Prompts before copying each file.");
 }
 
-fn is_directory_empty(
-    vol: &crate::filesystem::fat::FatVolume,
-    dir_cluster: u16,
-    disk: &mut dyn DiskIo,
-) -> bool {
+fn is_directory_empty(vol: &FatVolume, dir_cluster: u16, disk: &mut dyn DiskIo) -> bool {
     let all_pattern = [b'?'; 11];
     let attr_mask = fat_dir::ATTR_HIDDEN | fat_dir::ATTR_SYSTEM | fat_dir::ATTR_DIRECTORY;
     let mut si = 0u16;

--- a/crates/os/src/commands/xcopy.rs
+++ b/crates/os/src/commands/xcopy.rs
@@ -3,7 +3,7 @@
 use crate::{
     DiskIo, IoAccess, OsState,
     commands::{Command, RunningCommand, StepResult, is_help_request},
-    filesystem::fat_dir,
+    filesystem::{fat_dir, fat_file::FatFileCursor},
 };
 
 pub(crate) struct Xcopy;
@@ -40,10 +40,7 @@ struct XcopyState {
 
 struct FileCopyState {
     src_drive: u8,
-    src_cluster: u16,
-    src_remaining: u32,
-    src_buffer: Vec<u8>,
-    src_buffer_pos: usize,
+    src_cursor: FatFileCursor,
     src_entry: fat_dir::DirEntry,
     dst_drive: u8,
     dst_dir_cluster: u16,
@@ -186,8 +183,7 @@ impl RunningXcopy {
         io: &mut IoAccess,
         disk: &mut dyn DiskIo,
     ) -> StepResult {
-        if file_state.src_remaining == 0 && file_state.src_buffer_pos >= file_state.src_buffer.len()
-        {
+        if file_state.src_cursor.remaining() == 0 {
             self.phase = XcopyPhase::FinishFile(xcopy_state, file_state);
             return StepResult::Continue;
         }
@@ -196,51 +192,20 @@ impl RunningXcopy {
             Some(v) => v.bpb.cluster_size() as usize,
             None => return StepResult::Done(1),
         };
-        let mut write_data = Vec::with_capacity(dst_cluster_size);
-
-        while write_data.len() < dst_cluster_size {
-            if file_state.src_buffer_pos >= file_state.src_buffer.len() {
-                if file_state.src_remaining == 0 {
-                    break;
-                }
-                if file_state.src_cluster < 2 {
-                    io.println(b"Read error");
-                    return StepResult::Done(1);
-                }
-
-                let vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
-                    Some(v) => v,
-                    None => return StepResult::Done(1),
-                };
-
-                let cluster_data = match vol.read_cluster(file_state.src_cluster, disk) {
-                    Ok(d) => d,
-                    Err(_) => {
-                        io.println(b"Read error");
-                        return StepResult::Done(1);
-                    }
-                };
-
-                let bytes_in_cluster = cluster_data.len().min(file_state.src_remaining as usize);
-                file_state.src_remaining -= bytes_in_cluster as u32;
-                file_state.src_buffer = cluster_data[..bytes_in_cluster].to_vec();
-                file_state.src_buffer_pos = 0;
-                file_state.src_cluster = vol.next_cluster(file_state.src_cluster).unwrap_or(0);
+        let src_vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
+            Some(v) => v,
+            None => return StepResult::Done(1),
+        };
+        let write_data = match file_state
+            .src_cursor
+            .read_chunk(src_vol, disk, dst_cluster_size)
+        {
+            Ok(data) => data,
+            Err(_) => {
+                io.println(b"Read error");
+                return StepResult::Done(1);
             }
-
-            if file_state.src_buffer_pos >= file_state.src_buffer.len() {
-                break;
-            }
-
-            let available = file_state.src_buffer.len() - file_state.src_buffer_pos;
-            let needed = dst_cluster_size - write_data.len();
-            let bytes_to_take = available.min(needed);
-            write_data.extend_from_slice(
-                &file_state.src_buffer
-                    [file_state.src_buffer_pos..file_state.src_buffer_pos + bytes_to_take],
-            );
-            file_state.src_buffer_pos += bytes_to_take;
-        }
+        };
 
         if write_data.is_empty() {
             self.phase = XcopyPhase::FinishFile(xcopy_state, file_state);
@@ -512,10 +477,7 @@ impl RunningXcopy {
     fn start_file_copy(&mut self, xcopy_state: &mut XcopyState, entry: fat_dir::DirEntry) {
         let file_state = FileCopyState {
             src_drive: xcopy_state.src_drive,
-            src_cluster: entry.start_cluster,
-            src_remaining: entry.file_size,
-            src_buffer: Vec::new(),
-            src_buffer_pos: 0,
+            src_cursor: FatFileCursor::new(&entry),
             src_entry: entry,
             dst_drive: xcopy_state.dst_drive,
             dst_dir_cluster: xcopy_state.dst_dir_cluster,
@@ -546,7 +508,7 @@ impl RunningXcopy {
             },
         );
 
-        if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+        if file_state.src_entry.file_size == 0 {
             self.phase = XcopyPhase::FinishFile(taken, file_state);
         } else {
             self.phase = XcopyPhase::ReadChunk(taken, file_state);

--- a/crates/os/src/commands/xcopy.rs
+++ b/crates/os/src/commands/xcopy.rs
@@ -50,6 +50,7 @@ struct FileCopyState {
     dst_fcb_name: [u8; 11],
     dst_first_cluster: u16,
     dst_last_cluster: u16,
+    dst_total_written: u32,
 }
 
 enum XcopyPhase {
@@ -199,8 +200,12 @@ impl RunningXcopy {
 
         while write_data.len() < dst_cluster_size {
             if file_state.src_buffer_pos >= file_state.src_buffer.len() {
-                if file_state.src_remaining == 0 || file_state.src_cluster < 2 {
+                if file_state.src_remaining == 0 {
                     break;
+                }
+                if file_state.src_cluster < 2 {
+                    io.println(b"Read error");
+                    return StepResult::Done(1);
                 }
 
                 let vol = match state.fat_volumes[file_state.src_drive as usize].as_ref() {
@@ -274,6 +279,7 @@ impl RunningXcopy {
         file_state.dst_last_cluster = new_cluster;
 
         let cluster_size = vol.bpb.cluster_size() as usize;
+        let bytes_to_write = data.len();
         let mut write_data = data;
         write_data.resize(cluster_size, 0);
 
@@ -281,6 +287,8 @@ impl RunningXcopy {
             io.println(b"Write error");
             return StepResult::Done(1);
         }
+
+        file_state.dst_total_written += bytes_to_write as u32;
 
         self.phase = XcopyPhase::ReadChunk(xcopy_state, file_state);
         StepResult::Continue
@@ -317,7 +325,7 @@ impl RunningXcopy {
             time: file_state.src_entry.time,
             date: file_state.src_entry.date,
             start_cluster: file_state.dst_first_cluster,
-            file_size: file_state.src_entry.file_size,
+            file_size: file_state.dst_total_written,
             dir_sector: 0,
             dir_offset: 0,
         };
@@ -514,6 +522,7 @@ impl RunningXcopy {
             dst_fcb_name: [0; 11],
             dst_first_cluster: 0,
             dst_last_cluster: 0,
+            dst_total_written: 0,
         };
 
         let mut file_state = file_state;

--- a/crates/os/src/console.rs
+++ b/crates/os/src/console.rs
@@ -1891,6 +1891,21 @@ mod tests {
     }
 
     #[test]
+    fn esc_star_clears_screen() {
+        let mut console = make_console();
+        let mut memory = make_memory();
+        fill_row(&mut memory, 0, b'X');
+        console.set_cursor(&mut memory, 5, 10);
+        feed_str(&mut console, &mut memory, "\x1b*");
+        assert_vram_clear(&memory, 0, 0, 79);
+        assert_cursor(&console, &memory, 0, 0);
+        assert_eq!(
+            console.esc_parser.state,
+            crate::console_esc::EscState::Normal
+        );
+    }
+
+    #[test]
     fn parser_resets_on_unknown_csi() {
         let mut console = make_console();
         let mut memory = make_memory();

--- a/crates/os/src/console.rs
+++ b/crates/os/src/console.rs
@@ -1371,6 +1371,33 @@ mod tests {
     }
 
     #[test]
+    fn esc_plain_d_calls_linefeed() {
+        let mut console = make_console();
+        let mut memory = make_memory();
+        console.set_cursor(&mut memory, 5, 10);
+        feed_str(&mut console, &mut memory, "\x1bD");
+        assert_cursor(&console, &memory, 6, 10);
+    }
+
+    #[test]
+    fn esc_plain_e_calls_carriage_return_then_linefeed() {
+        let mut console = make_console();
+        let mut memory = make_memory();
+        console.set_cursor(&mut memory, 5, 10);
+        feed_str(&mut console, &mut memory, "\x1bE");
+        assert_cursor(&console, &memory, 6, 0);
+    }
+
+    #[test]
+    fn esc_plain_m_calls_reverse_linefeed() {
+        let mut console = make_console();
+        let mut memory = make_memory();
+        console.set_cursor(&mut memory, 5, 10);
+        feed_str(&mut console, &mut memory, "\x1bM");
+        assert_cursor(&console, &memory, 4, 10);
+    }
+
+    #[test]
     fn esc_printable_single() {
         let mut console = make_console();
         let mut memory = make_memory();

--- a/crates/os/src/console_esc.rs
+++ b/crates/os/src/console_esc.rs
@@ -100,6 +100,10 @@ impl Console {
             b'[' => {
                 self.esc_parser.state = EscState::GotCsi;
             }
+            b'*' => {
+                self.clear_screen(memory);
+                self.esc_parser.reset();
+            }
             b')' => {
                 self.esc_parser.state = EscState::GotEscRightParen;
             }

--- a/crates/os/src/console_esc.rs
+++ b/crates/os/src/console_esc.rs
@@ -104,6 +104,19 @@ impl Console {
                 self.clear_screen(memory);
                 self.esc_parser.reset();
             }
+            b'D' => {
+                self.linefeed(memory);
+                self.esc_parser.reset();
+            }
+            b'E' => {
+                self.carriage_return(memory);
+                self.linefeed(memory);
+                self.esc_parser.reset();
+            }
+            b'M' => {
+                self.reverse_linefeed(memory);
+                self.esc_parser.reset();
+            }
             b')' => {
                 self.esc_parser.state = EscState::GotEscRightParen;
             }

--- a/crates/os/src/dos.rs
+++ b/crates/os/src/dos.rs
@@ -56,6 +56,7 @@ impl NeetanOs {
             0x36 => self.int21h_36h_get_free_disk_space(cpu, memory, disk),
             0x37 => self.int21h_37h_switch_char(cpu),
             0x38 => self.int21h_38h_get_country_info(cpu, memory),
+            0x39 => self.int21h_39h_mkdir(cpu, memory, disk),
             0x3B => {
                 tracer.trace_int21h_chdir(cpu, memory);
                 tracer.trace_int21h_set_current_directory(cpu, memory);

--- a/crates/os/src/dos.rs
+++ b/crates/os/src/dos.rs
@@ -53,6 +53,7 @@ impl NeetanOs {
             0x33 => self.int21h_33h_extended(cpu),
             0x34 => self.int21h_34h_get_indos(cpu),
             0x35 => self.int21h_35h_get_interrupt_vector(cpu, memory),
+            0x36 => self.int21h_36h_get_free_disk_space(cpu, memory, disk),
             0x37 => self.int21h_37h_switch_char(cpu),
             0x38 => self.int21h_38h_get_country_info(cpu, memory),
             0x3B => {

--- a/crates/os/src/dos.rs
+++ b/crates/os/src/dos.rs
@@ -3,7 +3,7 @@
 use common::warn;
 
 use crate::{
-    BufferedInputState, CpuAccess, DiskIo, MemoryAccess, NeetanOs, Tracing, adjust_iret_ip,
+    BufferedInputState, CpuAccess, DriveIo, MemoryAccess, NeetanOs, Tracing, adjust_iret_ip,
     country, memory, set_iret_carry, set_iret_zf, tables,
 };
 
@@ -13,7 +13,7 @@ impl NeetanOs {
         &mut self,
         cpu: &mut dyn CpuAccess,
         memory: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
         tracer: &mut impl Tracing,
     ) {
         let indos_addr = self.state.indos_addr;
@@ -709,7 +709,7 @@ impl NeetanOs {
         &mut self,
         cpu: &mut dyn CpuAccess,
         memory: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) {
         let path_addr = ((cpu.ds() as u32) << 4) + cpu.dx() as u32;
 

--- a/crates/os/src/file_io.rs
+++ b/crates/os/src/file_io.rs
@@ -4,6 +4,7 @@ use common::warn;
 
 use crate::{
     CpuAccess, DiskIo, DriveIo, MemoryAccess, NeetanOs, OsState,
+    commands::md,
     filesystem::{
         ReadDirEntrySource, ReadDirectory, fat_dir,
         fat_file::{FatFileCursor, FatFileWriter},
@@ -205,6 +206,25 @@ impl NeetanOs {
         // Return AL: 0=no wildcards, 1=wildcards present, FF=invalid drive
         let has_wildcards = fcb.contains(&b'?');
         cpu.set_ax((cpu.ax() & 0xFF00) | if has_wildcards { 0x01 } else { 0x00 });
+    }
+
+    /// AH=39h: Create subdirectory.
+    pub(crate) fn int21h_39h_mkdir(
+        &mut self,
+        cpu: &mut dyn CpuAccess,
+        memory: &mut dyn MemoryAccess,
+        disk: &mut dyn DiskIo,
+    ) {
+        let path_addr = ((cpu.ds() as u32) << 4) + cpu.dx() as u32;
+        let path = OsState::read_asciiz(memory, path_addr, 128);
+
+        match md::create_directory(&mut self.state, memory, disk, &path) {
+            Ok(()) => set_iret_carry(cpu, memory, false),
+            Err(error) => {
+                cpu.set_ax(error);
+                set_iret_carry(cpu, memory, true);
+            }
+        }
     }
 
     /// AH=3Ch: Create file.

--- a/crates/os/src/file_io.rs
+++ b/crates/os/src/file_io.rs
@@ -4,7 +4,12 @@ use common::warn;
 
 use crate::{
     CpuAccess, DiskIo, MemoryAccess, NeetanOs, OsState,
-    filesystem::{fat_dir, split_path, virtual_drive::VirtualEntry},
+    filesystem::{
+        fat_dir,
+        fat_file::{FatFileCursor, FatFileWriter},
+        split_path,
+        virtual_drive::VirtualEntry,
+    },
     set_iret_carry, tables,
 };
 
@@ -394,33 +399,16 @@ impl NeetanOs {
             let vol = self.state.fat_volumes[drive_index as usize]
                 .as_ref()
                 .ok_or(0x000Fu16)?;
-
-            let cluster_size = vol.bpb.cluster_size();
             let bytes_to_read = count.min(file_size - position);
-            let mut bytes_read = 0u32;
-
-            while bytes_read < bytes_to_read {
-                let cluster_index = position / cluster_size;
-                let offset_in_cluster = position % cluster_size;
-
-                let cluster = vol
-                    .cluster_at_index(start_cluster, cluster_index)
-                    .ok_or(0x001Fu16)?;
-                let cluster_data = vol.read_cluster(cluster, disk)?;
-
-                let available = (cluster_size - offset_in_cluster).min(bytes_to_read - bytes_read);
-                let src_start = offset_in_cluster as usize;
-                let src_end = src_start + available as usize;
-                memory.write_block(buf_addr + bytes_read, &cluster_data[src_start..src_end]);
-
-                bytes_read += available;
-                position += available;
-            }
+            let mut cursor = FatFileCursor::with_position(start_cluster, file_size, position);
+            let read_data = cursor.read_chunk(vol, disk, bytes_to_read as usize)?;
+            memory.write_block(buf_addr, &read_data);
+            position = cursor.position();
 
             // Update SFT position
             write_dword(memory, sft_addr + tables::SFT_ENT_FILE_POS, position);
 
-            Ok(bytes_read as u16)
+            Ok(read_data.len() as u16)
         })();
 
         match result {
@@ -480,42 +468,14 @@ impl NeetanOs {
             let vol = self.state.fat_volumes[drive_index as usize]
                 .as_mut()
                 .ok_or(0x000Fu16)?;
-            let cluster_size = vol.bpb.cluster_size();
+            let mut write_data = vec![0u8; count as usize];
+            memory.read_block(buf_addr, &mut write_data);
 
-            // Allocate first cluster if needed
-            if start_cluster < 2 {
-                let new_cluster = vol.allocate_cluster(0).ok_or(0x001Fu16)?;
-                start_cluster = new_cluster;
-                memory.write_word(sft_addr + tables::SFT_ENT_START_CLUSTER, start_cluster);
-                // Zero out the cluster
-                let zeros = vec![0u8; cluster_size as usize];
-                vol.write_cluster(new_cluster, &zeros, disk)?;
-            }
-
-            let mut bytes_written = 0u32;
-            while bytes_written < count {
-                let cluster_index = position / cluster_size;
-                let offset_in_cluster = position % cluster_size;
-
-                // Walk to the right cluster, allocating if needed
-                let cluster = ensure_cluster_at_index(vol, start_cluster, cluster_index, disk)?;
-
-                let mut cluster_data = vol.read_cluster(cluster, disk)?;
-                let available = (cluster_size - offset_in_cluster).min(count - bytes_written);
-
-                // Read data from guest memory
-                let dst_start = offset_in_cluster as usize;
-                let dst_end = dst_start + available as usize;
-                memory.read_block(
-                    buf_addr + bytes_written,
-                    &mut cluster_data[dst_start..dst_end],
-                );
-
-                vol.write_cluster(cluster, &cluster_data, disk)?;
-
-                bytes_written += available;
-                position += available;
-            }
+            let mut writer = FatFileWriter::new(start_cluster, position);
+            writer.write_chunk(vol, disk, &write_data)?;
+            start_cluster = writer.start_cluster();
+            position = writer.position();
+            memory.write_word(sft_addr + tables::SFT_ENT_START_CLUSTER, start_cluster);
 
             if position > file_size {
                 file_size = position;
@@ -529,7 +489,7 @@ impl NeetanOs {
 
             vol.flush_fat(disk)?;
 
-            Ok(bytes_written as u16)
+            Ok(write_data.len() as u16)
         })();
 
         match result {
@@ -1139,29 +1099,4 @@ fn write_find_result(
     let len = display.len().min(12);
     mem.write_block(dta_addr + 0x1E, &display[..len]);
     mem.write_byte(dta_addr + 0x1E + len as u32, 0x00);
-}
-
-/// Ensures a cluster exists at the given index in the chain, allocating as needed.
-fn ensure_cluster_at_index(
-    vol: &mut crate::filesystem::fat::FatVolume,
-    start: u16,
-    index: u32,
-    disk: &mut dyn DiskIo,
-) -> Result<u16, u16> {
-    let mut current = start;
-    for _ in 0..index {
-        match vol.next_cluster(current) {
-            Some(next) => current = next,
-            None => {
-                // Allocate new cluster
-                let new = vol.allocate_cluster(current).ok_or(0x001Fu16)?;
-                // Zero out new cluster
-                let cluster_size = vol.bpb.cluster_size();
-                let zeros = vec![0u8; cluster_size as usize];
-                vol.write_cluster(new, &zeros, disk)?;
-                current = new;
-            }
-        }
-    }
-    Ok(current)
 }

--- a/crates/os/src/file_io.rs
+++ b/crates/os/src/file_io.rs
@@ -85,6 +85,70 @@ impl NeetanOs {
         }
     }
 
+    /// AH=36h: Get free disk space.
+    pub(crate) fn int21h_36h_get_free_disk_space(
+        &mut self,
+        cpu: &mut dyn CpuAccess,
+        memory: &dyn MemoryAccess,
+        disk: &mut dyn DriveIo,
+    ) {
+        let dl = (cpu.dx() & 0xFF) as u8;
+        let drive_index = if dl == 0 {
+            self.state.current_drive
+        } else {
+            dl - 1
+        };
+
+        if drive_index >= 26 {
+            cpu.set_ax(0xFFFF);
+            return;
+        }
+
+        if drive_index == 25 {
+            cpu.set_ax(1);
+            cpu.set_bx(0);
+            cpu.set_cx(512);
+            cpu.set_dx(0);
+            return;
+        }
+
+        let cds_addr = tables::CDS_BASE + (drive_index as u32) * tables::CDS_ENTRY_SIZE;
+        let cds_flags = memory.read_word(cds_addr + tables::CDS_OFF_FLAGS);
+        if cds_flags == 0 {
+            cpu.set_ax(0xFFFF);
+            return;
+        }
+
+        if self.state.mscdex.drive_letter == drive_index
+            && cds_flags & tables::CDS_FLAG_PHYSICAL == 0
+        {
+            cpu.set_ax(1);
+            cpu.set_bx(0);
+            cpu.set_cx(2048);
+            cpu.set_dx(0);
+            return;
+        }
+
+        if self
+            .state
+            .ensure_volume_mounted(drive_index, memory, disk)
+            .is_err()
+        {
+            cpu.set_ax(0xFFFF);
+            return;
+        }
+
+        let Some(volume) = self.state.fat_volumes[drive_index as usize].as_ref() else {
+            cpu.set_ax(0xFFFF);
+            return;
+        };
+
+        cpu.set_ax(volume.sectors_per_cluster());
+        cpu.set_bx(volume.free_cluster_count());
+        cpu.set_cx(volume.bytes_per_sector());
+        cpu.set_dx(volume.total_cluster_count());
+    }
+
     /// AH=29h: Parse filename into FCB.
     pub(crate) fn int21h_29h_parse_filename(
         &self,

--- a/crates/os/src/file_io.rs
+++ b/crates/os/src/file_io.rs
@@ -3,11 +3,11 @@
 use common::warn;
 
 use crate::{
-    CpuAccess, DiskIo, MemoryAccess, NeetanOs, OsState,
+    CpuAccess, DiskIo, DriveIo, MemoryAccess, NeetanOs, OsState,
     filesystem::{
-        fat_dir,
+        ReadDirEntrySource, ReadDirectory, fat_dir,
         fat_file::{FatFileCursor, FatFileWriter},
-        split_path,
+        find_matching_read_entry, find_read_entry, iso9660, split_path,
         virtual_drive::VirtualEntry,
     },
     set_iret_carry, tables,
@@ -230,20 +230,21 @@ impl NeetanOs {
         &mut self,
         cpu: &mut dyn CpuAccess,
         memory: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) {
         let path_addr = ((cpu.ds() as u32) << 4) + cpu.dx() as u32;
         let open_mode = cpu.ax() as u8 & 0x03;
         let path = OsState::read_asciiz(memory, path_addr, 128);
 
         let result = (|| -> Result<u16, u16> {
-            let (drive_index, dir_cluster, fcb_name) =
-                self.state.resolve_file_path(&path, memory, disk)?;
+            let read_path = self.state.resolve_read_file_path(&path, memory, disk)?;
+            let drive_index = read_path.drive_index;
 
             if drive_index == 25 {
                 if open_mode != 0x00 {
                     return Err(0x0005); // Z: is read-only
                 }
+                let (_, _, fcb_name) = self.state.resolve_file_path(&path, memory, disk)?;
                 let ventry = self
                     .state
                     .virtual_drive
@@ -254,14 +255,36 @@ impl NeetanOs {
                 return Ok(handle as u16);
             }
 
-            let vol = self.state.fat_volumes[drive_index as usize]
-                .as_ref()
-                .ok_or(0x000Fu16)?;
-
-            let entry = fat_dir::find_entry(vol, dir_cluster, &fcb_name, disk)?.ok_or(0x0002u16)?; // file not found
-
             let (handle, sft_index) = self.state.allocate_handle(memory)?;
-            self.write_sft_for_file(memory, sft_index, &entry, drive_index, open_mode as u16);
+            let entry = find_read_entry(&self.state, &read_path, disk)?.ok_or(0x0002u16)?;
+            if entry.attribute & fat_dir::ATTR_DIRECTORY != 0 {
+                return Err(0x0005);
+            }
+            match &entry.source {
+                ReadDirEntrySource::Fat(entry) => {
+                    self.write_sft_for_file(
+                        memory,
+                        sft_index,
+                        entry,
+                        drive_index,
+                        open_mode as u16,
+                    );
+                    self.state.open_iso_files[sft_index as usize] = None;
+                }
+                ReadDirEntrySource::Iso(entry) => {
+                    if open_mode != 0x00 {
+                        return Err(0x0005);
+                    }
+                    self.write_sft_for_iso_file(
+                        memory,
+                        sft_index,
+                        entry,
+                        drive_index,
+                        open_mode as u16,
+                    );
+                    self.state.open_iso_files[sft_index as usize] = Some(entry.clone());
+                }
+            }
             Ok(handle as u16)
         })();
 
@@ -289,6 +312,7 @@ impl NeetanOs {
         let result = (|| -> Result<(), u16> {
             let sft_index = self.state.handle_to_sft_index(handle, memory)?;
             let sft_addr = self.state.sft_entry_addr(sft_index).ok_or(0x0006u16)?;
+            let ref_count = memory.read_word(sft_addr + tables::SFT_ENT_REF_COUNT);
 
             let dev_info = memory.read_word(sft_addr + tables::SFT_ENT_DEV_INFO);
             let is_device = dev_info & tables::SFT_DEVINFO_CHAR != 0;
@@ -329,6 +353,9 @@ impl NeetanOs {
             }
 
             self.state.free_handle(handle, memory);
+            if ref_count <= 1 {
+                self.state.open_iso_files[sft_index as usize] = None;
+            }
             Ok(())
         })();
 
@@ -346,7 +373,7 @@ impl NeetanOs {
         &mut self,
         cpu: &mut dyn CpuAccess,
         memory: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) {
         let handle = cpu.bx();
         let count = cpu.cx() as u32;
@@ -391,17 +418,24 @@ impl NeetanOs {
                 return Ok(actual as u16);
             }
 
+            let bytes_to_read = count.min(file_size - position) as usize;
+            if let Some(entry) = self.state.open_iso_files[sft_index as usize].as_ref() {
+                let read_data = iso9660::read_file_chunk(entry, position, bytes_to_read, disk)?;
+                memory.write_block(buf_addr, &read_data);
+                position = position.saturating_add(read_data.len() as u32);
+                write_dword(memory, sft_addr + tables::SFT_ENT_FILE_POS, position);
+                return Ok(read_data.len() as u16);
+            }
+
             let start_cluster = memory.read_word(sft_addr + tables::SFT_ENT_START_CLUSTER);
             if start_cluster < 2 {
                 return Ok(0);
             }
-
             let vol = self.state.fat_volumes[drive_index as usize]
                 .as_ref()
                 .ok_or(0x000Fu16)?;
-            let bytes_to_read = count.min(file_size - position);
             let mut cursor = FatFileCursor::with_position(start_cluster, file_size, position);
-            let read_data = cursor.read_chunk(vol, disk, bytes_to_read as usize)?;
+            let read_data = cursor.read_chunk(vol, disk, bytes_to_read)?;
             memory.write_block(buf_addr, &read_data);
             position = cursor.position();
 
@@ -595,34 +629,37 @@ impl NeetanOs {
         &mut self,
         cpu: &mut dyn CpuAccess,
         memory: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) {
         let path_addr = ((cpu.ds() as u32) << 4) + cpu.dx() as u32;
         let al = cpu.ax() as u8;
         let path = OsState::read_asciiz(memory, path_addr, 128);
 
         let result = (|| -> Result<u16, u16> {
-            let (drive_index, dir_cluster, fcb_name) =
-                self.state.resolve_file_path(&path, memory, disk)?;
+            let read_path = self.state.resolve_read_file_path(&path, memory, disk)?;
+            let drive_index = read_path.drive_index;
 
             if drive_index == 25 {
                 // Virtual Z: drive
+                let (_, _, fcb_name) = self.state.resolve_file_path(&path, memory, disk)?;
                 if let Some(ventry) = self.state.virtual_drive.find_entry(&fcb_name) {
                     return Ok(ventry.attribute as u16);
                 }
                 return Err(0x0002);
             }
 
-            let vol = self.state.fat_volumes[drive_index as usize]
-                .as_mut()
-                .ok_or(0x000Fu16)?;
-
-            let entry = fat_dir::find_entry(vol, dir_cluster, &fcb_name, disk)?.ok_or(0x0002u16)?;
+            let entry = find_read_entry(&self.state, &read_path, disk)?.ok_or(0x0002u16)?;
 
             match al {
                 0x00 => Ok(entry.attribute as u16),
                 0x01 => {
+                    let ReadDirEntrySource::Fat(entry) = entry.source else {
+                        return Err(0x0005);
+                    };
                     let new_attr = cpu.cx() as u8;
+                    let vol = self.state.fat_volumes[drive_index as usize]
+                        .as_mut()
+                        .ok_or(0x000Fu16)?;
                     let mut updated = entry;
                     updated.attribute = new_attr & 0x27;
                     fat_dir::update_entry(vol, &updated, disk)?;
@@ -766,15 +803,30 @@ impl NeetanOs {
         &mut self,
         cpu: &mut dyn CpuAccess,
         memory: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) {
         let path_addr = ((cpu.ds() as u32) << 4) + cpu.dx() as u32;
         let attr_mask = cpu.cx() as u8;
         let path = OsState::read_asciiz(memory, path_addr, 128);
 
         let result = (|| -> Result<(), u16> {
-            let (drive_index, dir_cluster, pattern) =
-                self.state.resolve_file_path(&path, memory, disk)?;
+            let (drive_index, pattern, dir_cluster, read_directory) =
+                if let Ok(read_path) = self.state.resolve_read_file_path(&path, memory, disk) {
+                    let dir_cluster = match &read_path.directory {
+                        ReadDirectory::Fat(dir_cluster) => *dir_cluster,
+                        ReadDirectory::Iso(_) => 0,
+                    };
+                    (
+                        read_path.drive_index,
+                        read_path.name,
+                        dir_cluster,
+                        Some(read_path.directory),
+                    )
+                } else {
+                    let (drive_index, dir_cluster, pattern) =
+                        self.state.resolve_file_path(&path, memory, disk)?;
+                    (drive_index, pattern, dir_cluster, None)
+                };
 
             let dta_addr = ((self.state.dta_segment as u32) << 4) + self.state.dta_offset as u32;
 
@@ -784,6 +836,7 @@ impl NeetanOs {
             memory.write_byte(dta_addr + 0x0C, attr_mask);
             memory.write_word(dta_addr + 0x0D, 0); // start index
             memory.write_word(dta_addr + 0x0F, dir_cluster);
+            self.state.read_find_directory = read_directory;
 
             // Perform the search
             self.do_find_next(memory, disk)
@@ -803,7 +856,7 @@ impl NeetanOs {
         &mut self,
         cpu: &mut dyn CpuAccess,
         memory: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) {
         match self.do_find_next(memory, disk) {
             Ok(()) => set_iret_carry(cpu, memory, false),
@@ -818,7 +871,7 @@ impl NeetanOs {
     fn do_find_next(
         &mut self,
         memory: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> Result<(), u16> {
         let dta_addr = ((self.state.dta_segment as u32) << 4) + self.state.dta_offset as u32;
 
@@ -852,12 +905,21 @@ impl NeetanOs {
             return Err(0x0012); // no more files
         }
 
-        let vol = self.state.fat_volumes[drive_index as usize]
-            .as_ref()
-            .ok_or(0x0012u16)?;
+        let directory = self
+            .state
+            .read_find_directory
+            .clone()
+            .unwrap_or(ReadDirectory::Fat(dir_cluster));
 
-        let result =
-            fat_dir::find_matching(vol, dir_cluster, &pattern, attr_mask, start_index, disk)?;
+        let result = find_matching_read_entry(
+            &self.state,
+            drive_index,
+            &directory,
+            &pattern,
+            attr_mask,
+            start_index,
+            disk,
+        )?;
 
         if let Some((entry, next_index)) = result {
             memory.write_word(dta_addr + 0x0D, next_index);
@@ -1039,6 +1101,42 @@ impl NeetanOs {
             sft_addr + tables::SFT_ENT_DIR_INDEX,
             (entry.dir_offset / fat_dir::DIR_ENTRY_SIZE as u16) as u8,
         );
+        mem.write_block(sft_addr + tables::SFT_ENT_NAME, &entry.name);
+        mem.write_word(sft_addr + tables::SFT_ENT_PSP_OWNER, self.state.current_psp);
+    }
+
+    fn write_sft_for_iso_file(
+        &self,
+        mem: &mut dyn MemoryAccess,
+        sft_index: u8,
+        entry: &iso9660::IsoDirEntry,
+        drive_index: u8,
+        open_mode: u16,
+    ) {
+        let sft_addr = match self.state.sft_entry_addr(sft_index) {
+            Some(address) => address,
+            None => return,
+        };
+
+        mem.write_word(sft_addr + tables::SFT_ENT_REF_COUNT, 1);
+        mem.write_word(sft_addr + tables::SFT_ENT_OPEN_MODE, open_mode);
+        mem.write_byte(sft_addr + tables::SFT_ENT_FILE_ATTR, entry.attribute);
+        mem.write_word(sft_addr + tables::SFT_ENT_DEV_INFO, drive_index as u16);
+        tables::write_far_ptr(
+            mem,
+            sft_addr + tables::SFT_ENT_DEV_PTR,
+            tables::DOS_DATA_SEGMENT,
+            tables::DEV_NUL_OFFSET,
+        );
+        mem.write_word(sft_addr + tables::SFT_ENT_START_CLUSTER, 0);
+        mem.write_word(sft_addr + tables::SFT_ENT_FILE_TIME, entry.time);
+        mem.write_word(sft_addr + tables::SFT_ENT_FILE_DATE, entry.date);
+        write_dword(mem, sft_addr + tables::SFT_ENT_FILE_SIZE, entry.file_size);
+        write_dword(mem, sft_addr + tables::SFT_ENT_FILE_POS, 0);
+        mem.write_word(sft_addr + tables::SFT_ENT_REL_CLUSTER, 0);
+        mem.write_word(sft_addr + tables::SFT_ENT_CUR_CLUSTER, 0);
+        mem.write_word(sft_addr + tables::SFT_ENT_DIR_SECTOR, 0);
+        mem.write_byte(sft_addr + tables::SFT_ENT_DIR_INDEX, 0);
         mem.write_block(sft_addr + tables::SFT_ENT_NAME, &entry.name);
         mem.write_word(sft_addr + tables::SFT_ENT_PSP_OWNER, self.state.current_psp);
     }

--- a/crates/os/src/filesystem.rs
+++ b/crates/os/src/filesystem.rs
@@ -1,11 +1,150 @@
 //! Drive trait, DiskIo trait, drive mapping, error types.
 
+use crate::{DriveIo, OsState};
+
 pub mod fat;
 pub(crate) mod fat_bpb;
 pub(crate) mod fat_dir;
 pub(crate) mod fat_file;
 pub(crate) mod fat_partition;
+pub(crate) mod iso9660;
 pub(crate) mod virtual_drive;
+
+#[derive(Debug, Clone)]
+pub(crate) enum ReadDirectory {
+    Fat(u16),
+    Iso(iso9660::IsoDirectory),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReadFilePath {
+    pub drive_index: u8,
+    pub directory: ReadDirectory,
+    pub name: [u8; 11],
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReadDirPath {
+    pub drive_index: u8,
+    pub directory: ReadDirectory,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReadDirEntry {
+    pub name: [u8; 11],
+    pub attribute: u8,
+    pub time: u16,
+    pub date: u16,
+    pub file_size: u32,
+    pub source: ReadDirEntrySource,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ReadDirEntrySource {
+    Fat(fat_dir::DirEntry),
+    Iso(iso9660::IsoDirEntry),
+}
+
+impl ReadDirEntry {
+    pub(crate) fn from_fat(entry: fat_dir::DirEntry) -> Self {
+        Self {
+            name: entry.name,
+            attribute: entry.attribute,
+            time: entry.time,
+            date: entry.date,
+            file_size: entry.file_size,
+            source: ReadDirEntrySource::Fat(entry),
+        }
+    }
+
+    pub(crate) fn from_iso(entry: iso9660::IsoDirEntry) -> Self {
+        Self {
+            name: entry.name,
+            attribute: entry.attribute,
+            time: entry.time,
+            date: entry.date,
+            file_size: entry.file_size,
+            source: ReadDirEntrySource::Iso(entry),
+        }
+    }
+}
+
+pub(crate) fn find_read_entry(
+    state: &OsState,
+    path: &ReadFilePath,
+    device: &mut dyn DriveIo,
+) -> Result<Option<ReadDirEntry>, u16> {
+    match &path.directory {
+        ReadDirectory::Fat(dir_cluster) => {
+            let volume = state.fat_volumes[path.drive_index as usize]
+                .as_ref()
+                .ok_or(0x000Fu16)?;
+            let entry = fat_dir::find_entry(volume, *dir_cluster, &path.name, device)?;
+            Ok(entry.map(ReadDirEntry::from_fat))
+        }
+        ReadDirectory::Iso(directory) => {
+            let volume = iso9660::IsoVolume::mount(device)?;
+            let entry = iso9660::find_entry(&volume, directory, &path.name, device)?;
+            Ok(entry.map(ReadDirEntry::from_iso))
+        }
+    }
+}
+
+pub(crate) fn find_matching_read_entry(
+    state: &OsState,
+    drive_index: u8,
+    directory: &ReadDirectory,
+    pattern: &[u8; 11],
+    attr_mask: u8,
+    start_index: u16,
+    device: &mut dyn DriveIo,
+) -> Result<Option<(ReadDirEntry, u16)>, u16> {
+    match directory {
+        ReadDirectory::Fat(dir_cluster) => {
+            let volume = state.fat_volumes[drive_index as usize]
+                .as_ref()
+                .ok_or(0x000Fu16)?;
+            let entry = fat_dir::find_matching(
+                volume,
+                *dir_cluster,
+                pattern,
+                attr_mask,
+                start_index,
+                device,
+            )?;
+            Ok(entry.map(|(entry, next_index)| (ReadDirEntry::from_fat(entry), next_index)))
+        }
+        ReadDirectory::Iso(directory) => {
+            let volume = iso9660::IsoVolume::mount(device)?;
+            let entry = iso9660::find_matching(
+                &volume,
+                directory,
+                pattern,
+                attr_mask,
+                start_index,
+                device,
+            )?;
+            Ok(entry.map(|(entry, next_index)| (ReadDirEntry::from_iso(entry), next_index)))
+        }
+    }
+}
+
+pub(crate) fn read_entry_all(
+    state: &OsState,
+    drive_index: u8,
+    entry: &ReadDirEntry,
+    device: &mut dyn DriveIo,
+) -> Result<Vec<u8>, u16> {
+    match &entry.source {
+        ReadDirEntrySource::Fat(entry) => {
+            let volume = state.fat_volumes[drive_index as usize]
+                .as_ref()
+                .ok_or(0x000Fu16)?;
+            fat_file::read_all(volume, entry, device)
+        }
+        ReadDirEntrySource::Iso(entry) => iso9660::read_all(entry, device),
+    }
+}
 
 /// Returns true if the byte is a DBCS (Shift-JIS) lead byte.
 pub(crate) fn is_dbcs_lead_byte(b: u8) -> bool {

--- a/crates/os/src/filesystem.rs
+++ b/crates/os/src/filesystem.rs
@@ -3,6 +3,7 @@
 pub mod fat;
 pub(crate) mod fat_bpb;
 pub(crate) mod fat_dir;
+pub(crate) mod fat_file;
 pub(crate) mod fat_partition;
 pub(crate) mod virtual_drive;
 

--- a/crates/os/src/filesystem/fat.rs
+++ b/crates/os/src/filesystem/fat.rs
@@ -228,14 +228,4 @@ impl FatVolume {
         self.fat_dirty = false;
         Ok(())
     }
-
-    /// Walks the cluster chain from `start` and returns the cluster at position
-    /// `index` in the chain (0 = start itself). Returns None if chain is shorter.
-    pub fn cluster_at_index(&self, start: u16, index: u32) -> Option<u16> {
-        let mut current = start;
-        for _ in 0..index {
-            current = self.next_cluster(current)?;
-        }
-        Some(current)
-    }
 }

--- a/crates/os/src/filesystem/fat.rs
+++ b/crates/os/src/filesystem/fat.rs
@@ -159,6 +159,29 @@ impl FatVolume {
         self.sector_ratio
     }
 
+    pub fn bytes_per_sector(&self) -> u16 {
+        self.bpb.bytes_per_sector
+    }
+
+    pub fn sectors_per_cluster(&self) -> u16 {
+        self.bpb.sectors_per_cluster as u16
+    }
+
+    pub fn total_cluster_count(&self) -> u16 {
+        self.data_cluster_count.min(u16::MAX as u32) as u16
+    }
+
+    pub fn free_cluster_count(&self) -> u16 {
+        let mut free_clusters = 0u16;
+        let max_cluster = self.total_cluster_count().saturating_add(2);
+        for cluster in 2..max_cluster {
+            if self.read_fat_entry(cluster) == 0 {
+                free_clusters = free_clusters.saturating_add(1);
+            }
+        }
+        free_clusters
+    }
+
     /// Converts a cluster number to an absolute physical LBA.
     pub fn cluster_to_lba(&self, cluster: u16) -> u32 {
         self.partition_offset

--- a/crates/os/src/filesystem/fat_file.rs
+++ b/crates/os/src/filesystem/fat_file.rs
@@ -1,6 +1,9 @@
 use crate::{
     DiskIo,
-    filesystem::{fat::FatVolume, fat_dir::DirEntry},
+    filesystem::{
+        fat::FatVolume,
+        fat_dir::{self, DirEntry},
+    },
 };
 
 pub(crate) struct FatFileCursor {
@@ -212,6 +215,60 @@ pub(crate) fn read_all(
 
     let mut cursor = FatFileCursor::new(entry);
     cursor.read_chunk(vol, disk, entry.file_size as usize)
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct FileCreateOptions {
+    pub(crate) attributes: u8,
+    pub(crate) time: u16,
+    pub(crate) date: u16,
+}
+
+pub(crate) fn create_or_replace_file(
+    vol: &mut FatVolume,
+    dir_cluster: u16,
+    fcb_name: &[u8; 11],
+    data: &[u8],
+    options: FileCreateOptions,
+    disk: &mut dyn DiskIo,
+) -> Result<(), u16> {
+    if let Some(existing) = fat_dir::find_entry(vol, dir_cluster, fcb_name, disk)? {
+        if existing.attribute & fat_dir::ATTR_DIRECTORY != 0 {
+            return Err(0x0005);
+        }
+        if existing.start_cluster >= 2 {
+            vol.free_chain(existing.start_cluster);
+        }
+        fat_dir::delete_entry(vol, &existing, disk)?;
+    }
+
+    let mut writer = FatFileWriter::new(0, 0);
+    if let Err(error) = writer.write_chunk(vol, disk, data) {
+        if writer.start_cluster() >= 2 {
+            vol.free_chain(writer.start_cluster());
+        }
+        return Err(error);
+    }
+
+    let new_entry = DirEntry {
+        name: *fcb_name,
+        attribute: options.attributes,
+        time: options.time,
+        date: options.date,
+        start_cluster: writer.start_cluster(),
+        file_size: writer.position(),
+        dir_sector: 0,
+        dir_offset: 0,
+    };
+
+    if let Err(error) = fat_dir::create_entry(vol, dir_cluster, &new_entry, disk) {
+        if writer.start_cluster() >= 2 {
+            vol.free_chain(writer.start_cluster());
+        }
+        return Err(error);
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/os/src/filesystem/fat_file.rs
+++ b/crates/os/src/filesystem/fat_file.rs
@@ -1,0 +1,566 @@
+use crate::{
+    DiskIo,
+    filesystem::{fat::FatVolume, fat_dir::DirEntry},
+};
+
+pub(crate) struct FatFileCursor {
+    start_cluster: u16,
+    file_size: u32,
+    position: u32,
+    cached_cluster_index: u32,
+    cached_cluster: u16,
+}
+
+impl FatFileCursor {
+    pub(crate) fn new(entry: &DirEntry) -> Self {
+        Self::with_position(entry.start_cluster, entry.file_size, 0)
+    }
+
+    pub(crate) fn with_position(start_cluster: u16, file_size: u32, position: u32) -> Self {
+        Self {
+            start_cluster,
+            file_size,
+            position,
+            cached_cluster_index: 0,
+            cached_cluster: 0,
+        }
+    }
+
+    pub(crate) fn position(&self) -> u32 {
+        self.position
+    }
+
+    pub(crate) fn remaining(&self) -> u32 {
+        self.file_size.saturating_sub(self.position)
+    }
+
+    pub(crate) fn read_chunk(
+        &mut self,
+        vol: &FatVolume,
+        disk: &mut dyn DiskIo,
+        max_bytes: usize,
+    ) -> Result<Vec<u8>, u16> {
+        if self.position >= self.file_size || max_bytes == 0 {
+            return Ok(Vec::new());
+        }
+        if self.start_cluster < 2 {
+            return Err(0x001F);
+        }
+
+        let cluster_size = vol.bpb.cluster_size();
+        let bytes_to_read = (max_bytes as u32).min(self.remaining());
+        let mut result = Vec::with_capacity(bytes_to_read as usize);
+
+        while result.len() < bytes_to_read as usize {
+            let cluster_index = self.position / cluster_size;
+            let offset_in_cluster = self.position % cluster_size;
+            let cluster = self.cluster_for_index(vol, cluster_index)?;
+            let cluster_data = vol.read_cluster(cluster, disk)?;
+
+            let available = (cluster_size - offset_in_cluster)
+                .min(bytes_to_read - result.len() as u32) as usize;
+            let start = offset_in_cluster as usize;
+            let end = start + available;
+            result.extend_from_slice(&cluster_data[start..end]);
+            self.position += available as u32;
+        }
+
+        Ok(result)
+    }
+
+    fn cluster_for_index(&mut self, vol: &FatVolume, target_index: u32) -> Result<u16, u16> {
+        if self.start_cluster < 2 {
+            return Err(0x001F);
+        }
+        if target_index == 0 {
+            self.cached_cluster_index = 0;
+            self.cached_cluster = self.start_cluster;
+            return Ok(self.start_cluster);
+        }
+
+        let (mut current_index, mut current_cluster) =
+            if self.cached_cluster >= 2 && target_index >= self.cached_cluster_index {
+                (self.cached_cluster_index, self.cached_cluster)
+            } else {
+                (0, self.start_cluster)
+            };
+
+        while current_index < target_index {
+            current_cluster = vol.next_cluster(current_cluster).ok_or(0x001Fu16)?;
+            current_index += 1;
+        }
+
+        self.cached_cluster_index = current_index;
+        self.cached_cluster = current_cluster;
+        Ok(current_cluster)
+    }
+}
+
+pub(crate) struct FatFileWriter {
+    start_cluster: u16,
+    position: u32,
+    cached_cluster_index: u32,
+    cached_cluster: u16,
+}
+
+impl FatFileWriter {
+    pub(crate) fn new(start_cluster: u16, position: u32) -> Self {
+        Self {
+            start_cluster,
+            position,
+            cached_cluster_index: 0,
+            cached_cluster: 0,
+        }
+    }
+
+    pub(crate) fn start_cluster(&self) -> u16 {
+        self.start_cluster
+    }
+
+    pub(crate) fn position(&self) -> u32 {
+        self.position
+    }
+
+    pub(crate) fn write_chunk(
+        &mut self,
+        vol: &mut FatVolume,
+        disk: &mut dyn DiskIo,
+        data: &[u8],
+    ) -> Result<(), u16> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let cluster_size = vol.bpb.cluster_size() as usize;
+        let mut offset = 0usize;
+        while offset < data.len() {
+            let cluster_index = self.position / cluster_size as u32;
+            let offset_in_cluster = (self.position % cluster_size as u32) as usize;
+            let cluster = self.cluster_for_index(vol, disk, cluster_index)?;
+            let bytes_to_write = (cluster_size - offset_in_cluster).min(data.len() - offset);
+
+            if offset_in_cluster == 0 && bytes_to_write == cluster_size {
+                vol.write_cluster(cluster, &data[offset..offset + bytes_to_write], disk)?;
+            } else {
+                let mut cluster_data = vol.read_cluster(cluster, disk)?;
+                cluster_data[offset_in_cluster..offset_in_cluster + bytes_to_write]
+                    .copy_from_slice(&data[offset..offset + bytes_to_write]);
+                vol.write_cluster(cluster, &cluster_data, disk)?;
+            }
+
+            self.position += bytes_to_write as u32;
+            offset += bytes_to_write;
+        }
+
+        Ok(())
+    }
+
+    fn cluster_for_index(
+        &mut self,
+        vol: &mut FatVolume,
+        disk: &mut dyn DiskIo,
+        target_index: u32,
+    ) -> Result<u16, u16> {
+        if self.start_cluster < 2 {
+            let first_cluster = vol.allocate_cluster(0).ok_or(0x001Fu16)?;
+            zero_cluster(vol, disk, first_cluster)?;
+            self.start_cluster = first_cluster;
+            self.cached_cluster_index = 0;
+            self.cached_cluster = first_cluster;
+            if target_index == 0 {
+                return Ok(first_cluster);
+            }
+        }
+
+        let (mut current_index, mut current_cluster) =
+            if self.cached_cluster >= 2 && target_index >= self.cached_cluster_index {
+                (self.cached_cluster_index, self.cached_cluster)
+            } else {
+                (0, self.start_cluster)
+            };
+
+        while current_index < target_index {
+            if let Some(next_cluster) = vol.next_cluster(current_cluster) {
+                current_cluster = next_cluster;
+            } else {
+                let new_cluster = vol.allocate_cluster(current_cluster).ok_or(0x001Fu16)?;
+                zero_cluster(vol, disk, new_cluster)?;
+                current_cluster = new_cluster;
+            }
+            current_index += 1;
+        }
+
+        self.cached_cluster_index = current_index;
+        self.cached_cluster = current_cluster;
+        Ok(current_cluster)
+    }
+}
+
+fn zero_cluster(vol: &FatVolume, disk: &mut dyn DiskIo, cluster: u16) -> Result<(), u16> {
+    let zeros = vec![0u8; vol.bpb.cluster_size() as usize];
+    vol.write_cluster(cluster, &zeros, disk)
+}
+
+pub(crate) fn read_all(
+    vol: &FatVolume,
+    entry: &DirEntry,
+    disk: &mut dyn DiskIo,
+) -> Result<Vec<u8>, u16> {
+    if entry.file_size == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut cursor = FatFileCursor::new(entry);
+    cursor.read_chunk(vol, disk, entry.file_size as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::filesystem::fat::FatVolume;
+
+    struct MockDisk {
+        drive_da: u8,
+        sector_size: u16,
+        sectors_per_track: u8,
+        heads: u8,
+        data: Vec<u8>,
+    }
+
+    impl MockDisk {
+        fn new(
+            drive_da: u8,
+            sector_size: u16,
+            sectors_per_track: u8,
+            heads: u8,
+            total_sectors: u32,
+        ) -> Self {
+            Self {
+                drive_da,
+                sector_size,
+                sectors_per_track,
+                heads,
+                data: vec![0u8; total_sectors as usize * sector_size as usize],
+            }
+        }
+
+        fn write_sector(&mut self, lba: u32, sector: &[u8]) {
+            let offset = lba as usize * self.sector_size as usize;
+            self.data[offset..offset + self.sector_size as usize].copy_from_slice(sector);
+        }
+    }
+
+    impl DiskIo for MockDisk {
+        fn read_sectors(&mut self, drive_da: u8, lba: u32, count: u32) -> Result<Vec<u8>, u8> {
+            if drive_da != self.drive_da {
+                return Err(0x02);
+            }
+            let start = lba as usize * self.sector_size as usize;
+            let end = start + count as usize * self.sector_size as usize;
+            self.data.get(start..end).map(|s| s.to_vec()).ok_or(0x10)
+        }
+
+        fn write_sectors(&mut self, drive_da: u8, lba: u32, data: &[u8]) -> Result<(), u8> {
+            if drive_da != self.drive_da {
+                return Err(0x02);
+            }
+            let start = lba as usize * self.sector_size as usize;
+            let end = start + data.len();
+            let Some(slice) = self.data.get_mut(start..end) else {
+                return Err(0x10);
+            };
+            slice.copy_from_slice(data);
+            Ok(())
+        }
+
+        fn sector_size(&self, drive_da: u8) -> Option<u16> {
+            (drive_da == self.drive_da).then_some(self.sector_size)
+        }
+
+        fn total_sectors(&self, drive_da: u8) -> Option<u32> {
+            (drive_da == self.drive_da).then_some(self.data.len() as u32 / self.sector_size as u32)
+        }
+
+        fn drive_geometry(&self, drive_da: u8) -> Option<(u16, u8, u8)> {
+            (drive_da == self.drive_da).then_some((
+                self.total_sectors(drive_da)? as u16
+                    / self.heads as u16
+                    / self.sectors_per_track as u16,
+                self.heads,
+                self.sectors_per_track,
+            ))
+        }
+    }
+
+    fn set_fat12_entry(fat: &mut [u8], cluster: u16, value: u16) {
+        let offset = (cluster as usize * 3) / 2;
+        if cluster & 1 == 0 {
+            fat[offset] = (value & 0x00FF) as u8;
+            fat[offset + 1] = (fat[offset + 1] & 0xF0) | ((value >> 8) as u8 & 0x0F);
+        } else {
+            fat[offset] = (fat[offset] & 0x0F) | (((value << 4) as u8) & 0xF0);
+            fat[offset + 1] = (value >> 4) as u8;
+        }
+    }
+
+    fn mount_fat12_disk(
+        start_cluster: u16,
+        file_size: u32,
+    ) -> (MockDisk, FatVolume, DirEntry, Vec<u8>) {
+        let drive_da = 0x90;
+        let sector_size = 1024u16;
+        let reserved = 1u16;
+        let sectors_per_fat = 2u16;
+        let root_entries = 16u16;
+        let root_dir_sectors = 1u32;
+        let data_clusters = 1221u32;
+        let total_sectors =
+            reserved as u32 + sectors_per_fat as u32 + root_dir_sectors + data_clusters;
+        let mut disk = MockDisk::new(drive_da, sector_size, 8, 2, total_sectors);
+
+        let mut boot = vec![0u8; sector_size as usize];
+        boot[11..13].copy_from_slice(&sector_size.to_le_bytes());
+        boot[13] = 1;
+        boot[14..16].copy_from_slice(&reserved.to_le_bytes());
+        boot[16] = 1;
+        boot[17..19].copy_from_slice(&root_entries.to_le_bytes());
+        boot[19..21].copy_from_slice(&(total_sectors as u16).to_le_bytes());
+        boot[22..24].copy_from_slice(&sectors_per_fat.to_le_bytes());
+        disk.write_sector(0, &boot);
+
+        let mut fat = vec![0u8; sectors_per_fat as usize * sector_size as usize];
+        fat[0] = 0xFE;
+        fat[1] = 0xFF;
+        fat[2] = 0xFF;
+        set_fat12_entry(&mut fat, start_cluster, start_cluster + 1);
+        set_fat12_entry(&mut fat, start_cluster + 1, start_cluster + 2);
+        set_fat12_entry(&mut fat, start_cluster + 2, 0x0FFF);
+        for sector_index in 0..sectors_per_fat as u32 {
+            let offset = sector_index as usize * sector_size as usize;
+            disk.write_sector(
+                1 + sector_index,
+                &fat[offset..offset + sector_size as usize],
+            );
+        }
+
+        let mut root = vec![0u8; sector_size as usize];
+        root[0..11].copy_from_slice(b"BIGFILE BIN");
+        root[26..28].copy_from_slice(&start_cluster.to_le_bytes());
+        root[28..32].copy_from_slice(&file_size.to_le_bytes());
+        disk.write_sector(3, &root);
+
+        let payload: Vec<u8> = (0..file_size).map(|index| (index & 0xFF) as u8).collect();
+        for cluster_offset in 0..3u32 {
+            let lba = 4 + (start_cluster as u32 - 2) + cluster_offset;
+            let start = cluster_offset as usize * sector_size as usize;
+            let end = (start + sector_size as usize).min(payload.len());
+            let mut cluster = vec![0u8; sector_size as usize];
+            cluster[..end - start].copy_from_slice(&payload[start..end]);
+            disk.write_sector(lba, &cluster);
+        }
+
+        let mut mount_disk = MockDisk {
+            drive_da: disk.drive_da,
+            sector_size: disk.sector_size,
+            sectors_per_track: disk.sectors_per_track,
+            heads: disk.heads,
+            data: disk.data.clone(),
+        };
+        let volume = FatVolume::mount(drive_da, 0, &mut mount_disk).expect("mount FAT12");
+        let entry = DirEntry {
+            name: *b"BIGFILE BIN",
+            attribute: 0x20,
+            time: 0,
+            date: 0,
+            start_cluster,
+            file_size,
+            dir_sector: 3,
+            dir_offset: 0,
+        };
+        (disk, volume, entry, payload)
+    }
+
+    fn mount_fat16_disk(
+        start_cluster: u16,
+        file_size: u32,
+    ) -> (MockDisk, FatVolume, DirEntry, Vec<u8>) {
+        let drive_da = 0x80;
+        let sector_size = 512u16;
+        let reserved = 1u16;
+        let sectors_per_fat = 32u16;
+        let root_entries = 16u16;
+        let root_dir_sectors = 1u32;
+        let data_clusters = 5000u32;
+        let total_sectors =
+            reserved as u32 + sectors_per_fat as u32 + root_dir_sectors + data_clusters;
+        let mut disk = MockDisk::new(drive_da, sector_size, 17, 4, total_sectors);
+
+        let mut boot = vec![0u8; sector_size as usize];
+        boot[11..13].copy_from_slice(&sector_size.to_le_bytes());
+        boot[13] = 1;
+        boot[14..16].copy_from_slice(&reserved.to_le_bytes());
+        boot[16] = 1;
+        boot[17..19].copy_from_slice(&root_entries.to_le_bytes());
+        boot[19..21].copy_from_slice(&(total_sectors as u16).to_le_bytes());
+        boot[22..24].copy_from_slice(&sectors_per_fat.to_le_bytes());
+        disk.write_sector(0, &boot);
+
+        let mut fat = vec![0u8; sectors_per_fat as usize * sector_size as usize];
+        fat[0] = 0xF8;
+        fat[1] = 0xFF;
+        fat[2] = 0xFF;
+        fat[3] = 0xFF;
+        let first_offset = start_cluster as usize * 2;
+        fat[first_offset..first_offset + 2].copy_from_slice(&(start_cluster + 1).to_le_bytes());
+        fat[first_offset + 2..first_offset + 4].copy_from_slice(&(start_cluster + 2).to_le_bytes());
+        fat[first_offset + 4..first_offset + 6].copy_from_slice(&0xFFFFu16.to_le_bytes());
+        for sector_index in 0..sectors_per_fat as u32 {
+            let offset = sector_index as usize * sector_size as usize;
+            disk.write_sector(
+                1 + sector_index,
+                &fat[offset..offset + sector_size as usize],
+            );
+        }
+
+        let mut root = vec![0u8; sector_size as usize];
+        root[0..11].copy_from_slice(b"BIGFILE BIN");
+        root[26..28].copy_from_slice(&start_cluster.to_le_bytes());
+        root[28..32].copy_from_slice(&file_size.to_le_bytes());
+        disk.write_sector(33, &root);
+
+        let payload: Vec<u8> = (0..file_size)
+            .map(|index| 255 - ((index & 0xFF) as u8))
+            .collect();
+        for cluster_offset in 0..3u32 {
+            let lba = 34 + (start_cluster as u32 - 2) + cluster_offset;
+            let start = cluster_offset as usize * sector_size as usize;
+            let end = (start + sector_size as usize).min(payload.len());
+            let mut cluster = vec![0u8; sector_size as usize];
+            cluster[..end - start].copy_from_slice(&payload[start..end]);
+            disk.write_sector(lba, &cluster);
+        }
+
+        let mut mount_disk = MockDisk {
+            drive_da: disk.drive_da,
+            sector_size: disk.sector_size,
+            sectors_per_track: disk.sectors_per_track,
+            heads: disk.heads,
+            data: disk.data.clone(),
+        };
+        let volume = FatVolume::mount(drive_da, 0, &mut mount_disk).expect("mount FAT16");
+        let entry = DirEntry {
+            name: *b"BIGFILE BIN",
+            attribute: 0x20,
+            time: 0,
+            date: 0,
+            start_cluster,
+            file_size,
+            dir_sector: 33,
+            dir_offset: 0,
+        };
+        (disk, volume, entry, payload)
+    }
+
+    #[test]
+    fn fat12_cursor_reads_across_cluster_boundary_at_high_cluster_numbers() {
+        let (mut disk, volume, entry, payload) = mount_fat12_disk(682, 2500);
+        let mut cursor = FatFileCursor::new(&entry);
+        let mut combined = Vec::new();
+        combined.extend_from_slice(&cursor.read_chunk(&volume, &mut disk, 700).unwrap());
+        combined.extend_from_slice(&cursor.read_chunk(&volume, &mut disk, 900).unwrap());
+        combined.extend_from_slice(&cursor.read_chunk(&volume, &mut disk, 2000).unwrap());
+        assert_eq!(combined, payload);
+        assert!(
+            cursor
+                .read_chunk(&volume, &mut disk, 16)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn fat16_cursor_reads_across_cluster_boundary_at_high_cluster_numbers() {
+        let (mut disk, volume, entry, payload) = mount_fat16_disk(4094, 1400);
+        let mut cursor = FatFileCursor::new(&entry);
+        let mut combined = Vec::new();
+        combined.extend_from_slice(&cursor.read_chunk(&volume, &mut disk, 300).unwrap());
+        combined.extend_from_slice(&cursor.read_chunk(&volume, &mut disk, 700).unwrap());
+        combined.extend_from_slice(&cursor.read_chunk(&volume, &mut disk, 700).unwrap());
+        assert_eq!(combined, payload);
+    }
+
+    #[test]
+    fn read_all_returns_complete_file_contents() {
+        let (mut disk, volume, entry, payload) = mount_fat12_disk(682, 2500);
+        assert_eq!(read_all(&volume, &entry, &mut disk).unwrap(), payload);
+    }
+
+    #[test]
+    fn fat12_writer_overwrites_across_cluster_boundary_at_high_cluster_numbers() {
+        let (mut disk, mut volume, entry, _) = mount_fat12_disk(682, 2500);
+        let payload = (0..2500)
+            .map(|index| 255 - (index % 251) as u8)
+            .collect::<Vec<_>>();
+
+        let mut writer = FatFileWriter::new(entry.start_cluster, 0);
+        writer
+            .write_chunk(&mut volume, &mut disk, &payload)
+            .unwrap();
+
+        let updated_entry = DirEntry {
+            file_size: payload.len() as u32,
+            ..entry
+        };
+        assert_eq!(
+            read_all(&volume, &updated_entry, &mut disk).unwrap(),
+            payload
+        );
+    }
+
+    #[test]
+    fn fat16_writer_overwrites_across_cluster_boundary_at_high_cluster_numbers() {
+        let (mut disk, mut volume, entry, _) = mount_fat16_disk(4094, 1400);
+        let payload = (0..1400)
+            .map(|index| ((index * 3) % 253) as u8)
+            .collect::<Vec<_>>();
+
+        let mut writer = FatFileWriter::new(entry.start_cluster, 0);
+        writer
+            .write_chunk(&mut volume, &mut disk, &payload)
+            .unwrap();
+
+        let updated_entry = DirEntry {
+            file_size: payload.len() as u32,
+            ..entry
+        };
+        assert_eq!(
+            read_all(&volume, &updated_entry, &mut disk).unwrap(),
+            payload
+        );
+    }
+
+    #[test]
+    fn fat16_writer_appends_past_end_of_chain() {
+        let cluster_size = 512usize;
+        let original_size = cluster_size * 2;
+        let (mut disk, mut volume, entry, original_payload) =
+            mount_fat16_disk(4094, original_size as u32);
+        let suffix = b"tail-data".to_vec();
+
+        let mut writer = FatFileWriter::new(entry.start_cluster, original_payload.len() as u32);
+        writer.write_chunk(&mut volume, &mut disk, &suffix).unwrap();
+
+        let mut expected = original_payload;
+        expected.extend_from_slice(&suffix);
+
+        let updated_entry = DirEntry {
+            start_cluster: writer.start_cluster(),
+            file_size: writer.position(),
+            ..entry
+        };
+        assert_eq!(
+            read_all(&volume, &updated_entry, &mut disk).unwrap(),
+            expected
+        );
+    }
+}

--- a/crates/os/src/filesystem/iso9660.rs
+++ b/crates/os/src/filesystem/iso9660.rs
@@ -1,0 +1,270 @@
+use crate::{CdromIo, filesystem::fat_dir};
+
+const ISO_SECTOR_SIZE: usize = 2048;
+const PVD_LBA: u32 = 16;
+const PVD_ROOT_RECORD_OFFSET: usize = 156;
+
+#[derive(Debug, Clone)]
+pub(crate) struct IsoVolume {
+    pub volume_label: Vec<u8>,
+    pub root_directory: IsoDirectory,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct IsoDirectory {
+    pub start_lba: u32,
+    pub data_length: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct IsoDirEntry {
+    pub name: [u8; 11],
+    pub attribute: u8,
+    pub time: u16,
+    pub date: u16,
+    pub start_lba: u32,
+    pub file_size: u32,
+    pub directory: Option<IsoDirectory>,
+}
+
+impl IsoVolume {
+    pub(crate) fn mount(cdrom: &dyn CdromIo) -> Result<Self, u16> {
+        if !cdrom.cdrom_media_loaded() {
+            return Err(0x0015);
+        }
+
+        let mut sector = [0u8; ISO_SECTOR_SIZE];
+        let count = cdrom
+            .read_sector_cooked(PVD_LBA, &mut sector)
+            .ok_or(0x001Fu16)?;
+        if count < ISO_SECTOR_SIZE || sector[0] != 1 || &sector[1..6] != b"CD001" || sector[6] != 1
+        {
+            return Err(0x001F);
+        }
+
+        let volume_label = trim_trailing_spaces(&sector[40..72]).to_vec();
+        let root_directory = parse_directory_record(&sector[PVD_ROOT_RECORD_OFFSET..])
+            .ok_or(0x001Fu16)?
+            .directory
+            .ok_or(0x001Fu16)?;
+
+        Ok(Self {
+            volume_label,
+            root_directory,
+        })
+    }
+}
+
+pub(crate) fn find_entry(
+    volume: &IsoVolume,
+    directory: &IsoDirectory,
+    name: &[u8; 11],
+    cdrom: &dyn CdromIo,
+) -> Result<Option<IsoDirEntry>, u16> {
+    for_each_entry(volume, directory, cdrom, |entry| {
+        if entry.name == *name {
+            return IterAction::Return(entry);
+        }
+        IterAction::Continue
+    })
+}
+
+pub(crate) fn find_matching(
+    volume: &IsoVolume,
+    directory: &IsoDirectory,
+    pattern: &[u8; 11],
+    attr_mask: u8,
+    start_index: u16,
+    cdrom: &dyn CdromIo,
+) -> Result<Option<(IsoDirEntry, u16)>, u16> {
+    let mut current_index = 0u16;
+    let result = for_each_entry(volume, directory, cdrom, |entry| {
+        if current_index < start_index {
+            current_index += 1;
+            return IterAction::Continue;
+        }
+        current_index += 1;
+
+        if entry.attribute & fat_dir::ATTR_HIDDEN != 0 && attr_mask & fat_dir::ATTR_HIDDEN == 0 {
+            return IterAction::Continue;
+        }
+        if entry.attribute & fat_dir::ATTR_SYSTEM != 0 && attr_mask & fat_dir::ATTR_SYSTEM == 0 {
+            return IterAction::Continue;
+        }
+
+        if fat_dir::matches_pattern(&entry.name, pattern) {
+            return IterAction::Return(entry);
+        }
+        IterAction::Continue
+    })?;
+
+    Ok(result.map(|entry| (entry, current_index)))
+}
+
+pub(crate) fn read_file_chunk(
+    entry: &IsoDirEntry,
+    position: u32,
+    max_bytes: usize,
+    cdrom: &dyn CdromIo,
+) -> Result<Vec<u8>, u16> {
+    if position >= entry.file_size || max_bytes == 0 {
+        return Ok(Vec::new());
+    }
+
+    let bytes_to_read = (max_bytes as u32).min(entry.file_size - position) as usize;
+    let start_lba = entry.start_lba + position / ISO_SECTOR_SIZE as u32;
+    let end_position = position as usize + bytes_to_read;
+    let end_lba = entry.start_lba + end_position.div_ceil(ISO_SECTOR_SIZE) as u32;
+    let mut result = Vec::with_capacity((end_lba - start_lba) as usize * ISO_SECTOR_SIZE);
+
+    for lba in start_lba..end_lba {
+        let mut sector = [0u8; ISO_SECTOR_SIZE];
+        let count = cdrom
+            .read_sector_cooked(lba, &mut sector)
+            .ok_or(0x001Fu16)?;
+        result.extend_from_slice(&sector[..count.min(ISO_SECTOR_SIZE)]);
+    }
+
+    let offset = position as usize % ISO_SECTOR_SIZE;
+    let end = offset + bytes_to_read;
+    Ok(result[offset..end].to_vec())
+}
+
+pub(crate) fn read_all(entry: &IsoDirEntry, cdrom: &dyn CdromIo) -> Result<Vec<u8>, u16> {
+    read_file_chunk(entry, 0, entry.file_size as usize, cdrom)
+}
+
+enum IterAction {
+    Continue,
+    Return(IsoDirEntry),
+}
+
+fn for_each_entry(
+    _volume: &IsoVolume,
+    directory: &IsoDirectory,
+    cdrom: &dyn CdromIo,
+    mut callback: impl FnMut(IsoDirEntry) -> IterAction,
+) -> Result<Option<IsoDirEntry>, u16> {
+    if !cdrom.cdrom_media_loaded() {
+        return Err(0x0015);
+    }
+
+    let sector_count = directory.data_length.div_ceil(ISO_SECTOR_SIZE as u32);
+    for sector_index in 0..sector_count {
+        let mut sector = [0u8; ISO_SECTOR_SIZE];
+        let count = cdrom
+            .read_sector_cooked(directory.start_lba + sector_index, &mut sector)
+            .ok_or(0x001Fu16)?;
+        let limit = count.min(ISO_SECTOR_SIZE);
+        let mut offset = 0usize;
+
+        while offset < limit {
+            let record_len = sector[offset] as usize;
+            if record_len == 0 {
+                break;
+            }
+
+            if offset + record_len > limit {
+                return Err(0x001F);
+            }
+
+            if let Some(entry) = parse_directory_record(&sector[offset..offset + record_len])
+                && !is_self_or_parent(&entry)
+            {
+                match callback(entry) {
+                    IterAction::Continue => {}
+                    IterAction::Return(entry) => return Ok(Some(entry)),
+                }
+            }
+
+            offset += record_len;
+        }
+    }
+
+    Ok(None)
+}
+
+fn parse_directory_record(record: &[u8]) -> Option<IsoDirEntry> {
+    if record.len() < 34 {
+        return None;
+    }
+
+    let name_length = record[32] as usize;
+    if record.len() < 33 + name_length {
+        return None;
+    }
+
+    let start_lba = u32::from_le_bytes(record[2..6].try_into().ok()?);
+    let file_size = u32::from_le_bytes(record[10..14].try_into().ok()?);
+    let flags = record[25];
+    let is_directory = flags & 0x02 != 0;
+    let identifier = &record[33..33 + name_length];
+    let display_name = iso_identifier_to_name(identifier, is_directory)?;
+    let attribute = if is_directory {
+        fat_dir::ATTR_DIRECTORY
+    } else {
+        fat_dir::ATTR_READ_ONLY
+    };
+    let (time, date) = iso_datetime_to_dos(&record[18..25]);
+
+    Some(IsoDirEntry {
+        name: fat_dir::name_to_fcb(&display_name),
+        attribute,
+        time,
+        date,
+        start_lba,
+        file_size,
+        directory: is_directory.then_some(IsoDirectory {
+            start_lba,
+            data_length: file_size,
+        }),
+    })
+}
+
+fn iso_identifier_to_name(identifier: &[u8], is_directory: bool) -> Option<Vec<u8>> {
+    match identifier {
+        [0] => Some(b".".to_vec()),
+        [1] => Some(b"..".to_vec()),
+        _ => {
+            let mut name = identifier.to_vec();
+            if !is_directory
+                && let Some(version_separator) = name.iter().position(|&byte| byte == b';')
+            {
+                name.truncate(version_separator);
+            }
+            while name.last() == Some(&b'.') {
+                name.pop();
+            }
+            Some(name)
+        }
+    }
+}
+
+fn iso_datetime_to_dos(recording_time: &[u8]) -> (u16, u16) {
+    if recording_time.len() < 7 {
+        return (0, 0);
+    }
+
+    let year = 1900u16.saturating_add(recording_time[0] as u16);
+    let month = recording_time[1].clamp(1, 12) as u16;
+    let day = recording_time[2].clamp(1, 31) as u16;
+    let hour = recording_time[3].min(23) as u16;
+    let minute = recording_time[4].min(59) as u16;
+    let second = recording_time[5].min(59) as u16;
+
+    let dos_date = year.saturating_sub(1980).saturating_mul(512) | (month << 5) | day;
+    let dos_time = (hour << 11) | (minute << 5) | (second / 2);
+    (dos_time, dos_date)
+}
+
+fn trim_trailing_spaces(bytes: &[u8]) -> &[u8] {
+    let mut end = bytes.len();
+    while end > 0 && bytes[end - 1] == b' ' {
+        end -= 1;
+    }
+    &bytes[..end]
+}
+
+fn is_self_or_parent(entry: &IsoDirEntry) -> bool {
+    entry.name == *b".          " || entry.name == *b"..         "
+}

--- a/crates/os/src/lib.rs
+++ b/crates/os/src/lib.rs
@@ -24,7 +24,7 @@ pub mod tables;
 
 pub use common::{
     AudioChannelInfo, CdAudioState, CdAudioStatus, CdromIo, CdromTrackInfo, CdromTrackType,
-    ConsoleIo, CpuAccess, DiskIo, MemoryAccess, OsBootStage, Tracing,
+    ConsoleIo, CpuAccess, DiskIo, DriveIo, MemoryAccess, OsBootStage, Tracing,
 };
 
 /// Information about a discovered drive for CDS/DPB/DAUA population.
@@ -86,6 +86,10 @@ pub(crate) struct OsState {
     pub(crate) sft2_count: u16,
     /// Pending buffered input state for INT 21h AH=0Ah.
     pub(crate) buffered_input: Option<BufferedInputState>,
+    /// Active ISO-backed SFT entries, indexed by SFT slot.
+    pub(crate) open_iso_files: Vec<Option<filesystem::iso9660::IsoDirEntry>>,
+    /// Active directory for FINDFIRST/FINDNEXT on non-FAT media.
+    pub(crate) read_find_directory: Option<filesystem::ReadDirectory>,
     /// Function key escape code storage for INT DCh CL=0x0C/0x0D (786 bytes).
     pub(crate) fn_key_map: Vec<u8>,
     /// Pending bytes from function key / arrow key expansion. When an extended
@@ -320,6 +324,8 @@ impl NeetanOs {
                 mscdex: cdrom::MscdexState::new(),
                 sft2_count: 15,
                 buffered_input: None,
+                open_iso_files: vec![None; tables::SFT_TOTAL_COUNT as usize],
+                read_find_directory: None,
                 fn_key_map: build_default_fn_key_map(),
                 pending_key_bytes: std::collections::VecDeque::new(),
                 interim_console_flag: 0,
@@ -574,7 +580,7 @@ impl NeetanOs {
         &mut self,
         cpu: &mut dyn CpuAccess,
         memory: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) {
         let mut shell = self.shell.take().expect("shell not initialized");
         {
@@ -611,7 +617,7 @@ impl NeetanOs {
         &mut self,
         cpu: &mut dyn CpuAccess,
         mem: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
         path: &[u8],
         args: &[u8],
     ) -> Result<(), u16> {
@@ -1496,6 +1502,32 @@ impl OsState {
         Ok(())
     }
 
+    fn drive_has_cdrom_filesystem(&self, drive_index: u8, mem: &dyn MemoryAccess) -> bool {
+        if drive_index != self.mscdex.drive_letter {
+            return false;
+        }
+        let cds_addr = tables::CDS_BASE + (drive_index as u32) * tables::CDS_ENTRY_SIZE;
+        let cds_flags = mem.read_word(cds_addr + tables::CDS_OFF_FLAGS);
+        cds_flags != 0 && cds_flags & tables::CDS_FLAG_PHYSICAL == 0
+    }
+
+    pub(crate) fn ensure_readable_drive_ready(
+        &mut self,
+        drive_index: u8,
+        mem: &dyn MemoryAccess,
+        device: &mut dyn DriveIo,
+    ) -> Result<(), u16> {
+        if drive_index == 25 {
+            return Ok(());
+        }
+
+        if self.drive_has_cdrom_filesystem(drive_index, mem) {
+            filesystem::iso9660::IsoVolume::mount(device).map(|_| ())
+        } else {
+            self.ensure_volume_mounted(drive_index, mem, device)
+        }
+    }
+
     /// Reads an ASCIIZ string from emulated memory.
     pub(crate) fn read_asciiz(mem: &dyn MemoryAccess, addr: u32, max_len: usize) -> Vec<u8> {
         let mut result = Vec::new();
@@ -1559,6 +1591,74 @@ impl OsState {
         Ok((drive_index, dir_cluster, fcb_name))
     }
 
+    pub(crate) fn resolve_read_file_path(
+        &mut self,
+        path: &[u8],
+        mem: &dyn MemoryAccess,
+        device: &mut dyn DriveIo,
+    ) -> Result<filesystem::ReadFilePath, u16> {
+        let normalized_path = dos::normalize_path(path);
+        let (drive_opt, components, is_absolute) = filesystem::split_path(&normalized_path);
+        let drive_index = drive_opt.unwrap_or(self.current_drive);
+
+        if components.is_empty() {
+            return Err(0x0002);
+        }
+
+        if drive_index == 25 {
+            let (drive_index, dir_cluster, name) = self.resolve_file_path(path, mem, device)?;
+            return Ok(filesystem::ReadFilePath {
+                drive_index,
+                directory: filesystem::ReadDirectory::Fat(dir_cluster),
+                name,
+            });
+        }
+
+        self.ensure_readable_drive_ready(drive_index, mem, device)?;
+
+        let mut directory = if is_absolute {
+            if self.drive_has_cdrom_filesystem(drive_index, mem) {
+                let volume = filesystem::iso9660::IsoVolume::mount(device)?;
+                filesystem::ReadDirectory::Iso(volume.root_directory)
+            } else {
+                filesystem::ReadDirectory::Fat(0)
+            }
+        } else {
+            self.current_read_directory(drive_index, mem, device)?
+        };
+
+        for component in &components[..components.len() - 1] {
+            let fcb = filesystem::fat_dir::name_to_fcb(component);
+            directory = match &directory {
+                filesystem::ReadDirectory::Fat(dir_cluster) => {
+                    let volume = self.fat_volumes[drive_index as usize]
+                        .as_ref()
+                        .ok_or(0x000Fu16)?;
+                    let entry =
+                        filesystem::fat_dir::find_entry(volume, *dir_cluster, &fcb, device)?
+                            .ok_or(0x0003u16)?;
+                    if entry.attribute & filesystem::fat_dir::ATTR_DIRECTORY == 0 {
+                        return Err(0x0003);
+                    }
+                    filesystem::ReadDirectory::Fat(entry.start_cluster)
+                }
+                filesystem::ReadDirectory::Iso(directory) => {
+                    let volume = filesystem::iso9660::IsoVolume::mount(device)?;
+                    let entry = filesystem::iso9660::find_entry(&volume, directory, &fcb, device)?
+                        .ok_or(0x0003u16)?;
+                    let next_directory = entry.directory.ok_or(0x0003u16)?;
+                    filesystem::ReadDirectory::Iso(next_directory)
+                }
+            };
+        }
+
+        Ok(filesystem::ReadFilePath {
+            drive_index,
+            directory,
+            name: filesystem::fat_dir::name_to_fcb(components.last().unwrap()),
+        })
+    }
+
     /// Resolves a path to a directory, returning `(drive_index, dir_cluster)`.
     /// Walks all path components (unlike `resolve_file_path` which splits off the last).
     /// An empty path or just a drive letter returns the current directory for that drive.
@@ -1612,6 +1712,70 @@ impl OsState {
         Ok((drive_index, dir_cluster))
     }
 
+    pub(crate) fn resolve_read_dir_path(
+        &mut self,
+        path: &[u8],
+        mem: &dyn MemoryAccess,
+        device: &mut dyn DriveIo,
+    ) -> Result<filesystem::ReadDirPath, u16> {
+        let normalized_path = dos::normalize_path(path);
+        let (drive_opt, components, is_absolute) = filesystem::split_path(&normalized_path);
+        let drive_index = drive_opt.unwrap_or(self.current_drive);
+
+        if drive_index == 25 {
+            let (drive_index, dir_cluster) = self.resolve_dir_path(path, mem, device)?;
+            return Ok(filesystem::ReadDirPath {
+                drive_index,
+                directory: filesystem::ReadDirectory::Fat(dir_cluster),
+            });
+        }
+
+        self.ensure_readable_drive_ready(drive_index, mem, device)?;
+
+        let mut directory = if is_absolute || components.is_empty() {
+            if self.drive_has_cdrom_filesystem(drive_index, mem) {
+                let volume = filesystem::iso9660::IsoVolume::mount(device)?;
+                filesystem::ReadDirectory::Iso(volume.root_directory)
+            } else if components.is_empty() && !is_absolute {
+                self.current_read_directory(drive_index, mem, device)?
+            } else {
+                filesystem::ReadDirectory::Fat(0)
+            }
+        } else {
+            self.current_read_directory(drive_index, mem, device)?
+        };
+
+        for component in &components {
+            let fcb = filesystem::fat_dir::name_to_fcb(component);
+            directory = match &directory {
+                filesystem::ReadDirectory::Fat(dir_cluster) => {
+                    let volume = self.fat_volumes[drive_index as usize]
+                        .as_ref()
+                        .ok_or(0x000Fu16)?;
+                    let entry =
+                        filesystem::fat_dir::find_entry(volume, *dir_cluster, &fcb, device)?
+                            .ok_or(0x0003u16)?;
+                    if entry.attribute & filesystem::fat_dir::ATTR_DIRECTORY == 0 {
+                        return Err(0x0003);
+                    }
+                    filesystem::ReadDirectory::Fat(entry.start_cluster)
+                }
+                filesystem::ReadDirectory::Iso(directory) => {
+                    let volume = filesystem::iso9660::IsoVolume::mount(device)?;
+                    let entry = filesystem::iso9660::find_entry(&volume, directory, &fcb, device)?
+                        .ok_or(0x0003u16)?;
+                    let next_directory = entry.directory.ok_or(0x0003u16)?;
+                    filesystem::ReadDirectory::Iso(next_directory)
+                }
+            };
+        }
+
+        Ok(filesystem::ReadDirPath {
+            drive_index,
+            directory,
+        })
+    }
+
     /// Returns the cluster number of the current directory for a drive by
     /// reading the CDS path and walking from root.
     fn current_dir_cluster(
@@ -1649,12 +1813,54 @@ impl OsState {
         Ok(dir_cluster)
     }
 
+    fn current_read_directory(
+        &mut self,
+        drive_index: u8,
+        mem: &dyn MemoryAccess,
+        device: &mut dyn DriveIo,
+    ) -> Result<filesystem::ReadDirectory, u16> {
+        if self.drive_has_cdrom_filesystem(drive_index, mem) {
+            let volume = filesystem::iso9660::IsoVolume::mount(device)?;
+            let cds_path = Self::read_cds_path(mem, drive_index);
+            let (_, components, _) = filesystem::split_path(&cds_path);
+            let mut directory = volume.root_directory.clone();
+
+            for component in &components {
+                let fcb = filesystem::fat_dir::name_to_fcb(component);
+                let entry = filesystem::iso9660::find_entry(&volume, &directory, &fcb, device)?
+                    .ok_or(0x0003u16)?;
+                directory = entry.directory.ok_or(0x0003u16)?;
+            }
+
+            Ok(filesystem::ReadDirectory::Iso(directory))
+        } else {
+            Ok(filesystem::ReadDirectory::Fat(self.current_dir_cluster(
+                drive_index,
+                mem,
+                device,
+            )?))
+        }
+    }
+
+    fn read_cds_path(mem: &dyn MemoryAccess, drive_index: u8) -> Vec<u8> {
+        let cds_addr = tables::CDS_BASE + (drive_index as u32) * tables::CDS_ENTRY_SIZE;
+        let mut path = Vec::new();
+        for i in 0..67u32 {
+            let byte = mem.read_byte(cds_addr + tables::CDS_OFF_PATH + i);
+            if byte == 0 {
+                break;
+            }
+            path.push(byte);
+        }
+        path
+    }
+
     /// Changes the current directory for a drive.
     /// `path_bytes` is a raw path like `\DIR`, `C:\DIR`, or `SUBDIR`.
     pub(crate) fn change_directory(
         &mut self,
         memory: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        device: &mut dyn DriveIo,
         path_bytes: &[u8],
     ) -> Result<(), u16> {
         if path_bytes.is_empty() {
@@ -1731,21 +1937,7 @@ impl OsState {
                 // Z: is a virtual drive with no filesystem
                 return Err(0x0003);
             }
-            self.ensure_volume_mounted(drive_index, memory, disk)?;
-            let vol = self.fat_volumes[drive_index as usize]
-                .as_ref()
-                .ok_or(0x000Fu16)?;
-            let (_, components, _) = filesystem::split_path(final_path);
-            let mut dir_cluster = 0u16;
-            for component in &components {
-                let fcb = filesystem::fat_dir::name_to_fcb(component);
-                let entry = filesystem::fat_dir::find_entry(vol, dir_cluster, &fcb, disk)?
-                    .ok_or(0x0003u16)?;
-                if entry.attribute & filesystem::fat_dir::ATTR_DIRECTORY == 0 {
-                    return Err(0x0003);
-                }
-                dir_cluster = entry.start_cluster;
-            }
+            self.resolve_read_dir_path(final_path, memory, device)?;
         }
 
         // Write path to CDS entry

--- a/crates/os/src/lib.rs
+++ b/crates/os/src/lib.rs
@@ -359,6 +359,17 @@ impl NeetanOs {
         self.state.xms_32_enabled = enabled;
     }
 
+    /// Drops mounted FAT caches for any DOS drive backed by the given DA/UA.
+    pub fn invalidate_drive_caches(&mut self, memory: &dyn MemoryAccess, da_ua: u8) {
+        for drive_index in 0..26usize {
+            let mapped_da_ua = memory
+                .read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_DAUA_TABLE + drive_index as u32);
+            if mapped_da_ua == da_ua {
+                self.state.fat_volumes[drive_index] = None;
+            }
+        }
+    }
+
     /// Performs the DOS boot sequence: writes data structures into emulated RAM,
     /// mounts drives, parses CONFIG.SYS, and creates the COMMAND.COM process.
     pub fn boot(

--- a/crates/os/src/lib.rs
+++ b/crates/os/src/lib.rs
@@ -344,6 +344,12 @@ impl NeetanOs {
         self.state.host_local_time_fn = f;
     }
 
+    /// Returns a host-formatted overview of current HLE DOS memory usage.
+    pub fn debug_memory_overview_lines(&self, memory: &dyn MemoryAccess) -> Vec<String> {
+        let overview = memory::collect_memory_overview(&self.state, memory);
+        memory::format_host_memory_overview(&overview)
+    }
+
     /// Enables or disables EMS expanded memory.
     pub fn set_ems_enabled(&mut self, enabled: bool) {
         self.state.ems_enabled = enabled;

--- a/crates/os/src/memory.rs
+++ b/crates/os/src/memory.rs
@@ -3,16 +3,45 @@
 pub(crate) mod memory_manager;
 mod tlsf;
 
-use crate::{MemoryAccess, tables::*};
+use crate::{MemoryAccess, OsState, tables::*};
 
 const MCB_TYPE_M: u8 = 0x4D;
 const MCB_TYPE_Z: u8 = 0x5A;
 const MAX_CHAIN_WALK: usize = 4096;
+const CONVENTIONAL_MEMORY_TOTAL_BYTES: u32 = 640 * 1024;
+const HMA_TOTAL_BYTES: u32 = 0xFFF0;
 
 // DOS error codes
 const ERR_MCB_DESTROYED: u8 = 7;
 const ERR_INSUFFICIENT_MEMORY: u8 = 8;
 const ERR_INVALID_BLOCK: u8 = 9;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MemoryAmount {
+    pub(crate) total_bytes: u32,
+    pub(crate) used_bytes: u32,
+    pub(crate) free_bytes: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HmaMemoryAmount {
+    pub(crate) total_bytes: u32,
+    pub(crate) used_bytes: u32,
+    pub(crate) free_bytes: u32,
+    pub(crate) allocated: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MemoryOverview {
+    pub(crate) conventional: MemoryAmount,
+    pub(crate) umb: MemoryAmount,
+    pub(crate) hma: HmaMemoryAmount,
+    pub(crate) ems: MemoryAmount,
+    pub(crate) xms: MemoryAmount,
+    pub(crate) extended_pool: MemoryAmount,
+    pub(crate) largest_conventional_free_bytes: u32,
+    pub(crate) largest_umb_free_bytes: u32,
+}
 
 fn mcb_addr(segment: u16) -> u32 {
     (segment as u32) << 4
@@ -28,6 +57,61 @@ fn read_mcb_owner(mem: &dyn MemoryAccess, segment: u16) -> u16 {
 
 fn read_mcb_size(mem: &dyn MemoryAccess, segment: u16) -> u16 {
     mem.read_word(mcb_addr(segment) + MCB_OFF_SIZE)
+}
+
+fn walk_mcb_chain_usage(mem: &dyn MemoryAccess, first_segment: u16) -> (u32, u32) {
+    let mut used_paragraphs: u32 = 0;
+    let mut free_paragraphs: u32 = 0;
+    let mut current = first_segment;
+
+    for _ in 0..MAX_CHAIN_WALK {
+        let block_type = read_mcb_type(mem, current);
+        if !is_valid_mcb_type(block_type) {
+            break;
+        }
+
+        let owner = read_mcb_owner(mem, current);
+        let size = read_mcb_size(mem, current) as u32;
+        if owner == MCB_OWNER_FREE {
+            free_paragraphs += size;
+        } else {
+            used_paragraphs += size;
+        }
+
+        if block_type == MCB_TYPE_Z {
+            break;
+        }
+
+        current = current + size as u16 + 1;
+    }
+
+    (used_paragraphs, free_paragraphs)
+}
+
+fn largest_free_block_paragraphs(mem: &dyn MemoryAccess, first_segment: u16) -> u32 {
+    let mut largest: u32 = 0;
+    let mut current = first_segment;
+
+    for _ in 0..MAX_CHAIN_WALK {
+        let block_type = read_mcb_type(mem, current);
+        if !is_valid_mcb_type(block_type) {
+            break;
+        }
+
+        let owner = read_mcb_owner(mem, current);
+        let size = read_mcb_size(mem, current) as u32;
+        if owner == MCB_OWNER_FREE && size > largest {
+            largest = size;
+        }
+
+        if block_type == MCB_TYPE_Z {
+            break;
+        }
+
+        current = current + size as u16 + 1;
+    }
+
+    largest
 }
 
 fn write_mcb_type(mem: &mut dyn MemoryAccess, segment: u16, block_type: u8) {
@@ -51,6 +135,176 @@ fn clear_mcb_name(mem: &mut dyn MemoryAccess, segment: u16) {
 
 fn is_valid_mcb_type(t: u8) -> bool {
     t == MCB_TYPE_M || t == MCB_TYPE_Z
+}
+
+pub(crate) fn collect_memory_overview(state: &OsState, mem: &dyn MemoryAccess) -> MemoryOverview {
+    let (conventional_used_paragraphs, _) = walk_mcb_chain_usage(mem, FIRST_MCB_SEGMENT);
+    let conventional_used_bytes = conventional_used_paragraphs * 16;
+    let conventional = MemoryAmount {
+        total_bytes: CONVENTIONAL_MEMORY_TOTAL_BYTES,
+        used_bytes: conventional_used_bytes,
+        free_bytes: CONVENTIONAL_MEMORY_TOTAL_BYTES.saturating_sub(conventional_used_bytes),
+    };
+
+    let memory_manager = state.memory_manager.as_ref();
+
+    let umb = if let Some(manager) = memory_manager {
+        if manager.is_umb_enabled() {
+            let (umb_used_paragraphs, umb_free_paragraphs) =
+                walk_mcb_chain_usage(mem, UMB_FIRST_MCB_SEGMENT);
+            let total_bytes = (umb_used_paragraphs + umb_free_paragraphs) * 16;
+            let used_bytes = umb_used_paragraphs * 16;
+            MemoryAmount {
+                total_bytes,
+                used_bytes,
+                free_bytes: total_bytes.saturating_sub(used_bytes),
+            }
+        } else {
+            MemoryAmount {
+                total_bytes: 0,
+                used_bytes: 0,
+                free_bytes: 0,
+            }
+        }
+    } else {
+        MemoryAmount {
+            total_bytes: 0,
+            used_bytes: 0,
+            free_bytes: 0,
+        }
+    };
+
+    let hma_total_bytes = if memory_manager.is_some_and(|manager| manager.is_xms_enabled()) {
+        HMA_TOTAL_BYTES
+    } else {
+        0
+    };
+    let hma_allocated = memory_manager.is_some_and(|manager| manager.hma_is_allocated());
+    let hma = HmaMemoryAmount {
+        total_bytes: hma_total_bytes,
+        used_bytes: if hma_allocated { hma_total_bytes } else { 0 },
+        free_bytes: if hma_allocated { 0 } else { hma_total_bytes },
+        allocated: hma_allocated,
+    };
+
+    let ems_total_bytes = memory_manager.map_or(0, |manager| manager.ems_total_kb() * 1024);
+    let ems_free_bytes = memory_manager.map_or(0, |manager| manager.ems_free_kb() * 1024);
+    let ems = MemoryAmount {
+        total_bytes: ems_total_bytes,
+        used_bytes: ems_total_bytes.saturating_sub(ems_free_bytes),
+        free_bytes: ems_free_bytes,
+    };
+
+    let xms_total_bytes = memory_manager.map_or(0, |manager| manager.xms_total_kb() * 1024);
+    let xms_free_bytes = memory_manager.map_or(0, |manager| manager.xms_free_kb() * 1024);
+    let xms = MemoryAmount {
+        total_bytes: xms_total_bytes,
+        used_bytes: xms_total_bytes.saturating_sub(xms_free_bytes),
+        free_bytes: xms_free_bytes,
+    };
+
+    let extended_pool = if let Some(manager) = memory_manager {
+        MemoryAmount {
+            total_bytes: manager.extended_pool_total_bytes(),
+            used_bytes: manager.extended_pool_used_bytes(),
+            free_bytes: manager.extended_pool_free_bytes(),
+        }
+    } else {
+        MemoryAmount {
+            total_bytes: 0,
+            used_bytes: 0,
+            free_bytes: 0,
+        }
+    };
+
+    MemoryOverview {
+        conventional,
+        umb,
+        hma,
+        ems,
+        xms,
+        extended_pool,
+        largest_conventional_free_bytes: largest_free_block_paragraphs(mem, FIRST_MCB_SEGMENT) * 16,
+        largest_umb_free_bytes: if umb.total_bytes > 0 {
+            largest_free_block_paragraphs(mem, UMB_FIRST_MCB_SEGMENT) * 16
+        } else {
+            0
+        },
+    }
+}
+
+pub(crate) fn format_host_memory_overview(overview: &MemoryOverview) -> Vec<String> {
+    vec![
+        "Memory overview (HLE DOS)".to_string(),
+        format!(
+            "Conventional: total={} used={} free={}",
+            format_debug_size(overview.conventional.total_bytes),
+            format_debug_size(overview.conventional.used_bytes),
+            format_debug_size(overview.conventional.free_bytes),
+        ),
+        format!(
+            "UMB: total={} used={} free={}",
+            format_debug_size(overview.umb.total_bytes),
+            format_debug_size(overview.umb.used_bytes),
+            format_debug_size(overview.umb.free_bytes),
+        ),
+        format!(
+            "HMA: total={} used={} free={} state={}",
+            format_debug_size(overview.hma.total_bytes),
+            format_debug_size(overview.hma.used_bytes),
+            format_debug_size(overview.hma.free_bytes),
+            if overview.hma.allocated {
+                "allocated"
+            } else {
+                "free"
+            },
+        ),
+        format!(
+            "EMS: total={} used={} free={}",
+            format_debug_size(overview.ems.total_bytes),
+            format_debug_size(overview.ems.used_bytes),
+            format_debug_size(overview.ems.free_bytes),
+        ),
+        format!(
+            "XMS: total={} used={} free={}",
+            format_debug_size(overview.xms.total_bytes),
+            format_debug_size(overview.xms.used_bytes),
+            format_debug_size(overview.xms.free_bytes),
+        ),
+        format!(
+            "Extended backing pool (EMS+XMS): total={} used={} free={}",
+            format_debug_size(overview.extended_pool.total_bytes),
+            format_debug_size(overview.extended_pool.used_bytes),
+            format_debug_size(overview.extended_pool.free_bytes),
+        ),
+        "Note: EMS and XMS share the same backing pool.".to_string(),
+    ]
+}
+
+fn format_debug_size(bytes: u32) -> String {
+    if bytes == 0 {
+        return "0 bytes".to_string();
+    }
+    if bytes.is_multiple_of(1024) {
+        return format!(
+            "{}K ({} bytes)",
+            format_debug_number(bytes / 1024),
+            format_debug_number(bytes),
+        );
+    }
+    format!("{} bytes", format_debug_number(bytes))
+}
+
+fn format_debug_number(value: u32) -> String {
+    let digits = value.to_string();
+    let mut result = String::new();
+    for (index, ch) in digits.chars().rev().enumerate() {
+        if index > 0 && index % 3 == 0 {
+            result.push(',');
+        }
+        result.push(ch);
+    }
+    result.chars().rev().collect()
 }
 
 pub(crate) fn read_mcb_size_pub(mem: &dyn MemoryAccess, segment: u16) -> u16 {

--- a/crates/os/src/memory/memory_manager.rs
+++ b/crates/os/src/memory/memory_manager.rs
@@ -879,6 +879,19 @@ impl MemoryManager {
         }
     }
 
+    pub(crate) fn extended_pool_total_bytes(&self) -> u32 {
+        self.extended_memory_size
+    }
+
+    pub(crate) fn extended_pool_used_bytes(&self) -> u32 {
+        (self.allocated_ems_pages() as u32) * EMS_PAGE_SIZE + self.allocated_xms_kb() * 1024
+    }
+
+    pub(crate) fn extended_pool_free_bytes(&self) -> u32 {
+        self.extended_memory_size
+            .saturating_sub(self.extended_pool_used_bytes())
+    }
+
     pub(crate) fn hma_is_allocated(&self) -> bool {
         self.hma_allocated
     }

--- a/crates/os/src/process.rs
+++ b/crates/os/src/process.rs
@@ -4,8 +4,8 @@
 pub(crate) static COMMAND_COM_STUB: &[u8] = include_bytes!("../../../utils/os/os.rom");
 
 use crate::{
-    CpuAccess, DiskIo, MemoryAccess, NeetanOs, OsState, country, dos,
-    filesystem::{fat::FatVolume, fat_dir, fat_file},
+    CpuAccess, DiskIo, DriveIo, MemoryAccess, NeetanOs, OsState, country, dos,
+    filesystem::{fat::FatVolume, fat_dir, fat_file, find_read_entry, read_entry_all},
     memory, set_iret_carry,
     tables::*,
 };
@@ -377,7 +377,7 @@ impl NeetanOs {
         &mut self,
         cpu: &mut dyn CpuAccess,
         mem: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) {
         let al = (cpu.ax() & 0xFF) as u8;
         let result = match al {
@@ -402,7 +402,7 @@ impl NeetanOs {
         &mut self,
         cpu: &mut dyn CpuAccess,
         mem: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> Result<(), u16> {
         // Parse parameters.
         let filename_addr = ((cpu.ds() as u32) << 4) + cpu.dx() as u32;
@@ -426,8 +426,8 @@ impl NeetanOs {
         };
 
         // Resolve file path.
-        let (drive_index, dir_cluster, fcb_name) =
-            self.state.resolve_file_path(&path, mem, disk)?;
+        let read_path = self.state.resolve_read_file_path(&path, mem, disk)?;
+        let drive_index = read_path.drive_index;
 
         // Z: drive contains only COMMAND.COM for COMSPEC compatibility.
         // All shell commands are built-in and resolved from the command registry,
@@ -439,14 +439,8 @@ impl NeetanOs {
         }
 
         // Find the file on disk.
-        self.state.ensure_volume_mounted(drive_index, mem, disk)?;
-        let vol = self.state.fat_volumes[drive_index as usize]
-            .as_ref()
-            .ok_or(0x0003u16)?;
-        let dir_entry = fat_dir::find_entry(vol, dir_cluster, &fcb_name, disk)?.ok_or(0x0002u16)?;
-
-        // Read file data.
-        let file_data = read_file_data(vol, &dir_entry, disk)?;
+        let dir_entry = find_read_entry(&self.state, &read_path, disk)?.ok_or(0x0002u16)?;
+        let file_data = read_entry_all(&self.state, drive_index, &dir_entry, disk)?;
         if file_data.is_empty() {
             return Err(0x000B);
         }
@@ -470,7 +464,7 @@ impl NeetanOs {
         &mut self,
         cpu: &mut dyn CpuAccess,
         mem: &mut dyn MemoryAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> Result<(), u16> {
         let filename_addr = ((cpu.ds() as u32) << 4) + cpu.dx() as u32;
         let path = OsState::read_asciiz(mem, filename_addr, 128);
@@ -492,20 +486,15 @@ impl NeetanOs {
             fcb2_addr: ((fcb2_seg as u32) << 4) + fcb2_off as u32,
         };
 
-        let (drive_index, dir_cluster, fcb_name) =
-            self.state.resolve_file_path(&path, mem, disk)?;
+        let read_path = self.state.resolve_read_file_path(&path, mem, disk)?;
+        let drive_index = read_path.drive_index;
 
         if drive_index == 25 {
             return Err(0x0002);
         }
 
-        self.state.ensure_volume_mounted(drive_index, mem, disk)?;
-        let vol = self.state.fat_volumes[drive_index as usize]
-            .as_ref()
-            .ok_or(0x0003u16)?;
-        let dir_entry = fat_dir::find_entry(vol, dir_cluster, &fcb_name, disk)?.ok_or(0x0002u16)?;
-
-        let file_data = read_file_data(vol, &dir_entry, disk)?;
+        let dir_entry = find_read_entry(&self.state, &read_path, disk)?.ok_or(0x0002u16)?;
+        let file_data = read_entry_all(&self.state, drive_index, &dir_entry, disk)?;
         if file_data.is_empty() {
             return Err(0x000B);
         }

--- a/crates/os/src/process.rs
+++ b/crates/os/src/process.rs
@@ -5,7 +5,7 @@ pub(crate) static COMMAND_COM_STUB: &[u8] = include_bytes!("../../../utils/os/os
 
 use crate::{
     CpuAccess, DiskIo, MemoryAccess, NeetanOs, OsState, country, dos,
-    filesystem::{fat::FatVolume, fat_dir},
+    filesystem::{fat::FatVolume, fat_dir, fat_file},
     memory, set_iret_carry,
     tables::*,
 };
@@ -363,27 +363,7 @@ pub(crate) fn read_file_data(
     entry: &fat_dir::DirEntry,
     disk: &mut dyn DiskIo,
 ) -> Result<Vec<u8>, u16> {
-    if entry.file_size == 0 {
-        return Ok(Vec::new());
-    }
-
-    let mut data = Vec::with_capacity(entry.file_size as usize);
-    let mut cluster = entry.start_cluster;
-
-    loop {
-        let chunk = vol.read_cluster(cluster, disk)?;
-        data.extend_from_slice(&chunk);
-        if data.len() >= entry.file_size as usize {
-            break;
-        }
-        match vol.next_cluster(cluster) {
-            Some(next) => cluster = next,
-            None => break,
-        }
-    }
-
-    data.truncate(entry.file_size as usize);
-    Ok(data)
+    fat_file::read_all(vol, entry, disk)
 }
 
 impl NeetanOs {

--- a/crates/os/src/shell.rs
+++ b/crates/os/src/shell.rs
@@ -11,7 +11,7 @@ use crate::{
     DiskIo, DriveIo, IoAccess, MemoryAccess, OsState,
     commands::{self, Command, RunningCommand, StepResult},
     filesystem,
-    filesystem::{fat, fat_dir, fat_file, fat_file::FatFileWriter},
+    filesystem::{fat, fat_dir, fat_file},
     tables,
 };
 
@@ -105,6 +105,7 @@ impl Shell {
             Box::new(commands::del::Del),
             Box::new(commands::dir::Dir),
             Box::new(commands::diskcopy::Diskcopy),
+            Box::new(commands::dosmock::Dosmock),
             Box::new(commands::format::Format),
             Box::new(commands::md::Md),
             Box::new(commands::mem::Mem),
@@ -1026,47 +1027,35 @@ fn write_redirect_to_file(
         if let Ok(Some(existing)) = fat_dir::find_entry(vol, dir_cluster, &fcb_name, disk) {
             append_to_existing_file(vol, &existing, data, disk);
         } else {
-            create_new_file_with_data(vol, dir_cluster, &fcb_name, data, disk, time, date);
+            let _ = fat_file::create_or_replace_file(
+                vol,
+                dir_cluster,
+                &fcb_name,
+                data,
+                fat_file::FileCreateOptions {
+                    attributes: fat_dir::ATTR_ARCHIVE,
+                    time,
+                    date,
+                },
+                disk,
+            );
         }
     } else {
-        // Overwrite mode: delete existing, create new
-        if let Ok(Some(existing)) = fat_dir::find_entry(vol, dir_cluster, &fcb_name, disk) {
-            if existing.start_cluster >= 2 {
-                vol.free_chain(existing.start_cluster);
-            }
-            let _ = fat_dir::delete_entry(vol, &existing, disk);
-        }
-        create_new_file_with_data(vol, dir_cluster, &fcb_name, data, disk, time, date);
+        let _ = fat_file::create_or_replace_file(
+            vol,
+            dir_cluster,
+            &fcb_name,
+            data,
+            fat_file::FileCreateOptions {
+                attributes: fat_dir::ATTR_ARCHIVE,
+                time,
+                date,
+            },
+            disk,
+        );
     }
 
     let _ = vol.flush_fat(disk);
-}
-
-fn create_new_file_with_data(
-    vol: &mut fat::FatVolume,
-    dir_cluster: u16,
-    fcb_name: &[u8; 11],
-    data: &[u8],
-    disk: &mut dyn DiskIo,
-    time: u16,
-    date: u16,
-) {
-    let mut writer = FatFileWriter::new(0, 0);
-    if writer.write_chunk(vol, disk, data).is_err() {
-        return;
-    }
-
-    let new_entry = fat_dir::DirEntry {
-        name: *fcb_name,
-        attribute: 0x20, // archive
-        time,
-        date,
-        start_cluster: writer.start_cluster(),
-        file_size: writer.position(),
-        dir_sector: 0,
-        dir_offset: 0,
-    };
-    let _ = fat_dir::create_entry(vol, dir_cluster, &new_entry, disk);
 }
 
 fn append_to_existing_file(

--- a/crates/os/src/shell.rs
+++ b/crates/os/src/shell.rs
@@ -92,6 +92,7 @@ pub(crate) struct Shell {
 impl Shell {
     fn build_commands() -> Vec<Box<dyn Command>> {
         vec![
+            Box::new(commands::b3sum::B3sum),
             Box::new(commands::cls::Cls),
             Box::new(commands::ver::Ver),
             Box::new(commands::echo::Echo),

--- a/crates/os/src/shell.rs
+++ b/crates/os/src/shell.rs
@@ -161,7 +161,7 @@ impl Shell {
             ShellPhase::ShowPrompt => {
                 if !self.boot_banner_shown {
                     let (major, minor) = state.version;
-                    let msg = format!("Neetan OS Version {}.{}\r\n\r\n", major, minor);
+                    let msg = format!("Neetan DOS {}.{}\r\n\r\n", major, minor);
                     io.print(msg.as_bytes());
                     self.boot_banner_shown = true;
                 }
@@ -697,7 +697,7 @@ fn render_prompt(state: &OsState, io: &mut IoAccess) {
                 }
                 b'V' => {
                     let (major, minor) = state.version;
-                    let msg = format!("Neetan OS Version {}.{}", major, minor);
+                    let msg = format!("Neetan DOS {}.{}", major, minor);
                     for &byte in msg.as_bytes() {
                         io.console.process_byte(io.memory, byte);
                     }

--- a/crates/os/src/shell.rs
+++ b/crates/os/src/shell.rs
@@ -8,8 +8,9 @@ use std::collections::VecDeque;
 use history::History;
 
 use crate::{
-    DiskIo, IoAccess, MemoryAccess, OsState,
+    DiskIo, DriveIo, IoAccess, MemoryAccess, OsState,
     commands::{self, Command, RunningCommand, StepResult},
+    filesystem,
     filesystem::{fat, fat_dir, fat_file, fat_file::FatFileWriter},
     tables,
 };
@@ -156,7 +157,7 @@ impl Shell {
         }
     }
 
-    pub(crate) fn step(&mut self, state: &mut OsState, io: &mut IoAccess, disk: &mut dyn DiskIo) {
+    pub(crate) fn step(&mut self, state: &mut OsState, io: &mut IoAccess, disk: &mut dyn DriveIo) {
         let phase = std::mem::replace(&mut self.phase, ShellPhase::ShowPrompt);
         self.phase = match phase {
             ShellPhase::ShowPrompt => {
@@ -343,7 +344,7 @@ impl Shell {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
         line: &[u8],
     ) -> ShellPhase {
         let trimmed = line.trim_ascii();
@@ -391,7 +392,7 @@ impl Shell {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
         segment: &[u8],
     ) -> ShellPhase {
         let parsed = parse_redirections(segment);
@@ -424,7 +425,7 @@ impl Shell {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
         command: &[u8],
     ) -> ShellPhase {
         let trimmed = command.trim_ascii();
@@ -470,11 +471,9 @@ impl Shell {
                 self.last_exit_code = 1;
                 return ShellPhase::ShowPrompt;
             }
-            // For physical drives, verify media is accessible.
-            if drive_index != 25
-                && state
-                    .ensure_volume_mounted(drive_index, io.memory, disk)
-                    .is_err()
+            if state
+                .ensure_readable_drive_ready(drive_index, io.memory, disk)
+                .is_err()
             {
                 let msg = [
                     b"No media in drive ".as_slice(),
@@ -546,7 +545,7 @@ impl Shell {
         pipe_data: Option<Vec<u8>>,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> ShellPhase {
         // Set up output redirection for this command
         if pending.parsed.output_redirect.is_some() {
@@ -872,8 +871,8 @@ fn find_external_program(
     original_cmd: &[u8],
     cmd_upper: &[u8],
     state: &mut OsState,
-    memory: &dyn crate::MemoryAccess,
-    disk: &mut dyn DiskIo,
+    memory: &dyn MemoryAccess,
+    disk: &mut dyn DriveIo,
 ) -> Option<Vec<u8>> {
     let has_extension =
         cmd_upper.len() > 4 && (cmd_upper.ends_with(b".COM") || cmd_upper.ends_with(b".EXE"));
@@ -917,8 +916,8 @@ fn try_find_program(
     path: &[u8],
     has_extension: bool,
     state: &mut OsState,
-    memory: &dyn crate::MemoryAccess,
-    disk: &mut dyn DiskIo,
+    memory: &dyn MemoryAccess,
+    disk: &mut dyn DriveIo,
 ) -> Option<Vec<u8>> {
     if has_extension {
         if file_exists_on_disk(path, state, memory, disk) {
@@ -944,24 +943,18 @@ fn try_find_program(
 fn file_exists_on_disk(
     path: &[u8],
     state: &mut OsState,
-    memory: &dyn crate::MemoryAccess,
-    disk: &mut dyn DiskIo,
+    memory: &dyn MemoryAccess,
+    disk: &mut dyn DriveIo,
 ) -> bool {
-    let (drive_index, dir_cluster, fcb_name) = match state.resolve_file_path(path, memory, disk) {
-        Ok(r) => r,
+    let read_path = match state.resolve_read_file_path(path, memory, disk) {
+        Ok(path) => path,
         Err(_) => return false,
     };
-    if drive_index == 25 {
-        return false;
-    }
-    let vol = match state.fat_volumes[drive_index as usize].as_ref() {
-        Some(v) => v,
-        None => return false,
+    let entry = match filesystem::find_read_entry(state, &read_path, disk) {
+        Ok(Some(entry)) => entry,
+        _ => return false,
     };
-    matches!(
-        fat_dir::find_entry(vol, dir_cluster, &fcb_name, disk),
-        Ok(Some(e)) if e.attribute & fat_dir::ATTR_DIRECTORY == 0
-    )
+    entry.attribute & fat_dir::ATTR_DIRECTORY == 0
 }
 
 fn parse_bat_params(args: &[u8]) -> [Vec<u8>; 10] {
@@ -1096,24 +1089,20 @@ fn append_to_existing_file(
 fn read_file_data(
     state: &mut OsState,
     io: &mut IoAccess,
-    disk: &mut dyn DiskIo,
+    disk: &mut dyn DriveIo,
     filename: &[u8],
 ) -> Result<Vec<u8>, &'static [u8]> {
-    let (drive_index, dir_cluster, fcb_name) = state
-        .resolve_file_path(filename, io.memory, disk)
+    let read_path = state
+        .resolve_read_file_path(filename, io.memory, disk)
         .map_err(|_| &b"File not found\r\n"[..])?;
-
-    if drive_index == 25 {
+    if read_path.drive_index == 25 {
         return Err(b"Access denied\r\n");
     }
 
-    let vol = state.fat_volumes[drive_index as usize]
-        .as_ref()
-        .ok_or(&b"Invalid drive\r\n"[..])?;
-
-    let entry = fat_dir::find_entry(vol, dir_cluster, &fcb_name, disk)
+    let entry = filesystem::find_read_entry(state, &read_path, disk)
         .map_err(|_| &b"File not found\r\n"[..])?
         .ok_or(&b"File not found\r\n"[..])?;
 
-    fat_file::read_all(vol, &entry, disk).map_err(|_| &b"Read error\r\n"[..])
+    filesystem::read_entry_all(state, read_path.drive_index, &entry, disk)
+        .map_err(|_| &b"Read error\r\n"[..])
 }

--- a/crates/os/src/shell.rs
+++ b/crates/os/src/shell.rs
@@ -10,7 +10,7 @@ use history::History;
 use crate::{
     DiskIo, IoAccess, MemoryAccess, OsState,
     commands::{self, Command, RunningCommand, StepResult},
-    filesystem::{fat, fat_dir},
+    filesystem::{fat, fat_dir, fat_file, fat_file::FatFileWriter},
     tables,
 };
 
@@ -1058,26 +1058,9 @@ fn create_new_file_with_data(
     time: u16,
     date: u16,
 ) {
-    let cluster_size = vol.bpb.sectors_per_cluster as usize * vol.bpb.bytes_per_sector as usize;
-    let mut first_cluster: u16 = 0;
-    let mut last_cluster: u16 = 0;
-    let mut offset = 0;
-
-    while offset < data.len() {
-        let end = (offset + cluster_size).min(data.len());
-        let mut cluster_data = vec![0u8; cluster_size];
-        cluster_data[..end - offset].copy_from_slice(&data[offset..end]);
-
-        let new_cluster = match vol.allocate_cluster(last_cluster) {
-            Some(c) => c,
-            None => return,
-        };
-        if first_cluster == 0 {
-            first_cluster = new_cluster;
-        }
-        let _ = vol.write_cluster(new_cluster, &cluster_data, disk);
-        last_cluster = new_cluster;
-        offset = end;
+    let mut writer = FatFileWriter::new(0, 0);
+    if writer.write_chunk(vol, disk, data).is_err() {
+        return;
     }
 
     let new_entry = fat_dir::DirEntry {
@@ -1085,8 +1068,8 @@ fn create_new_file_with_data(
         attribute: 0x20, // archive
         time,
         date,
-        start_cluster: first_cluster,
-        file_size: data.len() as u32,
+        start_cluster: writer.start_cluster(),
+        file_size: writer.position(),
         dir_sector: 0,
         dir_offset: 0,
     };
@@ -1099,95 +1082,14 @@ fn append_to_existing_file(
     data: &[u8],
     disk: &mut dyn DiskIo,
 ) {
-    let cluster_size = vol.bpb.sectors_per_cluster as usize * vol.bpb.bytes_per_sector as usize;
-    let old_size = entry.file_size as usize;
-
-    // Find last cluster and its fill level
-    let mut last_cluster = entry.start_cluster;
-    let mut remaining_in_chain = old_size;
-
-    if last_cluster < 2 {
-        // Empty file: allocate first cluster
-        let new_cluster = match vol.allocate_cluster(0) {
-            Some(c) => c,
-            None => return,
-        };
-        let mut cluster_data = vec![0u8; cluster_size];
-        let write_len = data.len().min(cluster_size);
-        cluster_data[..write_len].copy_from_slice(&data[..write_len]);
-        let _ = vol.write_cluster(new_cluster, &cluster_data, disk);
-
-        let mut updated = entry.clone();
-        updated.start_cluster = new_cluster;
-        updated.file_size = data.len() as u32;
-
-        // Write remaining data if any
-        let mut offset = write_len;
-        let mut prev = new_cluster;
-        while offset < data.len() {
-            let end = (offset + cluster_size).min(data.len());
-            let mut cd = vec![0u8; cluster_size];
-            cd[..end - offset].copy_from_slice(&data[offset..end]);
-            let nc = match vol.allocate_cluster(prev) {
-                Some(c) => c,
-                None => break,
-            };
-            let _ = vol.write_cluster(nc, &cd, disk);
-            prev = nc;
-            offset = end;
-        }
-        updated.file_size = (old_size + data.len()) as u32;
-        let _ = fat_dir::update_entry(vol, &updated, disk);
+    let mut writer = fat_file::FatFileWriter::new(entry.start_cluster, entry.file_size);
+    if writer.write_chunk(vol, disk, data).is_err() {
         return;
     }
 
-    // Walk to last cluster
-    while remaining_in_chain > cluster_size {
-        if let Some(next) = vol.next_cluster(last_cluster) {
-            last_cluster = next;
-            remaining_in_chain -= cluster_size;
-        } else {
-            break;
-        }
-    }
-
-    let used_in_last = remaining_in_chain % cluster_size;
-    let free_in_last = if used_in_last == 0 && old_size > 0 {
-        0
-    } else {
-        cluster_size - used_in_last
-    };
-
-    let mut offset = 0;
-
-    // Fill remaining space in last cluster
-    if free_in_last > 0 && !data.is_empty() {
-        let mut existing_data = match vol.read_cluster(last_cluster, disk) {
-            Ok(d) => d,
-            Err(_) => return,
-        };
-        let write_len = data.len().min(free_in_last);
-        existing_data[used_in_last..used_in_last + write_len].copy_from_slice(&data[..write_len]);
-        let _ = vol.write_cluster(last_cluster, &existing_data, disk);
-        offset = write_len;
-    }
-
-    // Allocate new clusters for remaining data
-    while offset < data.len() {
-        let end = (offset + cluster_size).min(data.len());
-        let mut cluster_data = vec![0u8; cluster_size];
-        cluster_data[..end - offset].copy_from_slice(&data[offset..end]);
-        let new_cluster = match vol.allocate_cluster(last_cluster) {
-            Some(c) => c,
-            None => break,
-        };
-        let _ = vol.write_cluster(new_cluster, &cluster_data, disk);
-        last_cluster = new_cluster;
-        offset = end;
-    }
-
     let mut updated = entry.clone();
-    updated.file_size = (old_size + data.len()) as u32;
+    updated.start_cluster = writer.start_cluster();
+    updated.file_size = writer.position();
     let _ = fat_dir::update_entry(vol, &updated, disk);
 }
 
@@ -1213,29 +1115,5 @@ fn read_file_data(
         .map_err(|_| &b"File not found\r\n"[..])?
         .ok_or(&b"File not found\r\n"[..])?;
 
-    if entry.file_size == 0 || entry.start_cluster < 2 {
-        return Ok(Vec::new());
-    }
-
-    let mut data = Vec::with_capacity(entry.file_size as usize);
-    let mut cluster = entry.start_cluster;
-    let mut remaining = entry.file_size as usize;
-
-    loop {
-        let cluster_data = vol
-            .read_cluster(cluster, disk)
-            .map_err(|_| &b"Read error\r\n"[..])?;
-        let take = remaining.min(cluster_data.len());
-        data.extend_from_slice(&cluster_data[..take]);
-        remaining -= take;
-        if remaining == 0 {
-            break;
-        }
-        cluster = match vol.next_cluster(cluster) {
-            Some(c) => c,
-            None => break,
-        };
-    }
-
-    Ok(data)
+    fat_file::read_all(vol, &entry, disk).map_err(|_| &b"Read error\r\n"[..])
 }

--- a/crates/os/src/shell/batch.rs
+++ b/crates/os/src/shell/batch.rs
@@ -4,7 +4,7 @@ use super::{RedirectSpec, key_available, read_env_var, read_key};
 use crate::{
     DiskIo, IoAccess, MemoryAccess, OsState,
     commands::{RunningCommand, StepResult},
-    filesystem::{fat, fat_dir},
+    filesystem::{fat, fat_dir, fat_file},
 };
 
 struct CallFrame {
@@ -509,28 +509,7 @@ pub(crate) fn load_bat_file(
     entry: &fat_dir::DirEntry,
     disk: &mut dyn DiskIo,
 ) -> Result<Vec<Vec<u8>>, u16> {
-    if entry.file_size == 0 || entry.start_cluster < 2 {
-        return Ok(Vec::new());
-    }
-
-    let mut data = Vec::with_capacity(entry.file_size as usize);
-    let mut cluster = entry.start_cluster;
-    let mut remaining = entry.file_size as usize;
-
-    loop {
-        let cluster_data = vol.read_cluster(cluster, disk)?;
-        let take = remaining.min(cluster_data.len());
-        data.extend_from_slice(&cluster_data[..take]);
-        remaining -= take;
-        if remaining == 0 {
-            break;
-        }
-        cluster = match vol.next_cluster(cluster) {
-            Some(c) => c,
-            None => break,
-        };
-    }
-
+    let data = fat_file::read_all(vol, entry, disk)?;
     Ok(split_bat_lines(&data))
 }
 

--- a/crates/os/src/shell/batch.rs
+++ b/crates/os/src/shell/batch.rs
@@ -2,7 +2,7 @@
 
 use super::{RedirectSpec, key_available, read_env_var, read_key};
 use crate::{
-    DiskIo, IoAccess, MemoryAccess, OsState,
+    DriveIo, IoAccess, MemoryAccess, OsState,
     commands::{RunningCommand, StepResult},
     filesystem::{fat, fat_dir, fat_file},
 };
@@ -42,7 +42,7 @@ impl RunningCommand for WaitingForChildCommand {
         &mut self,
         state: &mut OsState,
         _io: &mut IoAccess,
-        _disk: &mut dyn DiskIo,
+        _disk: &mut dyn DriveIo,
     ) -> StepResult {
         if state.current_psp == self.command_com_psp {
             StepResult::Done(state.last_return_code)
@@ -159,7 +159,7 @@ impl BatchState {
         shell: &mut super::Shell,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
     ) -> BatchStepResult {
         // Handle paused state (PAUSE command)
         if self.paused {
@@ -346,7 +346,7 @@ impl BatchState {
         shell: &mut super::Shell,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
         args: &[u8],
     ) {
         let trimmed = args.trim_ascii();
@@ -424,7 +424,7 @@ impl BatchState {
         &mut self,
         state: &mut OsState,
         io: &mut IoAccess,
-        disk: &mut dyn DiskIo,
+        disk: &mut dyn DriveIo,
         args: &[u8],
     ) {
         let trimmed = args.trim_ascii();
@@ -507,7 +507,7 @@ pub(crate) enum BatchStepResult {
 pub(crate) fn load_bat_file(
     vol: &fat::FatVolume,
     entry: &fat_dir::DirEntry,
-    disk: &mut dyn DiskIo,
+    disk: &mut dyn DriveIo,
 ) -> Result<Vec<Vec<u8>>, u16> {
     let data = fat_file::read_all(vol, entry, disk)?;
     Ok(split_bat_lines(&data))
@@ -540,7 +540,7 @@ pub(crate) fn split_bat_lines(data: &[u8]) -> Vec<Vec<u8>> {
 fn check_file_exists(
     state: &mut OsState,
     io: &mut IoAccess,
-    disk: &mut dyn DiskIo,
+    disk: &mut dyn DriveIo,
     filename: &[u8],
 ) -> bool {
     let (drive_index, dir_cluster, fcb_name) =

--- a/crates/os/src/shell/batch.rs
+++ b/crates/os/src/shell/batch.rs
@@ -27,6 +27,31 @@ pub(crate) struct BatchState {
     paused: bool,
 }
 
+struct WaitingForChildCommand {
+    command_com_psp: u16,
+}
+
+impl WaitingForChildCommand {
+    fn new(command_com_psp: u16) -> Self {
+        Self { command_com_psp }
+    }
+}
+
+impl RunningCommand for WaitingForChildCommand {
+    fn step(
+        &mut self,
+        state: &mut OsState,
+        _io: &mut IoAccess,
+        _disk: &mut dyn DiskIo,
+    ) -> StepResult {
+        if state.current_psp == self.command_com_psp {
+            StepResult::Done(state.last_return_code)
+        } else {
+            StepResult::Continue
+        }
+    }
+}
+
 impl BatchState {
     pub(crate) fn new(
         lines: Vec<Vec<u8>>,
@@ -292,6 +317,11 @@ impl BatchState {
                     self.redirect_buffer = shell.redirect_buffer.take();
                     self.current_redirect = shell.current_redirect.take();
                 }
+                BatchStepResult::Continue
+            }
+            super::ShellPhase::WaitingForChild => {
+                self.running_command =
+                    Some(Box::new(WaitingForChildCommand::new(shell.command_com_psp)));
                 BatchStepResult::Continue
             }
             super::ShellPhase::ExecutingBatch(new_batch) => {

--- a/crates/os/tests/dos620.rs
+++ b/crates/os/tests/dos620.rs
@@ -64,6 +64,9 @@ mod commands_dir;
 #[path = "dos620/commands_copy.rs"]
 mod commands_copy;
 
+#[path = "dos620/commands_b3sum.rs"]
+mod commands_b3sum;
+
 #[path = "dos620/file_copy_harness.rs"]
 mod file_copy_harness;
 

--- a/crates/os/tests/dos620.rs
+++ b/crates/os/tests/dos620.rs
@@ -64,8 +64,8 @@ mod commands_dir;
 #[path = "dos620/commands_copy.rs"]
 mod commands_copy;
 
-#[path = "dos620/file_copy_repro.rs"]
-mod file_copy_repro;
+#[path = "dos620/file_copy_harness.rs"]
+mod file_copy_harness;
 
 #[path = "dos620/commands_xcopy.rs"]
 mod commands_xcopy;

--- a/crates/os/tests/dos620.rs
+++ b/crates/os/tests/dos620.rs
@@ -64,6 +64,12 @@ mod commands_dir;
 #[path = "dos620/commands_copy.rs"]
 mod commands_copy;
 
+#[path = "dos620/file_copy_repro.rs"]
+mod file_copy_repro;
+
+#[path = "dos620/commands_xcopy.rs"]
+mod commands_xcopy;
+
 #[path = "dos620/commands_file_ops.rs"]
 mod commands_file_ops;
 

--- a/crates/os/tests/dos620.rs
+++ b/crates/os/tests/dos620.rs
@@ -100,6 +100,9 @@ mod memory_manager_ems_xms;
 #[path = "dos620/commands_mem.rs"]
 mod commands_mem;
 
+#[path = "dos620/hle_memory_overview.rs"]
+mod hle_memory_overview;
+
 #[path = "dos620/multiplex_interrupt.rs"]
 mod multiplex_interrupt;
 

--- a/crates/os/tests/dos620.rs
+++ b/crates/os/tests/dos620.rs
@@ -61,6 +61,9 @@ mod shell;
 #[path = "dos620/commands_dir.rs"]
 mod commands_dir;
 
+#[path = "dos620/commands_dosmock.rs"]
+mod commands_dosmock;
+
 #[path = "dos620/commands_copy.rs"]
 mod commands_copy;
 

--- a/crates/os/tests/dos620.rs
+++ b/crates/os/tests/dos620.rs
@@ -28,6 +28,9 @@ mod config;
 #[path = "dos620/compatibility.rs"]
 mod compatibility;
 
+#[path = "dos620/escape_sequences.rs"]
+mod escape_sequences;
+
 #[path = "dos620/syscalls_int21h.rs"]
 mod syscalls_int21h;
 

--- a/crates/os/tests/dos620/commands_b3sum.rs
+++ b/crates/os/tests/dos620/commands_b3sum.rs
@@ -1,0 +1,153 @@
+use crate::{file_copy_harness::*, harness::*};
+
+fn digest_hex(data: &[u8]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    let mut digest = [0u8; 32];
+    hasher.update(data);
+    hasher.finalize(&mut digest);
+
+    let mut result = String::with_capacity(64);
+    for byte in digest {
+        result.push(char::from(b"0123456789abcdef"[(byte >> 4) as usize]));
+        result.push(char::from(b"0123456789abcdef"[(byte & 0x0F) as usize]));
+    }
+    result
+}
+
+fn text_codes(text: &str) -> Vec<u16> {
+    text.bytes().map(u16::from).collect()
+}
+
+#[test]
+fn b3sum_help_on_empty_args() {
+    let mut machine = boot_hle();
+
+    type_string(&mut machine.bus, b"B3SUM\r");
+    run_until_prompt(&mut machine);
+
+    assert!(
+        find_row_containing(&machine.bus, "Computes BLAKE3 hashes of files.").is_some(),
+        "B3SUM without arguments should print help text"
+    );
+}
+
+#[test]
+fn b3sum_help_on_help_flag() {
+    let mut machine = boot_hle();
+
+    type_string_long(&mut machine, b"B3SUM /?\r");
+    run_until_prompt(&mut machine);
+
+    assert!(
+        find_row_containing(&machine.bus, "B3SUM [drive:][path]filename [...]").is_some(),
+        "B3SUM /? should print usage text"
+    );
+}
+
+#[test]
+fn b3sum_hashes_single_file() {
+    let mut machine = boot_hle_with_floppy();
+    type_string(&mut machine.bus, b"A:\r");
+    run_until_prompt(&mut machine);
+
+    type_string_long(&mut machine, b"B3SUM TESTFILE.TXT\r");
+    run_until_prompt(&mut machine);
+
+    let expected_line = format!("{}  TESTFILE.TXT", digest_hex(TEST_FILE_CONTENT));
+    assert!(
+        find_row_containing(&machine.bus, &expected_line).is_some(),
+        "B3SUM should print the expected digest for TESTFILE.TXT"
+    );
+}
+
+#[test]
+fn b3sum_expands_wildcards_with_directory_prefix() {
+    let mut machine = boot_hle_with_floppy();
+    type_string(&mut machine.bus, b"A:\r");
+    run_until_prompt(&mut machine);
+
+    type_string(&mut machine.bus, b"MD HASHDIR\r");
+    run_until_prompt(&mut machine);
+    type_string_long(&mut machine, b"COPY TESTFILE.TXT HASHDIR\\ONE.TXT\r");
+    run_until_prompt(&mut machine);
+    type_string_long(&mut machine, b"COPY TESTFILE.TXT HASHDIR\\TWO.TXT\r");
+    run_until_prompt(&mut machine);
+
+    type_string(&mut machine.bus, b"CLS\r");
+    run_until_prompt(&mut machine);
+    type_string_long(&mut machine, b"B3SUM HASHDIR\\*.TXT\r");
+    run_until_prompt(&mut machine);
+
+    let expected_digest = digest_hex(TEST_FILE_CONTENT);
+    let one_line = format!("{expected_digest}  HASHDIR\\ONE.TXT");
+    let two_line = format!("{expected_digest}  HASHDIR\\TWO.TXT");
+
+    assert!(
+        find_string_in_text_vram(&machine.bus, &text_codes(&one_line)),
+        "B3SUM should print HASHDIR\\ONE.TXT"
+    );
+    assert!(
+        find_string_in_text_vram(&machine.bus, &text_codes(&two_line)),
+        "B3SUM should print HASHDIR\\TWO.TXT"
+    );
+}
+
+#[test]
+fn b3sum_stops_after_first_error() {
+    let mut machine = boot_hle_with_floppy();
+    type_string(&mut machine.bus, b"A:\r");
+    run_until_prompt(&mut machine);
+
+    type_string_long(&mut machine, b"B3SUM TESTFILE.TXT NOFILE.TXT COMMAND.COM\r");
+    run_until_prompt(&mut machine);
+
+    let testfile_line = format!("{}  TESTFILE.TXT", digest_hex(TEST_FILE_CONTENT));
+    let command_digest = digest_hex(TEST_COMMAND_COM);
+
+    assert!(
+        find_row_containing(&machine.bus, &testfile_line).is_some(),
+        "B3SUM should hash the first valid file before the error"
+    );
+    assert!(
+        find_row_containing(&machine.bus, "File not found").is_some(),
+        "B3SUM should report the first missing file"
+    );
+    assert!(
+        find_row_containing(&machine.bus, &command_digest).is_none(),
+        "B3SUM should stop after the first error"
+    );
+}
+
+#[test]
+fn b3sum_rejects_directories() {
+    let mut machine = boot_hle_with_floppy();
+    type_string(&mut machine.bus, b"A:\r");
+    run_until_prompt(&mut machine);
+
+    type_string(&mut machine.bus, b"MD SUBDIR\r");
+    run_until_prompt(&mut machine);
+    type_string_long(&mut machine, b"B3SUM SUBDIR\r");
+    run_until_prompt(&mut machine);
+
+    assert!(
+        find_row_containing(&machine.bus, "Access denied").is_some(),
+        "B3SUM should reject directory arguments"
+    );
+}
+
+#[test]
+fn b3sum_reports_broken_cluster_chains() {
+    let broken_name = *b"BROKEN  BIN";
+    let floppy = create_broken_chain_floppy_with_name(&broken_name, 4096);
+    let mut machine = boot_hle_with_floppy_image(floppy);
+
+    type_string(&mut machine.bus, b"A:\r");
+    run_until_prompt(&mut machine);
+    type_string_long(&mut machine, b"B3SUM BROKEN.BIN\r");
+    run_until_prompt(&mut machine);
+
+    assert!(
+        find_row_containing(&machine.bus, "Read error").is_some(),
+        "B3SUM should fail on truncated cluster chains"
+    );
+}

--- a/crates/os/tests/dos620/commands_copy.rs
+++ b/crates/os/tests/dos620/commands_copy.rs
@@ -1,4 +1,6 @@
-use crate::harness::*;
+use std::fs;
+
+use crate::{file_copy_repro::*, harness::*};
 
 #[test]
 fn copy_single_file() {
@@ -199,5 +201,50 @@ fn xcopy_recursive() {
     assert!(
         find_string_in_text_vram(&machine.bus, &testfile),
         "XCOPY should have copied TESTFILE.TXT into DSTDIR"
+    );
+}
+
+#[test]
+fn copy_multicluster_file_from_floppy_to_formatted_hdd_without_corruption() {
+    let source_bytes = prng_bytes(RANDOM_FILE_SIZE);
+    let floppy = create_random_file_floppy(&source_bytes);
+
+    let hdd_path = make_temp_hdd_path("copy-repro");
+    let hdd = create_empty_hdd(256);
+    fs::write(&hdd_path, hdd.to_bytes()).expect("write temp HDD image");
+
+    let mut machine = boot_hle_with_temp_hdd_and_floppy(&hdd_path, floppy);
+
+    type_string_long(&mut machine, b"FORMAT A:\r");
+    machine.run_for(10_000_000);
+    type_string(&mut machine.bus, b"Y");
+    run_until_prompt(&mut machine);
+
+    type_string_long(&mut machine, b"COPY /V C:RAND.BIN A:\\\r");
+    run_until_prompt(&mut machine);
+    machine.bus.flush_hdd(0);
+
+    let copied = [0x0063, 0x006F, 0x0070, 0x0069, 0x0065, 0x0064]; // "copied"
+    assert!(
+        find_string_in_text_vram(&machine.bus, &copied),
+        "COPY should report success before the on-disk bytes are checked"
+    );
+
+    let copied_bytes = extract_root_file(&hdd_path, &RANDOM_FILE_FCB)
+        .expect("destination file should be readable");
+    let mismatches = mismatch_offsets(&source_bytes, &copied_bytes, 8);
+
+    assert_eq!(
+        copied_bytes.len(),
+        source_bytes.len(),
+        "copied size mismatch"
+    );
+    assert!(
+        mismatches.is_empty(),
+        "COPY corrupted data: first mismatches at {mismatches:?}"
+    );
+    assert_eq!(
+        copied_bytes, source_bytes,
+        "COPY should preserve file contents"
     );
 }

--- a/crates/os/tests/dos620/commands_copy.rs
+++ b/crates/os/tests/dos620/commands_copy.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use crate::{file_copy_repro::*, harness::*};
+use crate::{file_copy_harness::*, harness::*};
 
 #[test]
 fn copy_single_file() {
@@ -246,5 +246,79 @@ fn copy_multicluster_file_from_floppy_to_formatted_hdd_without_corruption() {
     assert_eq!(
         copied_bytes, source_bytes,
         "COPY should preserve file contents"
+    );
+}
+
+#[test]
+fn copy_explicit_destination_path_uses_basename() {
+    let source_bytes = prng_bytes(RANDOM_FILE_SIZE);
+    let source_name = *b"COPYONE BIN";
+    let destination_name = *b"TARGET  BIN";
+    let floppy = create_random_file_floppy_with_name(&source_name, &source_bytes);
+
+    let hdd_path = make_temp_hdd_path("copy-destination-path");
+    let hdd = create_empty_hdd(256);
+    fs::write(&hdd_path, hdd.to_bytes()).expect("write temp HDD image");
+
+    let mut machine = boot_hle_with_temp_hdd_and_floppy(&hdd_path, floppy);
+
+    type_string_long(&mut machine, b"FORMAT A:\r");
+    machine.run_for(10_000_000);
+    type_string(&mut machine.bus, b"Y");
+    run_until_prompt(&mut machine);
+
+    type_string_long(&mut machine, b"COPY /V C:COPYONE.BIN A:\\TARGET.BIN\r");
+    run_until_prompt(&mut machine);
+    machine.bus.flush_hdd(0);
+
+    let copied_bytes = extract_root_file(&hdd_path, &destination_name)
+        .expect("destination file should be created with the explicit basename");
+    let mismatches = mismatch_offsets(&source_bytes, &copied_bytes, 8);
+
+    assert_eq!(
+        copied_bytes.len(),
+        source_bytes.len(),
+        "copy with explicit destination path should preserve file size"
+    );
+    assert!(
+        mismatches.is_empty(),
+        "copy with explicit destination path mismatches at {mismatches:?}"
+    );
+    assert_eq!(
+        copied_bytes, source_bytes,
+        "copy with explicit destination path should preserve file contents"
+    );
+}
+
+#[test]
+fn copy_broken_source_chain_reports_read_error() {
+    let broken_name = *b"BROKEN  BIN";
+    let floppy = create_broken_chain_floppy_with_name(&broken_name, 4096);
+
+    let hdd_path = make_temp_hdd_path("copy-broken-chain");
+    let hdd = create_empty_hdd(256);
+    fs::write(&hdd_path, hdd.to_bytes()).expect("write temp HDD image");
+
+    let mut machine = boot_hle_with_temp_hdd_and_floppy(&hdd_path, floppy);
+
+    type_string_long(&mut machine, b"FORMAT A:\r");
+    machine.run_for(10_000_000);
+    type_string(&mut machine.bus, b"Y");
+    run_until_prompt(&mut machine);
+
+    type_string_long(&mut machine, b"COPY C:BROKEN.BIN A:\\BROKEN.BIN\r");
+    run_until_prompt(&mut machine);
+    machine.bus.flush_hdd(0);
+
+    let read_error = [
+        0x0052, 0x0065, 0x0061, 0x0064, 0x0020, 0x0065, 0x0072, 0x0072, 0x006F, 0x0072,
+    ]; // "Read error"
+    assert!(
+        find_string_in_text_vram(&machine.bus, &read_error),
+        "COPY should report a read error for a truncated source chain"
+    );
+    assert!(
+        extract_root_file(&hdd_path, &broken_name).is_err(),
+        "COPY should not create a destination file after a read error"
     );
 }

--- a/crates/os/tests/dos620/commands_dir.rs
+++ b/crates/os/tests/dos620/commands_dir.rs
@@ -25,6 +25,22 @@ fn dir_basic_listing() {
 }
 
 #[test]
+fn dir_lists_cdrom_root() {
+    let mut machine = boot_hle_with_cdrom();
+    type_string(&mut machine.bus, b"Q:\r");
+    run_until_prompt_ap(&mut machine);
+
+    type_string(&mut machine.bus, b"DIR\r");
+    run_until_prompt_ap(&mut machine);
+
+    let readme = [0x0052, 0x0045, 0x0041, 0x0044, 0x004D, 0x0045]; // "README"
+    assert!(
+        find_string_in_text_vram(&machine.bus, &readme),
+        "DIR on Q: should list README.TXT from the synthetic CD-ROM"
+    );
+}
+
+#[test]
 fn dir_wildcard_txt() {
     let mut machine = boot_hle_with_floppy();
     type_string(&mut machine.bus, b"A:\r");

--- a/crates/os/tests/dos620/commands_dosmock.rs
+++ b/crates/os/tests/dos620/commands_dosmock.rs
@@ -1,0 +1,201 @@
+use crate::harness::*;
+
+static EXPECTED_STUB: &[u8] = include_bytes!("../../../../utils/os/os.rom");
+
+fn open_file_raw(machine: &mut machine::Pc9801Ra, filename: &[u8]) -> (u16, u16) {
+    let path_addr = INJECT_CODE_BASE + 0x200;
+    write_bytes(&mut machine.bus, path_addr, filename);
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xB4, 0x3D,
+        0xB0, 0x00,
+        0xBA, 0x00, 0x02,
+        0xCD, 0x21,
+        0xA3, 0x00, 0x01,
+        0x9C,
+        0x58,
+        0xA3, 0x02, 0x01,
+        0xFA,
+        0xF4,
+    ];
+    inject_and_run_with_budget(machine, code, INJECT_BUDGET_DISK_IO);
+    (result_word(&machine.bus, 0), result_word(&machine.bus, 2))
+}
+
+fn read_file(machine: &mut machine::Pc9801Ra, filename: &[u8], count: u16) -> Vec<u8> {
+    let path_addr = INJECT_CODE_BASE + 0x200;
+    write_bytes(&mut machine.bus, path_addr, filename);
+    let count_lo = (count & 0xFF) as u8;
+    let count_hi = (count >> 8) as u8;
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xB4, 0x3D,
+        0xB0, 0x00,
+        0xBA, 0x00, 0x02,
+        0xCD, 0x21,
+        0x89, 0xC3,
+        0xB9, count_lo, count_hi,
+        0xBA, 0x00, 0x03,
+        0xB4, 0x3F,
+        0xCD, 0x21,
+        0xA3, 0x00, 0x01,
+        0x53,
+        0xBB, 0x00, 0x00,
+        0x58,
+        0x93,
+        0xB4, 0x3E,
+        0xCD, 0x21,
+        0xFA,
+        0xF4,
+    ];
+    inject_and_run_with_budget(machine, code, INJECT_BUDGET_DISK_IO);
+    let bytes_read = result_word(&machine.bus, 0) as usize;
+    read_bytes(&machine.bus, INJECT_CODE_BASE + 0x300, bytes_read)
+}
+
+fn get_file_attributes(machine: &mut machine::Pc9801Ra, filename: &[u8]) -> (u8, u16) {
+    let path_addr = INJECT_CODE_BASE + 0x200;
+    write_bytes(&mut machine.bus, path_addr, filename);
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xB4, 0x43,
+        0xB0, 0x00,
+        0xBA, 0x00, 0x02,
+        0xCD, 0x21,
+        0x89, 0x0E, 0x00, 0x01,
+        0x9C,
+        0x58,
+        0xA3, 0x02, 0x01,
+        0xFA,
+        0xF4,
+    ];
+    inject_and_run_with_budget(machine, code, INJECT_BUDGET_DISK_IO);
+    (result_byte(&machine.bus, 0), result_word(&machine.bus, 2))
+}
+
+#[test]
+fn dosmock_creates_mock_dos_files_on_formatted_hdd() {
+    let mut machine = boot_hle_with_empty_sasi_hdd();
+
+    type_string_long(&mut machine, b"FORMAT A:\r");
+    machine.run_for(10_000_000);
+    type_string(&mut machine.bus, b"Y");
+    run_until_prompt(&mut machine);
+
+    type_string_long(&mut machine, b"DOSMOCK A:\r");
+    run_until_prompt(&mut machine);
+
+    let (io_attributes, io_flags) = get_file_attributes(&mut machine, b"A:\\IO.SYS\0");
+    assert_eq!(
+        io_flags & 0x0001,
+        0,
+        "IO.SYS attribute query should succeed"
+    );
+    assert_eq!(
+        io_attributes & (0x01 | 0x02 | 0x04),
+        0x01 | 0x02 | 0x04,
+        "IO.SYS should be read-only, hidden, and system"
+    );
+    let (io_open_result, io_open_flags) = open_file_raw(&mut machine, b"A:\\IO.SYS\0");
+    assert_eq!(
+        io_open_flags & 0x0001,
+        0,
+        "IO.SYS should exist and open successfully, flags={:#06X}, AX={:#06X}",
+        io_open_flags,
+        io_open_result
+    );
+
+    let (msdos_attributes, msdos_flags) = get_file_attributes(&mut machine, b"A:\\MSDOS.SYS\0");
+    assert_eq!(
+        msdos_flags & 0x0001,
+        0,
+        "MSDOS.SYS attribute query should succeed"
+    );
+    assert_eq!(
+        msdos_attributes & (0x01 | 0x02 | 0x04),
+        0x01 | 0x02 | 0x04,
+        "MSDOS.SYS should be read-only, hidden, and system"
+    );
+    let (msdos_open_result, msdos_open_flags) = open_file_raw(&mut machine, b"A:\\MSDOS.SYS\0");
+    assert_eq!(
+        msdos_open_flags & 0x0001,
+        0,
+        "MSDOS.SYS should exist and open successfully, flags={:#06X}, AX={:#06X}",
+        msdos_open_flags,
+        msdos_open_result
+    );
+
+    let (command_attributes, command_flags) =
+        get_file_attributes(&mut machine, b"A:\\COMMAND.COM\0");
+    assert_eq!(
+        command_flags & 0x0001,
+        0,
+        "COMMAND.COM attribute query should succeed"
+    );
+    assert_eq!(
+        command_attributes & (0x01 | 0x20),
+        0x01 | 0x20,
+        "COMMAND.COM should be read-only and archive"
+    );
+
+    let io_contents = read_file(&mut machine, b"A:\\IO.SYS\0", 1);
+    assert!(io_contents.is_empty(), "IO.SYS should be zero-byte");
+
+    let msdos_contents = read_file(&mut machine, b"A:\\MSDOS.SYS\0", 1);
+    assert!(msdos_contents.is_empty(), "MSDOS.SYS should be zero-byte");
+
+    let command_contents = read_file(
+        &mut machine,
+        b"A:\\COMMAND.COM\0",
+        EXPECTED_STUB.len() as u16,
+    );
+    assert_eq!(
+        command_contents, EXPECTED_STUB,
+        "COMMAND.COM should use the same stub as the virtual drive"
+    );
+}
+
+#[test]
+fn dosmock_aborts_before_writing_if_any_target_exists() {
+    let mut machine = boot_hle_with_empty_sasi_hdd();
+
+    type_string_long(&mut machine, b"FORMAT A:\r");
+    machine.run_for(10_000_000);
+    type_string(&mut machine.bus, b"Y");
+    run_until_prompt(&mut machine);
+
+    type_string_long(&mut machine, b"ECHO X > A:\\IO.SYS\r");
+    run_until_prompt(&mut machine);
+
+    type_string_long(&mut machine, b"DOSMOCK A:\r");
+    run_until_prompt(&mut machine);
+
+    let exists = [
+        0x0061, 0x006C, 0x0072, 0x0065, 0x0061, 0x0064, 0x0079, 0x0020, 0x0065, 0x0078, 0x0069,
+        0x0073, 0x0074,
+    ];
+    assert!(
+        find_string_in_text_vram(&machine.bus, &exists),
+        "DOSMOCK should report that mock files already exist"
+    );
+
+    let io_contents = read_file(&mut machine, b"A:\\IO.SYS\0", 8);
+    assert_eq!(
+        io_contents, b"X\r\n",
+        "Existing IO.SYS should remain unchanged after DOSMOCK aborts"
+    );
+
+    let (_, msdos_flags) = open_file_raw(&mut machine, b"A:\\MSDOS.SYS\0");
+    assert_ne!(
+        msdos_flags & 0x0001,
+        0,
+        "MSDOS.SYS should not be created when DOSMOCK aborts"
+    );
+
+    let (_, command_flags) = open_file_raw(&mut machine, b"A:\\COMMAND.COM\0");
+    assert_ne!(
+        command_flags & 0x0001,
+        0,
+        "COMMAND.COM should not be created when DOSMOCK aborts"
+    );
+}

--- a/crates/os/tests/dos620/commands_format.rs
+++ b/crates/os/tests/dos620/commands_format.rs
@@ -1,4 +1,6 @@
-use crate::harness::*;
+use std::fs;
+
+use crate::{file_copy_repro::*, harness::*};
 
 #[test]
 fn format_floppy_shows_complete() {
@@ -199,5 +201,44 @@ fn format_hdd_then_copy_file() {
     assert!(
         find_string_in_text_vram(&machine.bus, &test_txt),
         "DIR A: should show TEST file after creating it on formatted HDD"
+    );
+}
+
+#[test]
+fn format_sasi_hdd_supports_multicluster_file_copy_after_format() {
+    let source_bytes = prng_bytes(RANDOM_FILE_SIZE);
+    let floppy = create_random_file_floppy(&source_bytes);
+
+    let hdd_path = make_temp_hdd_path("format-repro");
+    let hdd = create_empty_hdd(256);
+    fs::write(&hdd_path, hdd.to_bytes()).expect("write temp HDD image");
+
+    let mut machine = boot_hle_with_temp_hdd_and_floppy(&hdd_path, floppy);
+
+    type_string_long(&mut machine, b"FORMAT A:\r");
+    machine.run_for(10_000_000);
+    type_string(&mut machine.bus, b"Y");
+    run_until_prompt(&mut machine);
+
+    type_string_long(&mut machine, b"COPY C:RAND.BIN A:\\\r");
+    run_until_prompt(&mut machine);
+    machine.bus.flush_hdd(0);
+
+    let copied_bytes = extract_root_file(&hdd_path, &RANDOM_FILE_FCB)
+        .expect("destination file should be readable");
+    let mismatches = mismatch_offsets(&source_bytes, &copied_bytes, 8);
+
+    assert_eq!(
+        copied_bytes.len(),
+        source_bytes.len(),
+        "formatted HDD should preserve copied file size"
+    );
+    assert!(
+        mismatches.is_empty(),
+        "formatted HDD corrupted copied data: first mismatches at {mismatches:?}"
+    );
+    assert_eq!(
+        copied_bytes, source_bytes,
+        "formatted HDD should preserve copied file contents"
     );
 }

--- a/crates/os/tests/dos620/commands_format.rs
+++ b/crates/os/tests/dos620/commands_format.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use crate::{file_copy_repro::*, harness::*};
+use crate::{file_copy_harness::*, harness::*};
 
 #[test]
 fn format_floppy_shows_complete() {

--- a/crates/os/tests/dos620/commands_xcopy.rs
+++ b/crates/os/tests/dos620/commands_xcopy.rs
@@ -1,0 +1,48 @@
+use std::fs;
+
+use crate::{file_copy_repro::*, harness::*};
+
+#[test]
+fn xcopy_copies_multicluster_file() {
+    let source_bytes = prng_bytes(RANDOM_FILE_SIZE);
+    let floppy = create_random_file_floppy(&source_bytes);
+
+    let hdd_path = make_temp_hdd_path("xcopy-repro");
+    let hdd = create_empty_hdd(256);
+    fs::write(&hdd_path, hdd.to_bytes()).expect("write temp HDD image");
+
+    let mut machine = boot_hle_with_temp_hdd_and_floppy(&hdd_path, floppy);
+
+    type_string_long(&mut machine, b"FORMAT A:\r");
+    machine.run_for(10_000_000);
+    type_string(&mut machine.bus, b"Y");
+    run_until_prompt(&mut machine);
+
+    type_string_long(&mut machine, b"XCOPY C:RAND.BIN A:\\\r");
+    run_until_prompt(&mut machine);
+    machine.bus.flush_hdd(0);
+
+    let copied = [0x0063, 0x006F, 0x0070, 0x0069, 0x0065, 0x0064]; // "copied"
+    assert!(
+        find_string_in_text_vram(&machine.bus, &copied),
+        "XCOPY should report success before the on-disk bytes are checked"
+    );
+
+    let copied_bytes = extract_root_file(&hdd_path, &RANDOM_FILE_FCB)
+        .expect("destination file should be readable");
+    let mismatches = mismatch_offsets(&source_bytes, &copied_bytes, 8);
+
+    assert_eq!(
+        copied_bytes.len(),
+        source_bytes.len(),
+        "copied size mismatch"
+    );
+    assert!(
+        mismatches.is_empty(),
+        "XCOPY corrupted data: first mismatches at {mismatches:?}"
+    );
+    assert_eq!(
+        copied_bytes, source_bytes,
+        "XCOPY should preserve file contents"
+    );
+}

--- a/crates/os/tests/dos620/commands_xcopy.rs
+++ b/crates/os/tests/dos620/commands_xcopy.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use crate::{file_copy_repro::*, harness::*};
+use crate::{file_copy_harness::*, harness::*};
 
 #[test]
 fn xcopy_copies_multicluster_file() {
@@ -44,5 +44,38 @@ fn xcopy_copies_multicluster_file() {
     assert_eq!(
         copied_bytes, source_bytes,
         "XCOPY should preserve file contents"
+    );
+}
+
+#[test]
+fn xcopy_broken_source_chain_reports_read_error() {
+    let broken_name = *b"BROKEN  BIN";
+    let floppy = create_broken_chain_floppy_with_name(&broken_name, 4096);
+
+    let hdd_path = make_temp_hdd_path("xcopy-broken-chain");
+    let hdd = create_empty_hdd(256);
+    fs::write(&hdd_path, hdd.to_bytes()).expect("write temp HDD image");
+
+    let mut machine = boot_hle_with_temp_hdd_and_floppy(&hdd_path, floppy);
+
+    type_string_long(&mut machine, b"FORMAT A:\r");
+    machine.run_for(10_000_000);
+    type_string(&mut machine.bus, b"Y");
+    run_until_prompt(&mut machine);
+
+    type_string_long(&mut machine, b"XCOPY C:BROKEN.BIN A:\\\r");
+    run_until_prompt(&mut machine);
+    machine.bus.flush_hdd(0);
+
+    let read_error = [
+        0x0052, 0x0065, 0x0061, 0x0064, 0x0020, 0x0065, 0x0072, 0x0072, 0x006F, 0x0072,
+    ]; // "Read error"
+    assert!(
+        find_string_in_text_vram(&machine.bus, &read_error),
+        "XCOPY should report a read error for a truncated source chain"
+    );
+    assert!(
+        extract_root_file(&hdd_path, &broken_name).is_err(),
+        "XCOPY should not create a destination file after a read error"
     );
 }

--- a/crates/os/tests/dos620/escape_sequences.rs
+++ b/crates/os/tests/dos620/escape_sequences.rs
@@ -1,0 +1,118 @@
+use crate::harness;
+
+const IOSYS_CURSOR_Y: u32 = 0x0600 + 0x0110;
+const IOSYS_CURSOR_X: u32 = 0x0600 + 0x011C;
+const TEXT_CHAR_BASE: u32 = 0xA0000;
+const TEXT_ATTR_BASE: u32 = 0xA2000;
+const COLUMNS: u32 = 80;
+
+fn write_ascii_text(machine: &mut machine::Pc9801Ra, row: u32, col: u32, text: &str) {
+    for (index, byte) in text.bytes().enumerate() {
+        let offset = (row * COLUMNS + col + index as u32) * 2;
+        harness::write_bytes(&mut machine.bus, TEXT_CHAR_BASE + offset, &[byte, 0x00]);
+        harness::write_bytes(&mut machine.bus, TEXT_ATTR_BASE + offset, &[0xE1, 0x00]);
+    }
+}
+
+fn set_cursor(machine: &mut machine::Pc9801Ra, row: u8, col: u8) {
+    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_Y, &[row]);
+    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_X, &[col]);
+}
+
+fn cursor(machine: &machine::Pc9801Ra) -> (u8, u8) {
+    (
+        machine.bus.read_byte_direct(IOSYS_CURSOR_Y),
+        machine.bus.read_byte_direct(IOSYS_CURSOR_X),
+    )
+}
+
+fn emit_int29_bytes(machine: &mut machine::Pc9801Ra, bytes: &[u8]) {
+    let mut code = Vec::with_capacity(bytes.len() * 4 + 2);
+    for &byte in bytes {
+        code.extend_from_slice(&[0xB0, byte, 0xCD, 0x29]);
+    }
+    code.extend_from_slice(&[0xFA, 0xF4]);
+    harness::inject_and_run(machine, &code);
+}
+
+#[test]
+fn esc_d_moves_cursor_down_preserving_column_via_int29h() {
+    let mut machine = harness::boot_hle();
+    set_cursor(&mut machine, 5, 10);
+
+    emit_int29_bytes(&mut machine, &[0x1B, b'D']);
+
+    assert_eq!(cursor(&machine), (6, 10));
+}
+
+#[test]
+fn esc_e_moves_cursor_to_next_line_start_via_int29h() {
+    let mut machine = harness::boot_hle();
+    set_cursor(&mut machine, 5, 10);
+
+    emit_int29_bytes(&mut machine, &[0x1B, b'E']);
+
+    assert_eq!(cursor(&machine), (6, 0));
+}
+
+#[test]
+fn esc_m_moves_cursor_up_preserving_column_via_int29h() {
+    let mut machine = harness::boot_hle();
+    set_cursor(&mut machine, 5, 10);
+
+    emit_int29_bytes(&mut machine, &[0x1B, b'M']);
+
+    assert_eq!(cursor(&machine), (4, 10));
+}
+
+#[test]
+fn esc_d_scrolls_at_bottom_via_int29h() {
+    let mut machine = harness::boot_hle();
+    write_ascii_text(&mut machine, 23, 0, "BOTTOM-23");
+    write_ascii_text(&mut machine, 24, 0, "BOTTOM-24");
+    set_cursor(&mut machine, 24, 7);
+
+    emit_int29_bytes(&mut machine, &[0x1B, b'D']);
+
+    assert_eq!(cursor(&machine), (24, 7));
+    assert!(harness::text_vram_row_to_string(&machine.bus, 23).contains("BOTTOM-24"));
+    assert!(
+        harness::text_vram_row_to_string(&machine.bus, 24)
+            .trim()
+            .is_empty()
+    );
+}
+
+#[test]
+fn esc_e_scrolls_at_bottom_and_resets_column_via_int29h() {
+    let mut machine = harness::boot_hle();
+    write_ascii_text(&mut machine, 24, 0, "BOTTOM-E");
+    set_cursor(&mut machine, 24, 7);
+
+    emit_int29_bytes(&mut machine, &[0x1B, b'E']);
+
+    assert_eq!(cursor(&machine), (24, 0));
+    assert!(harness::text_vram_row_to_string(&machine.bus, 23).contains("BOTTOM-E"));
+    assert!(
+        harness::text_vram_row_to_string(&machine.bus, 24)
+            .trim()
+            .is_empty()
+    );
+}
+
+#[test]
+fn esc_m_scrolls_at_top_via_int29h() {
+    let mut machine = harness::boot_hle();
+    write_ascii_text(&mut machine, 0, 0, "TOP-M");
+    set_cursor(&mut machine, 0, 7);
+
+    emit_int29_bytes(&mut machine, &[0x1B, b'M']);
+
+    assert_eq!(cursor(&machine), (0, 7));
+    assert!(
+        harness::text_vram_row_to_string(&machine.bus, 0)
+            .trim()
+            .is_empty()
+    );
+    assert!(harness::text_vram_row_to_string(&machine.bus, 1).contains("TOP-M"));
+}

--- a/crates/os/tests/dos620/file_copy_harness.rs
+++ b/crates/os/tests/dos620/file_copy_harness.rs
@@ -8,7 +8,7 @@ use common::Bus;
 use device::{
     disk::{self, HddImage},
     floppy::{
-        self, FloppyImage,
+        FloppyImage,
         d88::{D88Disk, D88MediaType, D88Sector},
     },
 };
@@ -56,6 +56,10 @@ fn set_fat12_entry(fat: &mut [u8], cluster: u16, value: u16) {
 }
 
 pub fn create_random_file_floppy(file_data: &[u8]) -> FloppyImage {
+    create_random_file_floppy_with_name(&RANDOM_FILE_FCB, file_data)
+}
+
+pub fn create_random_file_floppy_with_name(fcb_name: &[u8; 11], file_data: &[u8]) -> FloppyImage {
     let cylinders = 77usize;
     let heads = 2usize;
     let sectors_per_track = 8usize;
@@ -126,7 +130,7 @@ pub fn create_random_file_floppy(file_data: &[u8]) -> FloppyImage {
     }
     {
         let entry = &mut disk_data[root_offset + 64..root_offset + 96];
-        entry[0..11].copy_from_slice(&RANDOM_FILE_FCB);
+        entry[0..11].copy_from_slice(fcb_name);
         entry[11] = 0x20;
         entry[22..24].copy_from_slice(&TEST_FILE_TIME.to_le_bytes());
         entry[24..26].copy_from_slice(&TEST_FILE_DATE.to_le_bytes());
@@ -172,7 +176,118 @@ pub fn create_random_file_floppy(file_data: &[u8]) -> FloppyImage {
     }
 
     let d88 = D88Disk::from_tracks("XRAND".to_string(), false, D88MediaType::Disk2HD, tracks);
-    floppy::FloppyImage::from_d88(d88)
+    FloppyImage::from_d88(d88)
+}
+
+pub fn create_broken_chain_floppy_with_name(
+    fcb_name: &[u8; 11],
+    advertised_size: usize,
+) -> FloppyImage {
+    let first_cluster_data = prng_bytes(1024);
+    let cylinders = 77usize;
+    let heads = 2usize;
+    let sectors_per_track = 8usize;
+    let sector_size = 1024usize;
+    let total_tracks = cylinders * heads;
+    let total_sectors = cylinders * heads * sectors_per_track;
+    let mut disk_data = vec![0u8; total_sectors * sector_size];
+
+    {
+        let bpb = &mut disk_data[0..sector_size];
+        bpb[0] = 0xEB;
+        bpb[1] = 0x3C;
+        bpb[2] = 0x90;
+        bpb[3..11].copy_from_slice(b"NEETAN  ");
+        bpb[11..13].copy_from_slice(&1024u16.to_le_bytes());
+        bpb[13] = 1;
+        bpb[14..16].copy_from_slice(&1u16.to_le_bytes());
+        bpb[16] = 2;
+        bpb[17..19].copy_from_slice(&192u16.to_le_bytes());
+        bpb[19..21].copy_from_slice(&1232u16.to_le_bytes());
+        bpb[21] = 0xFE;
+        bpb[22..24].copy_from_slice(&2u16.to_le_bytes());
+        bpb[24..26].copy_from_slice(&8u16.to_le_bytes());
+        bpb[26..28].copy_from_slice(&2u16.to_le_bytes());
+    }
+
+    let fat1_offset = sector_size;
+    let fat = &mut disk_data[fat1_offset..fat1_offset + 2 * sector_size];
+    fat[0] = 0xFE;
+    fat[1] = 0xFF;
+    fat[2] = 0xFF;
+    set_fat12_entry(fat, 2, FAT12_EOC);
+    set_fat12_entry(fat, 3, FAT12_EOC);
+    set_fat12_entry(fat, 4, FAT12_EOC);
+
+    let fat2_offset = 3 * sector_size;
+    let fat_copy = disk_data[fat1_offset..fat1_offset + 2 * sector_size].to_vec();
+    disk_data[fat2_offset..fat2_offset + fat_copy.len()].copy_from_slice(&fat_copy);
+
+    let root_offset = 5 * sector_size;
+    {
+        let entry = &mut disk_data[root_offset..root_offset + 32];
+        entry[0..11].copy_from_slice(b"COMMAND COM");
+        entry[11] = 0x20;
+        entry[22..24].copy_from_slice(&TEST_FILE_TIME.to_le_bytes());
+        entry[24..26].copy_from_slice(&TEST_FILE_DATE.to_le_bytes());
+        entry[26..28].copy_from_slice(&2u16.to_le_bytes());
+        entry[28..32].copy_from_slice(&(TEST_COMMAND_COM.len() as u32).to_le_bytes());
+    }
+    {
+        let entry = &mut disk_data[root_offset + 32..root_offset + 64];
+        entry[0..11].copy_from_slice(b"TESTFILETXT");
+        entry[11] = 0x20;
+        entry[22..24].copy_from_slice(&TEST_FILE_TIME.to_le_bytes());
+        entry[24..26].copy_from_slice(&TEST_FILE_DATE.to_le_bytes());
+        entry[26..28].copy_from_slice(&3u16.to_le_bytes());
+        entry[28..32].copy_from_slice(&(TEST_FILE_CONTENT.len() as u32).to_le_bytes());
+    }
+    {
+        let entry = &mut disk_data[root_offset + 64..root_offset + 96];
+        entry[0..11].copy_from_slice(fcb_name);
+        entry[11] = 0x20;
+        entry[22..24].copy_from_slice(&TEST_FILE_TIME.to_le_bytes());
+        entry[24..26].copy_from_slice(&TEST_FILE_DATE.to_le_bytes());
+        entry[26..28].copy_from_slice(&4u16.to_le_bytes());
+        entry[28..32].copy_from_slice(&(advertised_size as u32).to_le_bytes());
+    }
+
+    let cluster2_offset = 11 * sector_size;
+    disk_data[cluster2_offset..cluster2_offset + TEST_COMMAND_COM.len()]
+        .copy_from_slice(TEST_COMMAND_COM);
+    let cluster3_offset = 12 * sector_size;
+    disk_data[cluster3_offset..cluster3_offset + TEST_FILE_CONTENT.len()]
+        .copy_from_slice(TEST_FILE_CONTENT);
+    let cluster4_offset = 13 * sector_size;
+    disk_data[cluster4_offset..cluster4_offset + first_cluster_data.len()]
+        .copy_from_slice(&first_cluster_data);
+
+    let mut tracks = Vec::with_capacity(total_tracks);
+    for track_index in 0..total_tracks {
+        let cylinder = (track_index / heads) as u8;
+        let head = (track_index % heads) as u8;
+        let mut sectors = Vec::with_capacity(sectors_per_track);
+        for sector in 0..sectors_per_track {
+            let lba = track_index * sectors_per_track + sector;
+            let offset = lba * sector_size;
+            sectors.push(D88Sector {
+                cylinder,
+                head,
+                record: (sector + 1) as u8,
+                size_code: 3,
+                sector_count: sectors_per_track as u16,
+                mfm_flag: 0x40,
+                deleted: 0,
+                status: 0,
+                reserved: [0; 5],
+                data: disk_data[offset..offset + sector_size].to_vec(),
+            });
+        }
+        tracks.push(Some(sectors));
+    }
+
+    let d88 = D88Disk::from_tracks("BROKEN".to_string(), false, D88MediaType::Disk2HD, tracks);
+    FloppyImage::from_d88(d88)
 }
 
 pub fn make_temp_hdd_path(prefix: &str) -> PathBuf {

--- a/crates/os/tests/dos620/file_copy_repro.rs
+++ b/crates/os/tests/dos620/file_copy_repro.rs
@@ -1,0 +1,389 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use common::Bus;
+use device::{
+    disk::{self, HddImage},
+    floppy::{
+        self, FloppyImage,
+        d88::{D88Disk, D88MediaType, D88Sector},
+    },
+};
+
+use crate::harness::*;
+
+pub const RANDOM_FILE_FCB: [u8; 11] = *b"RAND    BIN";
+pub const RANDOM_FILE_SIZE: usize = 0x4977;
+const FAT12_EOC: u16 = 0x0FFF;
+
+#[derive(Debug, Clone, Copy)]
+struct BpbInfo {
+    partition_offset: u32,
+    bytes_per_sector: u16,
+    sectors_per_cluster: u8,
+    reserved_sectors: u16,
+    num_fats: u8,
+    root_entry_count: u16,
+    sectors_per_fat: u16,
+    is_fat16: bool,
+}
+
+pub fn prng_bytes(len: usize) -> Vec<u8> {
+    let mut state = 0x1234_5678u32;
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        out.push((state >> 16) as u8);
+    }
+    out
+}
+
+fn set_fat12_entry(fat: &mut [u8], cluster: u16, value: u16) {
+    let value = value & 0x0FFF;
+    let offset = (cluster as usize * 3) / 2;
+    if cluster & 1 == 0 {
+        fat[offset] = (value & 0x00FF) as u8;
+        fat[offset + 1] = (fat[offset + 1] & 0xF0) | ((value >> 8) as u8 & 0x0F);
+    } else {
+        fat[offset] = (fat[offset] & 0x0F) | (((value << 4) as u8) & 0xF0);
+        fat[offset + 1] = (value >> 4) as u8;
+    }
+}
+
+pub fn create_random_file_floppy(file_data: &[u8]) -> FloppyImage {
+    let cylinders = 77usize;
+    let heads = 2usize;
+    let sectors_per_track = 8usize;
+    let sector_size = 1024usize;
+    let total_tracks = cylinders * heads;
+    let total_sectors = cylinders * heads * sectors_per_track;
+    let mut disk_data = vec![0u8; total_sectors * sector_size];
+
+    {
+        let bpb = &mut disk_data[0..sector_size];
+        bpb[0] = 0xEB;
+        bpb[1] = 0x3C;
+        bpb[2] = 0x90;
+        bpb[3..11].copy_from_slice(b"NEETAN  ");
+        bpb[11..13].copy_from_slice(&1024u16.to_le_bytes());
+        bpb[13] = 1;
+        bpb[14..16].copy_from_slice(&1u16.to_le_bytes());
+        bpb[16] = 2;
+        bpb[17..19].copy_from_slice(&192u16.to_le_bytes());
+        bpb[19..21].copy_from_slice(&1232u16.to_le_bytes());
+        bpb[21] = 0xFE;
+        bpb[22..24].copy_from_slice(&2u16.to_le_bytes());
+        bpb[24..26].copy_from_slice(&8u16.to_le_bytes());
+        bpb[26..28].copy_from_slice(&2u16.to_le_bytes());
+    }
+
+    let fat1_offset = sector_size;
+    let fat = &mut disk_data[fat1_offset..fat1_offset + 2 * sector_size];
+    fat[0] = 0xFE;
+    fat[1] = 0xFF;
+    fat[2] = 0xFF;
+    set_fat12_entry(fat, 2, FAT12_EOC);
+    set_fat12_entry(fat, 3, FAT12_EOC);
+
+    let random_cluster_count = file_data.len().div_ceil(sector_size);
+    for index in 0..random_cluster_count {
+        let cluster = 4 + index as u16;
+        let next = if index + 1 == random_cluster_count {
+            FAT12_EOC
+        } else {
+            cluster + 1
+        };
+        set_fat12_entry(fat, cluster, next);
+    }
+
+    let fat2_offset = 3 * sector_size;
+    let fat_copy = disk_data[fat1_offset..fat1_offset + 2 * sector_size].to_vec();
+    disk_data[fat2_offset..fat2_offset + fat_copy.len()].copy_from_slice(&fat_copy);
+
+    let root_offset = 5 * sector_size;
+    {
+        let entry = &mut disk_data[root_offset..root_offset + 32];
+        entry[0..11].copy_from_slice(b"COMMAND COM");
+        entry[11] = 0x20;
+        entry[22..24].copy_from_slice(&TEST_FILE_TIME.to_le_bytes());
+        entry[24..26].copy_from_slice(&TEST_FILE_DATE.to_le_bytes());
+        entry[26..28].copy_from_slice(&2u16.to_le_bytes());
+        entry[28..32].copy_from_slice(&(TEST_COMMAND_COM.len() as u32).to_le_bytes());
+    }
+    {
+        let entry = &mut disk_data[root_offset + 32..root_offset + 64];
+        entry[0..11].copy_from_slice(b"TESTFILETXT");
+        entry[11] = 0x20;
+        entry[22..24].copy_from_slice(&TEST_FILE_TIME.to_le_bytes());
+        entry[24..26].copy_from_slice(&TEST_FILE_DATE.to_le_bytes());
+        entry[26..28].copy_from_slice(&3u16.to_le_bytes());
+        entry[28..32].copy_from_slice(&(TEST_FILE_CONTENT.len() as u32).to_le_bytes());
+    }
+    {
+        let entry = &mut disk_data[root_offset + 64..root_offset + 96];
+        entry[0..11].copy_from_slice(&RANDOM_FILE_FCB);
+        entry[11] = 0x20;
+        entry[22..24].copy_from_slice(&TEST_FILE_TIME.to_le_bytes());
+        entry[24..26].copy_from_slice(&TEST_FILE_DATE.to_le_bytes());
+        entry[26..28].copy_from_slice(&4u16.to_le_bytes());
+        entry[28..32].copy_from_slice(&(file_data.len() as u32).to_le_bytes());
+    }
+
+    let cluster2_offset = 11 * sector_size;
+    disk_data[cluster2_offset..cluster2_offset + TEST_COMMAND_COM.len()]
+        .copy_from_slice(TEST_COMMAND_COM);
+    let cluster3_offset = 12 * sector_size;
+    disk_data[cluster3_offset..cluster3_offset + TEST_FILE_CONTENT.len()]
+        .copy_from_slice(TEST_FILE_CONTENT);
+
+    for (index, chunk) in file_data.chunks(sector_size).enumerate() {
+        let lba = 13 + index;
+        let offset = lba * sector_size;
+        disk_data[offset..offset + chunk.len()].copy_from_slice(chunk);
+    }
+
+    let mut tracks = Vec::with_capacity(total_tracks);
+    for track_index in 0..total_tracks {
+        let cylinder = (track_index / heads) as u8;
+        let head = (track_index % heads) as u8;
+        let mut sectors = Vec::with_capacity(sectors_per_track);
+        for sector in 0..sectors_per_track {
+            let lba = track_index * sectors_per_track + sector;
+            let offset = lba * sector_size;
+            sectors.push(D88Sector {
+                cylinder,
+                head,
+                record: (sector + 1) as u8,
+                size_code: 3,
+                sector_count: sectors_per_track as u16,
+                mfm_flag: 0x40,
+                deleted: 0,
+                status: 0,
+                reserved: [0; 5],
+                data: disk_data[offset..offset + sector_size].to_vec(),
+            });
+        }
+        tracks.push(Some(sectors));
+    }
+
+    let d88 = D88Disk::from_tracks("XRAND".to_string(), false, D88MediaType::Disk2HD, tracks);
+    floppy::FloppyImage::from_d88(d88)
+}
+
+pub fn make_temp_hdd_path(prefix: &str) -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be after unix epoch");
+    std::env::temp_dir().join(format!(
+        "neetan-{prefix}-{}-{}.nhd",
+        std::process::id(),
+        now.as_nanos()
+    ))
+}
+
+pub fn load_hdd_from_path(path: &Path) -> HddImage {
+    let bytes = fs::read(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    disk::load_hdd_image(path, &bytes)
+        .unwrap_or_else(|error| panic!("parse {}: {error}", path.display()))
+}
+
+pub fn boot_hle_with_temp_hdd_and_floppy(
+    hdd_path: &Path,
+    floppy: FloppyImage,
+) -> machine::Pc9801Ra {
+    let mut machine = create_hle_machine();
+    machine.bus.write_byte(0x055C, 0x01);
+    machine.bus.write_byte(0x055D, 0x01);
+    machine.bus.insert_hdd(
+        0,
+        load_hdd_from_path(hdd_path),
+        Some(hdd_path.to_path_buf()),
+    );
+
+    let mut total_cycles = 0u64;
+    loop {
+        total_cycles += machine.run_for(1_000_000);
+        if hle_prompt_visible(&machine.bus) {
+            break;
+        }
+        assert!(
+            total_cycles < 500_000_000,
+            "HLE OS did not show prompt with HDD+FDD test setup"
+        );
+    }
+
+    machine.bus.insert_floppy(0, floppy, None);
+    machine
+}
+
+fn find_partition_offset(hdd: &HddImage) -> u32 {
+    let sector = hdd.read_sector(1).expect("partition table sector");
+    for entry in sector.chunks_exact(32).take(16) {
+        if entry[0] == 0 && entry[1] == 0 {
+            break;
+        }
+        let mid = entry[0];
+        let sid = entry[1];
+        if sid & 0x80 == 0 || mid & 0x70 != 0x20 {
+            continue;
+        }
+        let start_sector = entry[8] as u32;
+        let start_head = entry[9] as u32;
+        let start_cylinder = u16::from_le_bytes([entry[10], entry[11]]) as u32;
+        return (start_cylinder * hdd.geometry.heads as u32 + start_head)
+            * hdd.geometry.sectors_per_track as u32
+            + start_sector;
+    }
+    0
+}
+
+fn read_bpb(hdd: &HddImage) -> BpbInfo {
+    let partition_offset = find_partition_offset(hdd);
+    let boot = hdd
+        .read_sector(partition_offset)
+        .expect("partition boot sector");
+    let total_sectors_16 = u16::from_le_bytes([boot[19], boot[20]]) as u32;
+    let total_sectors_32 = u32::from_le_bytes([boot[32], boot[33], boot[34], boot[35]]);
+    let total_sectors = if total_sectors_16 != 0 {
+        total_sectors_16
+    } else {
+        total_sectors_32
+    };
+    let reserved_sectors = u16::from_le_bytes([boot[14], boot[15]]);
+    let num_fats = boot[16];
+    let root_entry_count = u16::from_le_bytes([boot[17], boot[18]]);
+    let sectors_per_fat = u16::from_le_bytes([boot[22], boot[23]]);
+    let bytes_per_sector = u16::from_le_bytes([boot[11], boot[12]]);
+    let sectors_per_cluster = boot[13];
+    let root_dir_sectors = (root_entry_count as u32 * 32).div_ceil(bytes_per_sector as u32);
+    let first_data_sector =
+        reserved_sectors as u32 + num_fats as u32 * sectors_per_fat as u32 + root_dir_sectors;
+    let data_cluster_count =
+        total_sectors.saturating_sub(first_data_sector) / sectors_per_cluster as u32;
+    BpbInfo {
+        partition_offset,
+        bytes_per_sector,
+        sectors_per_cluster,
+        reserved_sectors,
+        num_fats,
+        root_entry_count,
+        sectors_per_fat,
+        is_fat16: data_cluster_count >= 4085,
+    }
+}
+
+fn read_logical_sector(hdd: &HddImage, bpb: &BpbInfo, lba: u32) -> Option<Vec<u8>> {
+    let physical = hdd.geometry.sector_size as usize;
+    let logical = bpb.bytes_per_sector as usize;
+    let ratio = logical / physical;
+    let mut data = Vec::with_capacity(logical);
+    for part in 0..ratio as u32 {
+        data.extend_from_slice(hdd.read_sector(bpb.partition_offset + lba * ratio as u32 + part)?);
+    }
+    Some(data)
+}
+
+fn read_fat_entry(fat: &[u8], cluster: u16, is_fat16: bool) -> u16 {
+    if is_fat16 {
+        let offset = cluster as usize * 2;
+        u16::from_le_bytes([fat[offset], fat[offset + 1]])
+    } else {
+        let offset = (cluster as usize * 3) / 2;
+        let pair = u16::from_le_bytes([fat[offset], fat[offset + 1]]);
+        if cluster & 1 == 0 {
+            pair & 0x0FFF
+        } else {
+            pair >> 4
+        }
+    }
+}
+
+pub fn extract_root_file(hdd_path: &Path, fcb_name: &[u8; 11]) -> Result<Vec<u8>, String> {
+    let hdd = load_hdd_from_path(hdd_path);
+    let bpb = read_bpb(&hdd);
+    let root_dir_sectors = (bpb.root_entry_count as u32 * 32).div_ceil(bpb.bytes_per_sector as u32);
+    let fat_start = bpb.reserved_sectors as u32;
+    let root_start = fat_start + bpb.num_fats as u32 * bpb.sectors_per_fat as u32;
+    let data_start = root_start + root_dir_sectors;
+
+    let mut fat = Vec::with_capacity(bpb.sectors_per_fat as usize * bpb.bytes_per_sector as usize);
+    for sector in 0..bpb.sectors_per_fat as u32 {
+        let bytes = read_logical_sector(&hdd, &bpb, fat_start + sector)
+            .ok_or_else(|| format!("failed to read FAT logical sector {}", fat_start + sector))?;
+        fat.extend_from_slice(&bytes);
+    }
+
+    let mut root = Vec::with_capacity(root_dir_sectors as usize * bpb.bytes_per_sector as usize);
+    for sector in 0..root_dir_sectors {
+        let bytes = read_logical_sector(&hdd, &bpb, root_start + sector).ok_or_else(|| {
+            format!(
+                "failed to read root directory logical sector {}",
+                root_start + sector
+            )
+        })?;
+        root.extend_from_slice(&bytes);
+    }
+
+    let mut start_cluster = None;
+    let mut file_size = None;
+    for entry in root.chunks_exact(32) {
+        if entry[0] == 0x00 {
+            break;
+        }
+        if entry[0] == 0xE5 {
+            continue;
+        }
+        if entry[0..11] == fcb_name[..] {
+            start_cluster = Some(u16::from_le_bytes([entry[26], entry[27]]));
+            file_size = Some(u32::from_le_bytes([
+                entry[28], entry[29], entry[30], entry[31],
+            ]));
+            break;
+        }
+    }
+
+    let mut cluster = start_cluster.ok_or_else(|| "destination file not found".to_string())?;
+    let file_size = file_size.ok_or_else(|| "destination file size missing".to_string())?;
+    let mut data = Vec::with_capacity(file_size as usize);
+    let mut chain = Vec::new();
+
+    let eoc = if bpb.is_fat16 { 0xFFF8 } else { 0x0FF8 };
+    while cluster >= 2 && cluster < eoc && data.len() < file_size as usize {
+        chain.push(cluster);
+        let first_sector = data_start + (cluster as u32 - 2) * bpb.sectors_per_cluster as u32;
+        for sector in 0..bpb.sectors_per_cluster as u32 {
+            let logical_sector = first_sector + sector;
+            let bytes = read_logical_sector(&hdd, &bpb, logical_sector).ok_or_else(|| {
+                format!(
+                    "cluster chain left disk: cluster={cluster:04X} logical_sector={logical_sector} chain={chain:?}"
+                )
+            })?;
+            data.extend_from_slice(&bytes);
+        }
+        if data.len() >= file_size as usize {
+            break;
+        }
+        let next = read_fat_entry(&fat, cluster, bpb.is_fat16);
+        if next == 0 || next == cluster {
+            break;
+        }
+        cluster = next;
+    }
+
+    data.truncate(file_size as usize);
+    Ok(data)
+}
+
+pub fn mismatch_offsets(lhs: &[u8], rhs: &[u8], limit: usize) -> Vec<usize> {
+    lhs.iter()
+        .zip(rhs.iter())
+        .enumerate()
+        .filter_map(|(index, (left, right))| (left != right).then_some(index))
+        .take(limit)
+        .collect()
+}

--- a/crates/os/tests/dos620/harness.rs
+++ b/crates/os/tests/dos620/harness.rs
@@ -76,6 +76,9 @@ It contains exactly one hundred bytes of known content!!";
 /// Known content for TESTFILE.TXT on the test floppy.
 pub const TEST_FILE_CONTENT: &[u8] = b"HELLO WORLD\r\n";
 
+/// Known content for README.TXT on the synthetic test CD-ROM.
+pub const TEST_CDROM_README: &[u8] = b"NEETAN CD README\r\n";
+
 /// Tiny .COM program for EXEC testing: terminates with exit code 0x42.
 /// MOV AH, 4Ch ; B4 4C
 /// MOV AL, 42h ; B0 42
@@ -1238,57 +1241,137 @@ pub fn create_test_cdimage() -> device::cdrom::CdImage {
   TRACK 02 AUDIO
     INDEX 01 00:02:00
 "#;
+    const ROOT_DIR_LBA: u32 = 20;
+    const README_LBA: u32 = 21;
+    const INSTALL_LBA: u32 = 22;
+
+    fn write_both_endian_u16(dst: &mut [u8], value: u16) {
+        dst[..2].copy_from_slice(&value.to_le_bytes());
+        dst[2..4].copy_from_slice(&value.to_be_bytes());
+    }
+
+    fn write_both_endian_u32(dst: &mut [u8], value: u32) {
+        dst[..4].copy_from_slice(&value.to_le_bytes());
+        dst[4..8].copy_from_slice(&value.to_be_bytes());
+    }
+
+    fn recording_time() -> [u8; 7] {
+        [95, 1, 1, 12, 0, 0, 0]
+    }
+
+    fn write_directory_record(
+        buffer: &mut [u8],
+        offset: &mut usize,
+        identifier: &[u8],
+        extent_lba: u32,
+        data_length: u32,
+        is_directory: bool,
+    ) {
+        let padding = usize::from(identifier.len().is_multiple_of(2));
+        let length = 33 + identifier.len() + padding;
+        let record = &mut buffer[*offset..*offset + length];
+        record.fill(0);
+        record[0] = length as u8;
+        write_both_endian_u32(&mut record[2..10], extent_lba);
+        write_both_endian_u32(&mut record[10..18], data_length);
+        record[18..25].copy_from_slice(&recording_time());
+        record[25] = if is_directory { 0x02 } else { 0x00 };
+        write_both_endian_u16(&mut record[28..32], 1);
+        record[32] = identifier.len() as u8;
+        record[33..33 + identifier.len()].copy_from_slice(identifier);
+        *offset += length;
+    }
+
+    fn make_raw_sector(user_data: &[u8; 2048]) -> Vec<u8> {
+        let mut sector = vec![0u8; 2352];
+        sector[0] = 0x00;
+        for byte in &mut sector[1..11] {
+            *byte = 0xFF;
+        }
+        sector[11] = 0x00;
+        sector[15] = 0x01;
+        sector[16..16 + 2048].copy_from_slice(user_data);
+        sector
+    }
+
     // Track 1: 150 raw data sectors (2352 bytes each, with sync+header+user data).
     let mut bin_data = Vec::with_capacity(2352 * 200);
     for sector_index in 0..150u32 {
-        let mut sector = vec![0u8; 2352];
-        // Minimal sync pattern.
-        sector[0] = 0x00;
-        for b in &mut sector[1..11] {
-            *b = 0xFF;
-        }
-        sector[11] = 0x00;
-        sector[15] = 0x01; // Mode 1.
-
-        let user_data = &mut sector[16..16 + 2048];
+        let mut user_data = [0u8; 2048];
         match sector_index {
             16 => {
-                // ISO 9660 Primary Volume Descriptor.
-                user_data[0] = 1; // Type: PVD.
+                user_data[0] = 1;
                 user_data[1..6].copy_from_slice(b"CD001");
-                user_data[6] = 1; // Version.
-                // Copyright file identifier at PVD offset 702 (37 bytes, space-padded).
+                user_data[6] = 1;
+                user_data[8..40].copy_from_slice(b"NEETAN TEST CD                  ");
+                user_data[40..72].copy_from_slice(b"NEETAN_CD                       ");
+                write_both_endian_u32(&mut user_data[80..88], 150);
+                write_both_endian_u16(&mut user_data[120..124], 1);
+                write_both_endian_u16(&mut user_data[124..128], 1);
+                write_both_endian_u16(&mut user_data[128..132], 2048);
+                write_both_endian_u32(&mut user_data[132..140], 10);
+                let mut root_record_offset = 156usize;
+                write_directory_record(
+                    &mut user_data,
+                    &mut root_record_offset,
+                    &[0],
+                    ROOT_DIR_LBA,
+                    2048,
+                    true,
+                );
                 let copyright = b"COPYRIGHT.TXT;1";
                 user_data[702..702 + copyright.len()].copy_from_slice(copyright);
-                for b in &mut user_data[702 + copyright.len()..702 + 37] {
-                    *b = b' ';
+                for byte in &mut user_data[702 + copyright.len()..702 + 37] {
+                    *byte = b' ';
                 }
-                // Abstract file identifier at PVD offset 739 (37 bytes, space-padded).
                 let abstract_id = b"ABSTRACT.TXT;1";
                 user_data[739..739 + abstract_id.len()].copy_from_slice(abstract_id);
-                for b in &mut user_data[739 + abstract_id.len()..739 + 37] {
-                    *b = b' ';
+                for byte in &mut user_data[739 + abstract_id.len()..739 + 37] {
+                    *byte = b' ';
                 }
-                // Bibliographic file identifier at PVD offset 776 (37 bytes, space-padded).
                 let biblio = b"BIBLIO.TXT;1";
                 user_data[776..776 + biblio.len()].copy_from_slice(biblio);
-                for b in &mut user_data[776 + biblio.len()..776 + 37] {
-                    *b = b' ';
+                for byte in &mut user_data[776 + biblio.len()..776 + 37] {
+                    *byte = b' ';
                 }
             }
             17 => {
-                // Volume Descriptor Set Terminator.
-                user_data[0] = 0xFF; // Type: Terminator.
+                user_data[0] = 0xFF;
                 user_data[1..6].copy_from_slice(b"CD001");
-                user_data[6] = 1; // Version.
+                user_data[6] = 1;
+            }
+            ROOT_DIR_LBA => {
+                let mut offset = 0usize;
+                write_directory_record(&mut user_data, &mut offset, &[0], ROOT_DIR_LBA, 2048, true);
+                write_directory_record(&mut user_data, &mut offset, &[1], ROOT_DIR_LBA, 2048, true);
+                write_directory_record(
+                    &mut user_data,
+                    &mut offset,
+                    b"README.TXT;1",
+                    README_LBA,
+                    TEST_CDROM_README.len() as u32,
+                    false,
+                );
+                write_directory_record(
+                    &mut user_data,
+                    &mut offset,
+                    b"INSTALL.EXE;1",
+                    INSTALL_LBA,
+                    4,
+                    false,
+                );
+            }
+            README_LBA => {
+                user_data[..TEST_CDROM_README.len()].copy_from_slice(TEST_CDROM_README);
+            }
+            INSTALL_LBA => {
+                user_data[..4].copy_from_slice(b"MZ\x90\x00");
             }
             _ => {
-                for b in user_data.iter_mut() {
-                    *b = 0x11;
-                }
+                user_data.fill(0x11);
             }
         }
-        bin_data.extend_from_slice(&sector);
+        bin_data.extend_from_slice(&make_raw_sector(&user_data));
     }
     // Track 2: 50 audio sectors (2352 bytes each).
     bin_data.extend_from_slice(&vec![0xAAu8; 2352 * 50]);

--- a/crates/os/tests/dos620/hdd_file_io.rs
+++ b/crates/os/tests/dos620/hdd_file_io.rs
@@ -245,6 +245,89 @@ fn run_hdd_write_tests<const M: u8>(
     delete_file_generic(machine, &path);
 }
 
+fn run_hdd_multicluster_write_tests<const M: u8>(
+    machine: &mut machine::Machine<cpu::I386<M>>,
+    drive_letter: &[u8],
+) {
+    let mut path = Vec::new();
+    path.extend_from_slice(drive_letter);
+    path.extend_from_slice(b":\\WBIG.TMP\0");
+
+    let payload = (0..4096)
+        .map(|index| ((index * 5) % 251) as u8)
+        .collect::<Vec<_>>();
+
+    let handle = create_file_generic(machine, &path);
+    let handle_lo = (handle & 0xFF) as u8;
+    let handle_hi = (handle >> 8) as u8;
+
+    let write_addr = harness::INJECT_CODE_BASE + 0x400;
+    let read_addr = harness::INJECT_CODE_BASE + 0x1800;
+    harness::write_bytes(&mut machine.bus, write_addr, &payload);
+
+    #[rustfmt::skip]
+    let write_code: Vec<u8> = vec![
+        0xBB, handle_lo, handle_hi,
+        0xB9, 0x00, 0x10,
+        0xBA, 0x00, 0x04,
+        0xB4, 0x40,
+        0xCD, 0x21,
+        0xA3, 0x00, 0x01,
+        0x9C, 0x58,
+        0xA3, 0x02, 0x01,
+        0xFA, 0xF4,
+    ];
+    harness::inject_and_run_generic_with_budget(
+        machine,
+        &write_code,
+        harness::INJECT_BUDGET_DISK_IO,
+    );
+
+    let write_flags = harness::result_word(&machine.bus, 2);
+    assert_eq!(write_flags & 0x0001, 0, "multicluster write failed");
+    assert_eq!(harness::result_word(&machine.bus, 0), payload.len() as u16);
+
+    #[rustfmt::skip]
+    let seek_code: Vec<u8> = vec![
+        0xBB, handle_lo, handle_hi,
+        0xB4, 0x42, 0xB0, 0x00,
+        0xB9, 0x00, 0x00, 0xBA, 0x00, 0x00,
+        0xCD, 0x21, 0xFA, 0xF4,
+    ];
+    harness::inject_and_run_generic_with_budget(
+        machine,
+        &seek_code,
+        harness::INJECT_BUDGET_DISK_IO,
+    );
+
+    #[rustfmt::skip]
+    let read_code: Vec<u8> = vec![
+        0xBB, handle_lo, handle_hi,
+        0xB9, 0x00, 0x10,
+        0xBA, 0x00, 0x18,
+        0xB4, 0x3F,
+        0xCD, 0x21,
+        0xA3, 0x00, 0x01,
+        0x9C, 0x58,
+        0xA3, 0x02, 0x01,
+        0xFA, 0xF4,
+    ];
+    harness::inject_and_run_generic_with_budget(
+        machine,
+        &read_code,
+        harness::INJECT_BUDGET_DISK_IO,
+    );
+
+    let read_flags = harness::result_word(&machine.bus, 2);
+    assert_eq!(read_flags & 0x0001, 0, "multicluster read failed");
+    assert_eq!(harness::result_word(&machine.bus, 0), payload.len() as u16);
+    let read_back = harness::read_bytes(&machine.bus, read_addr, payload.len());
+    assert_eq!(read_back, payload, "multicluster read-back mismatch");
+
+    close_file_generic(machine, handle);
+    delete_file_generic(machine, &path);
+}
+
 #[test]
 fn sasi_hdd_256_open_read_lseek() {
     let mut machine = harness::boot_hle_with_sasi_hdd(256);
@@ -270,6 +353,12 @@ fn ide_hdd_512_create_write_read_delete() {
 }
 
 #[test]
+fn ide_hdd_512_create_write_read_multicluster_file() {
+    let mut machine = harness::boot_hle_with_ide_hdd(512);
+    run_hdd_multicluster_write_tests(&mut machine, b"A");
+}
+
+#[test]
 fn ide_hdd_256_open_read_lseek() {
     let mut machine = harness::boot_hle_with_ide_hdd(256);
     run_hdd_file_io_tests(&mut machine, b"A");
@@ -291,4 +380,10 @@ fn sasi_hdd_mismatched_sectors_open_read_lseek() {
 fn sasi_hdd_mismatched_sectors_create_write_read_delete() {
     let mut machine = harness::boot_hle_with_sasi_hdd_mismatched_sectors();
     run_hdd_write_tests(&mut machine, b"A");
+}
+
+#[test]
+fn sasi_hdd_256_create_write_read_multicluster_file() {
+    let mut machine = harness::boot_hle_with_sasi_hdd(256);
+    run_hdd_multicluster_write_tests(&mut machine, b"A");
 }

--- a/crates/os/tests/dos620/hle_memory_overview.rs
+++ b/crates/os/tests/dos620/hle_memory_overview.rs
@@ -1,0 +1,136 @@
+use common::MachineModel;
+
+use crate::harness;
+
+fn find_line<'a>(lines: &'a [String], prefix: &str) -> &'a str {
+    lines
+        .iter()
+        .find(|line| line.starts_with(prefix))
+        .map(String::as_str)
+        .unwrap_or_else(|| panic!("missing line starting with {prefix:?}: {lines:?}"))
+}
+
+#[test]
+fn host_memory_overview_is_unavailable_without_hle_dos() {
+    let mut bus: machine::Pc9801Bus<machine::NoTracing> =
+        machine::Pc9801Bus::new(MachineModel::PC9801RA, 48_000);
+    assert!(
+        bus.debug_memory_overview_lines().is_none(),
+        "overview should be unavailable before HLE DOS is active"
+    );
+}
+
+#[test]
+fn host_memory_overview_reports_all_sections() {
+    let mut machine = harness::boot_hle();
+    let lines = machine
+        .bus
+        .debug_memory_overview_lines()
+        .expect("overview should be available under HLE DOS");
+
+    assert_eq!(lines[0], "Memory overview (HLE DOS)");
+    assert!(find_line(&lines, "Conventional: ").contains("free="));
+    assert!(find_line(&lines, "UMB: ").contains("free="));
+    assert!(find_line(&lines, "HMA: ").contains("state=free"));
+    assert!(find_line(&lines, "EMS: ").contains("free="));
+    assert!(find_line(&lines, "XMS: ").contains("free="));
+    assert!(find_line(&lines, "Extended backing pool (EMS+XMS): ").contains("free="));
+    assert_eq!(
+        lines.last().unwrap(),
+        "Note: EMS and XMS share the same backing pool."
+    );
+}
+
+#[test]
+fn host_memory_overview_reports_hma_allocation_state() {
+    let mut machine = harness::boot_hle();
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xBA, 0xFF, 0xFF,                   // MOV DX, FFFFh
+        0xB4, 0x01,                         // MOV AH, 01h (request HMA)
+        0xCD, 0xFE,                         // INT FEh
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run(&mut machine, code);
+
+    let lines = machine
+        .bus
+        .debug_memory_overview_lines()
+        .expect("overview should be available under HLE DOS");
+    let hma_line = find_line(&lines, "HMA: ");
+    assert!(
+        hma_line.contains("used=65,520 bytes")
+            && hma_line.contains("free=0 bytes")
+            && hma_line.contains("state=allocated"),
+        "unexpected HMA line: {hma_line}"
+    );
+}
+
+#[test]
+fn host_memory_overview_reports_umb_usage() {
+    let mut machine = harness::boot_hle();
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xBA, 0x10, 0x00,                   // MOV DX, 16
+        0xB4, 0x10,                         // MOV AH, 10h (UMB allocate)
+        0xCD, 0xFE,                         // INT FEh
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run(&mut machine, code);
+
+    let lines = machine
+        .bus
+        .debug_memory_overview_lines()
+        .expect("overview should be available under HLE DOS");
+    let umb_line = find_line(&lines, "UMB: ");
+    assert!(
+        umb_line.contains("total=65,504 bytes")
+            && umb_line.contains("used=256 bytes")
+            && umb_line.contains("free=65,248 bytes"),
+        "unexpected UMB line: {umb_line}"
+    );
+}
+
+#[test]
+fn host_memory_overview_reports_shared_ems_xms_pool_usage() {
+    let mut machine = harness::boot_hle();
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        // Allocate EMS: 1 page
+        0xBB, 0x01, 0x00,                   // MOV BX, 1
+        0xB4, 0x43,                         // MOV AH, 43h
+        0xCD, 0x67,                         // INT 67h
+        // Allocate XMS: 64 KB
+        0xBA, 0x40, 0x00,                   // MOV DX, 64
+        0xB4, 0x09,                         // MOV AH, 09h
+        0xCD, 0xFE,                         // INT FEh
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run(&mut machine, code);
+
+    let lines = machine
+        .bus
+        .debug_memory_overview_lines()
+        .expect("overview should be available under HLE DOS");
+    let ems_line = find_line(&lines, "EMS: ");
+    let xms_line = find_line(&lines, "XMS: ");
+    let pool_line = find_line(&lines, "Extended backing pool (EMS+XMS): ");
+
+    assert!(
+        ems_line.contains("used=16K (16,384 bytes)"),
+        "unexpected EMS line: {ems_line}"
+    );
+    assert!(
+        xms_line.contains("used=64K (65,536 bytes)"),
+        "unexpected XMS line: {xms_line}"
+    );
+    assert!(
+        pool_line.contains("total=12,288K (12,582,912 bytes)")
+            && pool_line.contains("used=80K (81,920 bytes)")
+            && pool_line.contains("free=12,208K (12,500,992 bytes)"),
+        "unexpected shared pool line: {pool_line}"
+    );
+}

--- a/crates/os/tests/dos620/shell.rs
+++ b/crates/os/tests/dos620/shell.rs
@@ -199,6 +199,50 @@ fn shell_switch_to_drive_no_media() {
 }
 
 #[test]
+fn shell_switch_to_q_drive_with_cdrom() {
+    let mut machine = boot_hle_with_cdrom();
+
+    type_string(&mut machine.bus, b"Q:\r");
+    run_until_prompt_ap(&mut machine);
+
+    assert!(
+        find_row_containing(&machine.bus, "No media in drive Q").is_none(),
+        "Q: should not report missing media for the MSCDEX CD-ROM drive"
+    );
+
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xB4, 0x19,                         // MOV AH, 19h
+        0xCD, 0x21,                         // INT 21h
+        0xA3, 0x00, 0x01,                   // MOV [0x0100], AX
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    inject_and_run_generic_with_budget(&mut machine, code, INJECT_BUDGET);
+
+    let current_drive = result_byte(&machine.bus, 0);
+    assert_eq!(
+        current_drive, 16,
+        "Q: command should switch the current drive to Q:, got index {}",
+        current_drive
+    );
+}
+
+#[test]
+fn shell_switch_to_q_drive_without_media() {
+    let mut machine = boot_hle_with_cdrom();
+    machine.bus.eject_cdrom();
+
+    type_string(&mut machine.bus, b"Q:\r");
+    run_until_prompt_ap(&mut machine);
+
+    assert!(
+        find_row_containing(&machine.bus, "No media in drive Q").is_some(),
+        "Q: should report missing media after the CD-ROM is ejected"
+    );
+}
+
+#[test]
 fn shell_cd_nonexistent_directory() {
     let mut machine = boot_hle_with_floppy();
 

--- a/crates/os/tests/dos620/shell_batch.rs
+++ b/crates/os/tests/dos620/shell_batch.rs
@@ -152,6 +152,30 @@ fn batch_if_errorlevel() {
 }
 
 #[test]
+fn batch_if_errorlevel_after_external_program() {
+    let floppy_a = create_test_floppy_with_program(
+        b"TEST    BAT",
+        b"B:\\RUNME\r\nIF ERRORLEVEL 66 ECHO EXITOK\r\n",
+    );
+    let floppy_b = create_test_floppy_with_program(b"RUNME   COM", TEST_COM_PROGRAM);
+    let mut machine = boot_hle_with_two_floppy_images(floppy_a, floppy_b);
+    type_string(&mut machine.bus, b"A:\r");
+    run_until_prompt(&mut machine);
+
+    type_string(&mut machine.bus, b"CLS\r");
+    run_until_prompt(&mut machine);
+
+    type_string(&mut machine.bus, b"TEST\r");
+    run_until_prompt(&mut machine);
+
+    let exitok = [0x0045, 0x0058, 0x0049, 0x0054, 0x004F, 0x004B]; // "EXITOK"
+    assert!(
+        find_string_in_text_vram(&machine.bus, &exitok),
+        "batch should wait for external programs before evaluating following lines"
+    );
+}
+
+#[test]
 fn batch_params() {
     let mut machine = boot_with_bat(b"ECHO %1 %2\r\n");
     type_string(&mut machine.bus, b"A:\r");

--- a/crates/os/tests/dos620/syscalls_int21h.rs
+++ b/crates/os/tests/dos620/syscalls_int21h.rs
@@ -743,6 +743,120 @@ fn get_allocation_info() {
 }
 
 #[test]
+fn get_free_disk_space() {
+    let mut machine = harness::boot_hle_with_floppy();
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xB4, 0x36,                         // MOV AH, 36h
+        0xB2, 0x01,                         // MOV DL, 01h (A:)
+        0xCD, 0x21,                         // INT 21h
+        0x89, 0x06, 0x00, 0x01,             // MOV [0x0100], AX
+        0x89, 0x1E, 0x02, 0x01,             // MOV [0x0102], BX
+        0x89, 0x0E, 0x04, 0x01,             // MOV [0x0104], CX
+        0x89, 0x16, 0x06, 0x01,             // MOV [0x0106], DX
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run_with_budget(&mut machine, code, harness::INJECT_BUDGET_DISK_IO);
+
+    let sectors_per_cluster = harness::result_word(&machine.bus, 0);
+    assert_eq!(
+        sectors_per_cluster, 1,
+        "Test floppy should report 1 sector per cluster, got {}",
+        sectors_per_cluster
+    );
+
+    let free_clusters = harness::result_word(&machine.bus, 2);
+    assert_eq!(
+        free_clusters, 1218,
+        "Test floppy should report 1218 free clusters, got {}",
+        free_clusters
+    );
+
+    let bytes_per_sector = harness::result_word(&machine.bus, 4);
+    assert_eq!(
+        bytes_per_sector, 1024,
+        "Test floppy should report 1024 bytes per sector, got {}",
+        bytes_per_sector
+    );
+
+    let total_clusters = harness::result_word(&machine.bus, 6);
+    assert_eq!(
+        total_clusters, 1221,
+        "Test floppy should report 1221 total clusters, got {}",
+        total_clusters
+    );
+}
+
+#[test]
+fn get_free_disk_space_invalid_drive_returns_ffff() {
+    let mut machine = harness::boot_hle();
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xB4, 0x36,                         // MOV AH, 36h
+        0xB2, 0x1B,                         // MOV DL, 1Bh (invalid)
+        0xCD, 0x21,                         // INT 21h
+        0x89, 0x06, 0x00, 0x01,             // MOV [0x0100], AX
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run(&mut machine, code);
+
+    let ax = harness::result_word(&machine.bus, 0);
+    assert_eq!(
+        ax, 0xFFFF,
+        "Invalid drive should return AX=FFFFh, got {:#06X}",
+        ax
+    );
+}
+
+#[test]
+fn get_free_disk_space_virtual_drive_is_empty() {
+    let mut machine = harness::boot_hle();
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xB4, 0x36,                         // MOV AH, 36h
+        0xB2, 0x1A,                         // MOV DL, 1Ah (Z:)
+        0xCD, 0x21,                         // INT 21h
+        0x89, 0x06, 0x00, 0x01,             // MOV [0x0100], AX
+        0x89, 0x1E, 0x02, 0x01,             // MOV [0x0102], BX
+        0x89, 0x0E, 0x04, 0x01,             // MOV [0x0104], CX
+        0x89, 0x16, 0x06, 0x01,             // MOV [0x0106], DX
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run(&mut machine, code);
+
+    let sectors_per_cluster = harness::result_word(&machine.bus, 0);
+    assert_eq!(
+        sectors_per_cluster, 1,
+        "Virtual Z: drive should report a synthetic 1 sector per cluster, got {}",
+        sectors_per_cluster
+    );
+
+    let free_clusters = harness::result_word(&machine.bus, 2);
+    assert_eq!(
+        free_clusters, 0,
+        "Virtual Z: drive should report no free clusters, got {}",
+        free_clusters
+    );
+
+    let bytes_per_sector = harness::result_word(&machine.bus, 4);
+    assert_eq!(
+        bytes_per_sector, 512,
+        "Virtual Z: drive should report a synthetic 512-byte sector, got {}",
+        bytes_per_sector
+    );
+
+    let total_clusters = harness::result_word(&machine.bus, 6);
+    assert_eq!(
+        total_clusters, 0,
+        "Virtual Z: drive should report zero total clusters, got {}",
+        total_clusters
+    );
+}
+
+#[test]
 fn get_extended_country_info() {
     let mut machine = harness::boot_hle();
     let buffer_offset: u16 = harness::INJECT_RESULT_OFFSET + 0x10;

--- a/crates/os/tests/dos620/syscalls_int21h_file_io.rs
+++ b/crates/os/tests/dos620/syscalls_int21h_file_io.rs
@@ -29,6 +29,34 @@ fn open_file(machine: &mut machine::Pc9801Ra, filename: &[u8]) -> u16 {
     harness::result_word(&machine.bus, 0)
 }
 
+fn open_file_ap(machine: &mut machine::Pc9821Ap, filename: &[u8]) -> u16 {
+    let path_addr = harness::INJECT_CODE_BASE + 0x200;
+    harness::write_bytes(&mut machine.bus, path_addr, filename);
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xB4, 0x3D,                         // MOV AH, 3Dh (open)
+        0xB0, 0x00,                         // MOV AL, 00h (read-only)
+        0xBA, 0x00, 0x02,                   // MOV DX, 0200h
+        0xCD, 0x21,                         // INT 21h
+        0xA3, 0x00, 0x01,                   // MOV [0x0100], AX (handle)
+        0x9C,                               // PUSHF
+        0x58,                               // POP AX
+        0xA3, 0x02, 0x01,                   // MOV [0x0102], AX (flags)
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run_generic_with_budget(machine, code, harness::INJECT_BUDGET_DISK_IO);
+
+    let flags = harness::result_word(&machine.bus, 2);
+    assert_eq!(
+        flags & 0x0001,
+        0,
+        "open_file_ap: CF should be 0, flags={:#06X}",
+        flags
+    );
+    harness::result_word(&machine.bus, 0)
+}
+
 /// Helper: close a file handle.
 fn close_file(machine: &mut machine::Pc9801Ra, handle: u16) {
     let handle_lo = (handle & 0xFF) as u8;
@@ -174,6 +202,51 @@ fn read_from_file() {
     );
 
     close_file(&mut machine, handle);
+}
+
+#[test]
+fn open_read_from_cdrom_file() {
+    let mut machine = harness::boot_hle_with_cdrom();
+
+    let handle = open_file_ap(&mut machine, b"Q:\\README.TXT\0");
+    let handle_lo = (handle & 0xFF) as u8;
+    let handle_hi = (handle >> 8) as u8;
+
+    #[rustfmt::skip]
+    let code: Vec<u8> = vec![
+        0xBB, handle_lo, handle_hi,          // MOV BX, handle
+        0xB9, 0x05, 0x00,                   // MOV CX, 0005h
+        0xBA, 0x10, 0x02,                   // MOV DX, 0210h
+        0xB4, 0x3F,                         // MOV AH, 3Fh (read)
+        0xCD, 0x21,                         // INT 21h
+        0xA3, 0x00, 0x01,                   // MOV [0x0100], AX (bytes read)
+        0x9C,                               // PUSHF
+        0x58,                               // POP AX
+        0xA3, 0x02, 0x01,                   // MOV [0x0102], AX (flags)
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run_generic_with_budget(
+        &mut machine,
+        &code,
+        harness::INJECT_BUDGET_DISK_IO,
+    );
+
+    let flags = harness::result_word(&machine.bus, 2);
+    assert_eq!(
+        flags & 0x0001,
+        0,
+        "CD-ROM read should succeed, flags={:#06X}",
+        flags
+    );
+    assert_eq!(
+        harness::result_word(&machine.bus, 0),
+        5,
+        "CD-ROM read should return 5 bytes"
+    );
+
+    let read_back = harness::read_bytes(&machine.bus, harness::INJECT_CODE_BASE + 0x210, 5);
+    assert_eq!(&read_back, &harness::TEST_CDROM_README[..5]);
 }
 
 #[test]

--- a/crates/os/tests/dos620/syscalls_int21h_file_io.rs
+++ b/crates/os/tests/dos620/syscalls_int21h_file_io.rs
@@ -468,6 +468,136 @@ fn get_file_attributes() {
 }
 
 #[test]
+fn create_directory_via_int21h_39h() {
+    let mut machine = harness::boot_hle_with_floppy();
+
+    let create_path_addr = harness::INJECT_CODE_BASE + 0x200;
+    let attrs_path_addr = harness::INJECT_CODE_BASE + 0x220;
+    harness::write_bytes(&mut machine.bus, create_path_addr, b"A:\\NEWDIR\0");
+    harness::write_bytes(&mut machine.bus, attrs_path_addr, b"A:\\NEWDIR\0");
+
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xBA, 0x00, 0x02,                   // MOV DX, 0200h
+        0xB4, 0x39,                         // MOV AH, 39h
+        0xCD, 0x21,                         // INT 21h
+        0x9C,                               // PUSHF
+        0x58,                               // POP AX
+        0xA3, 0x00, 0x01,                   // MOV [0x0100], AX (create flags)
+        0xBA, 0x20, 0x02,                   // MOV DX, 0220h
+        0xB4, 0x43,                         // MOV AH, 43h
+        0xB0, 0x00,                         // MOV AL, 00h
+        0xCD, 0x21,                         // INT 21h
+        0x89, 0x0E, 0x02, 0x01,             // MOV [0x0102], CX (attributes)
+        0x9C,                               // PUSHF
+        0x58,                               // POP AX
+        0xA3, 0x04, 0x01,                   // MOV [0x0104], AX (attr flags)
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run_with_budget(&mut machine, code, harness::INJECT_BUDGET_DISK_IO);
+
+    let create_flags = harness::result_word(&machine.bus, 0);
+    assert_eq!(
+        create_flags & 0x0001,
+        0,
+        "AH=39h should succeed (CF=0), flags={:#06X}",
+        create_flags
+    );
+
+    let attr_flags = harness::result_word(&machine.bus, 4);
+    assert_eq!(
+        attr_flags & 0x0001,
+        0,
+        "New directory should be queryable via AH=43h, flags={:#06X}",
+        attr_flags
+    );
+
+    let attributes = harness::result_byte(&machine.bus, 2);
+    assert_ne!(
+        attributes & 0x10,
+        0,
+        "NEWDIR should have directory attribute set, got {:#04X}",
+        attributes
+    );
+}
+
+#[test]
+fn create_directory_via_int21h_39h_existing_returns_access_denied() {
+    let mut machine = harness::boot_hle_with_floppy();
+
+    let path_addr = harness::INJECT_CODE_BASE + 0x200;
+    harness::write_bytes(&mut machine.bus, path_addr, b"A:\\DUPDIR\0");
+
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xBA, 0x00, 0x02,                   // MOV DX, 0200h
+        0xB4, 0x39,                         // MOV AH, 39h
+        0xCD, 0x21,                         // INT 21h
+        0xBA, 0x00, 0x02,                   // MOV DX, 0200h
+        0xB4, 0x39,                         // MOV AH, 39h
+        0xCD, 0x21,                         // INT 21h
+        0xA3, 0x00, 0x01,                   // MOV [0x0100], AX
+        0x9C,                               // PUSHF
+        0x58,                               // POP AX
+        0xA3, 0x02, 0x01,                   // MOV [0x0102], AX
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run_with_budget(&mut machine, code, harness::INJECT_BUDGET_DISK_IO);
+
+    let error_code = harness::result_word(&machine.bus, 0);
+    let flags = harness::result_word(&machine.bus, 2);
+    assert_eq!(
+        flags & 0x0001,
+        1,
+        "Second AH=39h should fail (CF=1), flags={:#06X}",
+        flags
+    );
+    assert_eq!(
+        error_code, 0x0005,
+        "Creating an existing directory should return access denied, got {:#06X}",
+        error_code
+    );
+}
+
+#[test]
+fn create_directory_via_int21h_39h_missing_parent_returns_path_not_found() {
+    let mut machine = harness::boot_hle_with_floppy();
+
+    let path_addr = harness::INJECT_CODE_BASE + 0x200;
+    harness::write_bytes(&mut machine.bus, path_addr, b"A:\\NOPE\\CHILD\0");
+
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xBA, 0x00, 0x02,                   // MOV DX, 0200h
+        0xB4, 0x39,                         // MOV AH, 39h
+        0xCD, 0x21,                         // INT 21h
+        0xA3, 0x00, 0x01,                   // MOV [0x0100], AX
+        0x9C,                               // PUSHF
+        0x58,                               // POP AX
+        0xA3, 0x02, 0x01,                   // MOV [0x0102], AX
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run_with_budget(&mut machine, code, harness::INJECT_BUDGET_DISK_IO);
+
+    let error_code = harness::result_word(&machine.bus, 0);
+    let flags = harness::result_word(&machine.bus, 2);
+    assert_eq!(
+        flags & 0x0001,
+        1,
+        "AH=39h with a missing parent should fail (CF=1), flags={:#06X}",
+        flags
+    );
+    assert_eq!(
+        error_code, 0x0003,
+        "Missing parent path should return path not found, got {:#06X}",
+        error_code
+    );
+}
+
+#[test]
 fn get_file_datetime() {
     let mut machine = harness::boot_hle_with_floppy();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -526,6 +526,8 @@ impl Application {
                         self.open_or_toggle_selector(MediaType::Floppy(1));
                     } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::F11) {
                         self.open_or_toggle_selector(MediaType::CdRom);
+                    } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::F12) {
+                        self.log_memory_overview();
                     } else if !repeat
                         && let Some(code) = (*scancode).map(|sc| self.key_map.lookup(sc))
                     {
@@ -707,6 +709,17 @@ impl Application {
     fn close_selector(&mut self) {
         self.image_selector = None;
         self.audio_engine.resume();
+    }
+
+    fn log_memory_overview(&mut self) {
+        let Some(lines) = self.machine.debug_memory_overview() else {
+            info!("Memory overview unavailable outside HLE DOS");
+            return;
+        };
+
+        for line in lines {
+            info!("{line}");
+        }
     }
 
     fn handle_selector_key(&mut self, scancode: Option<Scancode>, alt_gui_held: bool) {


### PR DESCRIPTION
Still many rough edges. But A-TRAIN, YUNO and DOOM are all running fine now.

I also inlcuded a `dosmock` command to mock real DOS, since the DOOM installer has a check for a real MS DOS installation. I also included `b3sum` that does the same thing as the real `b3sum` hash files with BLAKE3. Useful when debugging file content for similarity. Will also in the future replace the SHA-1 code with blake3 in the munt port for uniform hash implementation.