### PR TITLE
feature: implement CRT shader

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ neetan <COMMAND>
 | `--cdrom <PATH>`             | CD-ROM disc image CUE file (repeatable, PC-9821 only)                    | -          |
 | `--audio-volume <FLOAT>`     | Audio volume 0.0–1.0                                                     | `1.0`      |
 | `--aspect-mode <MODE>`       | Display aspect mode: `4:3` or `1:1`                                      | `4:3`      |
+| `--crt <on\|off>`            | Enable the CRT effect                                                    | `on`       |
 | `--window-mode <MODE>`       | Window mode: `windowed` or `fullscreen`                                  | `windowed` |
 | `--force-gdc-clock <2.5\|5>` | Force GDC clock to 2.5 or 5 MHz. VX and later only                       | auto       |
 | `--bios-rom <PATH>`          | Path to BIOS ROM file                                                    | HLE BIOS   |
@@ -113,6 +114,7 @@ soundboard = 86+26k
 force-gdc-clock = 2.5
 audio-volume = 0.8
 aspect-mode = 4:3
+crt = on
 fdd1 = /path/to/disk_a.d88
 fdd1 = /path/to/disk_b.d88
 fdd2 = /path/to/save_game.d88
@@ -162,6 +164,7 @@ For example, if your global config sets `machine = PC9801RA` and you run
 | Right Ctrl         | Toggle mouse capture             |
 | GUI + Alt + Enter  | Toggle fullscreen                |
 | GUI + Alt + Escape | Quit the emulator                |
+| GUI + Alt + F1     | Toggle CRT effect                |
 | GUI + Alt + F9     | Open floppy selector for drive 1 |
 | GUI + Alt + F10    | Open floppy selector for drive 2 |
 | GUI + Alt + F11    | Open CD-ROM selector             |

--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -37,6 +37,9 @@
 ; Display aspect mode: 4:3 or 1:1
 ; aspect-mode = 4:3
 
+; CRT effect: on or off
+; crt = on
+
 ; Force GDC clock to 2.5 MHz or 5 MHz (default: auto-detect).
 ; Auto-detect starts at 2.5 MHz and switches to 5 MHz when software
 ; requests 400-line mode via BIOS or port 0x6A.

--- a/crates/graphics_engine/build.rs
+++ b/crates/graphics_engine/build.rs
@@ -137,6 +137,9 @@ fn main() {
     let pass_files = discover_pass_files(&passes_dir);
 
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed={}", shader_dir.display());
+    println!("cargo:rerun-if-changed={}", modules_dir.display());
+    println!("cargo:rerun-if-changed={}", passes_dir.display());
     for module_file in &module_files {
         println!("cargo:rerun-if-changed={}", module_file.display());
     }

--- a/crates/graphics_engine/shaders/passes/crt/crt.slang
+++ b/crates/graphics_engine/shaders/passes/crt/crt.slang
@@ -1,0 +1,279 @@
+#language slang 2026
+
+// CRT shader emulating typical NEC monitors (dot pitch, dot-type black matrix).
+//
+// Single-pass flat-surface CRT with:
+//   - Lanczos2 center row / 3-tap Gaussian adjacent rows with analog bandwidth sharpness.
+//   - Per-channel brightness-adaptive scanlines.
+//   - Luminance-adaptive dot-triad black-matrix phosphor mask.
+
+import screen_space;
+
+[[vk::binding(1, 0)]] var linear_sampler: SamplerState;
+[[vk::binding(1, 1)]] var native_target: Texture2D;
+
+struct CrtPushConstants {
+    float content_height;
+    float padding0;
+    float2 output_size;
+    float2 source_size;
+    float2 padding1;
+}
+
+[[vk::push_constant]] var push_constants: CrtPushConstants;
+
+static const float2 NATIVE_TEXTURE_SIZE = float2(640.0, 480.0);
+static const float PI = 3.14159265359;
+
+// Horizontal Lanczos2 sharpness: 0.0 = pure sinc interpolation, 1.0 = hard pixel edges.
+// NEC monitors had sharp analog bandwidth at 640 pixels, so moderate values work well.
+static const float HORIZONTAL_SHARPNESS = 0.5;
+// Scanline Gaussian shape exponent. 2.0 = true Gaussian, higher = flatter top with steeper rolloff.
+static const float SHAPE = 2.0;
+// Horizontal Gaussian sharpness for off-center scanline rows. More negative = sharper.
+static const float HARD_PIX = -3.0;
+
+// Scanline Gaussian sharpness. More negative = harder scanlines.
+static const float HARD_SCAN = -4.0;
+// Minimum beam width multiplier (dark pixels).
+static const float SCAN_BEAM_MIN = 0.7;
+// Maximum beam width multiplier (bright pixels).
+static const float SCAN_BEAM_MAX = 1.05;
+
+// Mask strength: 0.0 = no mask, 1.0 = full physical mask contrast.
+static const float MASK_STRENGTH = 0.15;
+// Source pixels per R+G+B triad (physical dot pitch of the simulated monitor).
+static const float MASK_TRIAD_WIDTH = 1.5;
+// Ratio of lit phosphor area within each cell.
+static const float MASK_DOT_RADIUS = 0.75;
+// Luminance threshold above which mask fades out (bright phosphors bloom through gaps).
+static const float MASK_CUTOFF = 0.3;
+
+// Bright boost for dark pixels (compensates scanline energy loss).
+static const float BRIGHT_BOOST_DARK = 1.35;
+// Bright boost for bright pixels.
+static const float BRIGHT_BOOST_BRIGHT = 1.10;
+
+// Shoulder compress: linear passthrough below knee, exponential
+// soft-clip above. Asymptotes to 1.0. Values below knee are untouched.
+[ForceInline]
+func shoulder_compress(x: float, knee: float) -> float {
+    if (x <= knee) { return x; }
+    let range = 1.0 - knee;
+    return knee + range * (1.0 - exp(-(x - knee) / range));
+}
+
+// Hue-preserving phosphor saturation: scales all channels by the
+// same ratio so color ratios (hue) are maintained.
+[ForceInline]
+func phosphor_saturate(color: float3, knee: float) -> float3 {
+    let peak = max(color.r, max(color.g, color.b));
+    if (peak <= knee) { return color; }
+    return color * (shoulder_compress(peak, knee) / peak);
+}
+
+[ForceInline]
+func source_domain_to_backing_uv(uv: float2, source_size: float2) -> float2 {
+    return uv * (source_size / NATIVE_TEXTURE_SIZE);
+}
+
+[ForceInline]
+func fetch(pos: float2, offset: float2, source_size: float2) -> float3 {
+    let source_pixel = floor(pos * source_size + offset);
+    if (any(source_pixel < float2(0.0)) || any(source_pixel >= source_size)) {
+        return float3(0.0);
+    }
+
+    let sample_uv = (source_pixel + float2(0.5)) / source_size;
+    let backing_uv = source_domain_to_backing_uv(sample_uv, source_size);
+    return native_target.SampleLevel(linear_sampler, backing_uv, 0.0).xyz;
+}
+
+[ForceInline]
+func distance_to_nearest_texel(pos: float2, source_size: float2) -> float2 {
+    let scaled_pos = pos * source_size;
+    return -((scaled_pos - floor(scaled_pos)) - float2(0.5));
+}
+
+// Half-circle S-curve applied to fractional texel position. Controls how
+// sharply pixels transition: 0.0 = smooth sinc interpolation, 1.0 = hard
+// pixel edges that approach nearest-neighbor.
+[ForceInline]
+func curve_distance(x: float, sharp: float) -> float {
+    let x_step = step(0.5, x);
+    let curve = 0.5 - sqrt(0.25 - (x - x_step) * (x - x_step)) * sign(0.5 - x);
+    return lerp(x, curve, sharp);
+}
+
+// 4-tap Lanczos2 filter along a horizontal scanline row. Produces sharper
+// pixel transitions than Gaussian with less ringing, matching the high analog
+// bandwidth of NEC PC-98 monitors at 640 horizontal pixels.
+[ForceInline]
+func horizontal_lanczos(pos: float2, offset: float, source_size: float2) -> float3 {
+    // Shift to texel-centered coordinates so the base texel is always to the
+    // left of the sample point, giving a stable fractional distance in [0, 1).
+    let f = fract(pos.x * source_size.x);
+    let shift = (f < 0.5) ? -1.0 : 0.0;
+    let d = f - 0.5 - shift;
+
+    let s0 = fetch(pos, float2(shift - 1.0, offset), source_size);
+    let s1 = fetch(pos, float2(shift, offset), source_size);
+    let s2 = fetch(pos, float2(shift + 1.0, offset), source_size);
+    let s3 = fetch(pos, float2(shift + 2.0, offset), source_size);
+
+    let curve_d = curve_distance(d, HORIZONTAL_SHARPNESS);
+
+    // Lanczos2 kernel: sinc(x) * sinc(x/2), evaluated via the trig identity
+    // L(x) = 2 * sin(pi*x) * sin(pi*x/2) / (pi*x)^2.
+    var coeffs = float4(1.0 + curve_d, curve_d, 1.0 - curve_d, 2.0 - curve_d) * PI;
+    coeffs = max(abs(coeffs), float4(1e-5));
+    coeffs = 2.0 * sin(coeffs) * sin(coeffs * 0.5) / (coeffs * coeffs);
+    coeffs /= dot(coeffs, float4(1.0));
+
+    let result = s0 * coeffs.x + s1 * coeffs.y + s2 * coeffs.z + s3 * coeffs.w;
+
+    // Anti-ringing clamp: restrict output to the range of the two nearest
+    // samples, preventing visible overshoot from Lanczos negative lobes.
+    return clamp(result, min(s1, s2), max(s1, s2));
+}
+
+// 3-tap Gaussian filter along a horizontal scanline row. Used for adjacent
+// rows (offset -1/+1) where scanline weights heavily attenuate the signal,
+// making full Lanczos2 quality unnecessary.
+[ForceInline]
+func horizontal_3tap(pos: float2, offset: float, source_size: float2) -> float3 {
+    let s0 = fetch(pos, float2(-1.0, offset), source_size);
+    let s1 = fetch(pos, float2( 0.0, offset), source_size);
+    let s2 = fetch(pos, float2( 1.0, offset), source_size);
+
+    let dst = distance_to_nearest_texel(pos, source_size).x;
+
+    let w0 = exp2(HARD_PIX * pow(abs(dst - 1.0), SHAPE));
+    let w1 = exp2(HARD_PIX * pow(abs(dst),       SHAPE));
+    let w2 = exp2(HARD_PIX * pow(abs(dst + 1.0), SHAPE));
+
+    return (s0 * w0 + s1 * w1 + s2 * w2) / (w0 + w1 + w2);
+}
+
+// Per-channel scanline weight: each channel gets its own beam width based on
+// that channel's brightness, matching how independent electron guns work on
+// real NEC RGB monitors.
+[ForceInline]
+func scan_weight(pos: float2, offset: float, color: float3, source_size: float2) -> float3 {
+    let beam_width = lerp(float3(SCAN_BEAM_MIN), float3(SCAN_BEAM_MAX), color);
+    let distance = distance_to_nearest_texel(pos, source_size).y;
+    let d = float3(distance + offset);
+    return float3(
+        exp2(HARD_SCAN * pow(abs(d.x / beam_width.x), SHAPE)),
+        exp2(HARD_SCAN * pow(abs(d.y / beam_width.y), SHAPE)),
+        exp2(HARD_SCAN * pow(abs(d.z / beam_width.z), SHAPE)),
+    );
+}
+
+[ForceInline]
+func tri(pos: float2, source_size: float2) -> float3 {
+    let raw_a = horizontal_3tap(pos, -1.0, source_size);
+    let raw_b = horizontal_lanczos(pos, 0.0, source_size);
+    let raw_c = horizontal_3tap(pos, 1.0, source_size);
+
+    // Luminance-dependent bright boost applied before scanlines: dark pixels
+    // get more boost because scanlines remove proportionally more of their energy.
+    let row_a = raw_a * lerp(BRIGHT_BOOST_DARK, BRIGHT_BOOST_BRIGHT, max(raw_a.r, max(raw_a.g, raw_a.b)));
+    let row_b = raw_b * lerp(BRIGHT_BOOST_DARK, BRIGHT_BOOST_BRIGHT, max(raw_b.r, max(raw_b.g, raw_b.b)));
+    let row_c = raw_c * lerp(BRIGHT_BOOST_DARK, BRIGHT_BOOST_BRIGHT, max(raw_c.r, max(raw_c.g, raw_c.b)));
+
+    let weight_a = scan_weight(pos, -1.0, row_a, source_size);
+    let weight_b = scan_weight(pos, 0.0, row_b, source_size);
+    let weight_c = scan_weight(pos, 1.0, row_c, source_size);
+
+    // Clamp-from-above normalization: only scale down when weights exceed 1.0
+    // (preventing clipping), but never scale up (preserving scanline gap darkness).
+    var wa = weight_a;
+    var wb = weight_b;
+    var wc = weight_c;
+    let peak_weight = max((wa + wb + wc).r, max((wa + wb + wc).g, (wa + wb + wc).b));
+    if (peak_weight > 1.0) {
+        let scale = 1.0 / peak_weight;
+        wa *= scale;
+        wb *= scale;
+        wc *= scale;
+    }
+
+    return row_a * wa + row_b * wb + row_c * wc;
+}
+
+// Luminance-adaptive dot-triad mask: bright content blooms through the mask
+// gaps on real CRTs, so we reduce mask contrast for bright pixels.
+[ForceInline]
+func dot_triad_mask(output_pos: float2, triad_width: float, color: float3) -> float3 {
+    let mask_x = output_pos.x / triad_width;
+    let mask_y = output_pos.y / triad_width;
+
+    // Stagger every other row by half a triad width for delta arrangement.
+    let row = floor(mask_y);
+    let stagger = (fract(row * 0.5) > 0.25) ? 0.5 : 0.0;
+
+    let cell_x = fract(mask_x + stagger);
+    let cell_y = fract(mask_y);
+
+    // Which phosphor dot: 0=R, 1=G, 2=B
+    let phosphor_index = floor(cell_x * 3.0);
+
+    // Distance from center of this phosphor dot.
+    let dx = fract(cell_x * 3.0) - 0.5;
+    let dy = cell_y - 0.5;
+    let dot_dist = length(float2(dx, dy));
+
+    // Dot falloff: 1.0 at center, fading to 0.0 toward edges.
+    let dot_value = 1.0 - smoothstep(MASK_DOT_RADIUS * 0.5, MASK_DOT_RADIUS, dot_dist);
+
+    // Effective mask strength reduced for bright content (phosphor bloom through
+    // gaps) and for low resolutions (anti-moire).
+    let peak = max(color.r, max(color.g, color.b));
+    let effective_strength = MASK_STRENGTH * (1.0 - smoothstep(MASK_CUTOFF, 1.0, peak));
+
+    // Per-channel weights: active phosphor is boosted, others are dimmed.
+    // Energy-neutral: (active + 2*inactive)/3 = 1.0 per channel across a
+    // full triad, so the mask does not steal overall brightness.
+    let active_weight = 1.0 + 2.0 * effective_strength;
+    let inactive_weight = 1.0 - effective_strength;
+    let r_weight = (phosphor_index < 0.5) ? active_weight : inactive_weight;
+    let g_weight = (phosphor_index > 0.5 && phosphor_index < 1.5) ? active_weight : inactive_weight;
+    let b_weight = (phosphor_index > 1.5) ? active_weight : inactive_weight;
+
+    let channel_mask = float3(r_weight, g_weight, b_weight);
+
+    // Black matrix: attenuate between dots.
+    let matrix = lerp(1.0, dot_value, effective_strength);
+
+    return channel_mask * matrix;
+}
+
+[[shader("vertex")]]
+func vs_main(uint vertex_index : SV_VulkanVertexID) -> FullscreenVertex {
+    return FullscreenVertex::new(vertex_index);
+}
+
+[[shader("pixel")]]
+func fs_main(FullscreenVertex input) -> float4 {
+    let source_size = max(
+        float2(push_constants.source_size.x, push_constants.content_height),
+        float2(1.0, 1.0)
+    );
+    let output_size = max(push_constants.output_size, float2(1.0, 1.0));
+    let source_uv = float2(input.uv.x, input.uv.y);
+
+    // Per-channel beam blur + brightness-adaptive scanlines.
+    var color = tri(source_uv, source_size);
+
+    // Luminance-adaptive dot-triad black-matrix mask in output pixel space.
+    // Scale triad width by the output-to-source ratio so the number of triads
+    // stays fixed to the source resolution, matching a real shadow mask.
+    let triad_width = MASK_TRIAD_WIDTH * (output_size.x / source_size.x);
+    color *= dot_triad_mask(input.uv * output_size * 1.000001, triad_width, color);
+
+    // Hue-preserving phosphor saturation limiter.
+    color = phosphor_saturate(color, 0.9);
+
+    return float4(color, 1.0);
+}

--- a/crates/graphics_engine/src/descriptors.rs
+++ b/crates/graphics_engine/src/descriptors.rs
@@ -101,7 +101,7 @@ impl DescriptorResources {
         let push_constant_range = vk::PushConstantRange::default()
             .stage_flags(vk::ShaderStageFlags::FRAGMENT)
             .offset(0)
-            .size(8); // int2 = 2 × i32 = 8 bytes
+            .size(32);
 
         let set_layouts = [set_layout_0, set_layout_1];
         let pipeline_layout_info = vk::PipelineLayoutCreateInfo::default()

--- a/crates/graphics_engine/src/instructions.rs
+++ b/crates/graphics_engine/src/instructions.rs
@@ -8,4 +8,6 @@ pub struct RenderInstructions<'a> {
     pub display_snapshot: &'a DisplaySnapshotUpload,
     /// Optional PEGC snapshot for 256-color mode rendering.
     pub pegc_snapshot: Option<&'a PegcSnapshotUpload>,
+    /// Whether the CRT upscale effect is enabled.
+    pub crt: bool,
 }

--- a/crates/graphics_engine/src/lib.rs
+++ b/crates/graphics_engine/src/lib.rs
@@ -27,8 +27,8 @@ use crate::{
     descriptors::{DescriptorResources, FrameDescriptorSets},
     layout_transitioner::LayoutTransitioner,
     passes::{
-        Blitter, Compose, Scale, clear_frame_pass, render_blitter_pass, render_compose_pass,
-        render_scale_pass,
+        Blitter, Compose, Crt, Scale, clear_frame_pass, render_blitter_pass, render_compose_pass,
+        render_crt_pass, render_scale_pass,
     },
     pipeline_loader::PipelineLoader,
     plumbing::{
@@ -103,6 +103,8 @@ pub struct GraphicsEngine {
     compose: Compose,
     /// Scales the native-resolution image to the window resolution.
     scale: Scale,
+    /// Applies CRT scaling from the native-resolution image to the window resolution.
+    crt: Crt,
     /// Copies the color target to the swapchain.
     blitter: Blitter,
     /// Pipeline loader for creating graphics pipelines.
@@ -188,6 +190,9 @@ impl GraphicsEngine {
         let scale = Scale::new(&pipeline_loader, descriptor_resources.pipeline_layout())
             .context("Can't create scale pipeline")?;
 
+        let crt = Crt::new(&pipeline_loader, descriptor_resources.pipeline_layout())
+            .context("Can't create crt pipeline")?;
+
         let blitter = Blitter::new(
             &pipeline_loader,
             DEFAULT_BLITTER_IMAGE_FORMAT,
@@ -218,6 +223,7 @@ impl GraphicsEngine {
             layout_transitioner,
             compose,
             scale,
+            crt,
             blitter,
             pipeline_loader,
             frame_resources: None,
@@ -526,10 +532,8 @@ impl GraphicsEngine {
                         encoder.end_debug_label();
                     }
 
-                    // Stage 2 - Scale: read native_target, write to color_target (window res).
+                    // Stage 2 - Upscale: read native_target, write to color_target (window res).
                     {
-                        encoder.begin_debug_label(c"Scale Pass", [0.0, 1.0, 0.0, 1.0]);
-
                         let gdc_al = render_instructions.display_snapshot.gdc_graphics_al;
                         let native_height = if (render_instructions.display_snapshot.display_flags
                             & DISPLAY_FLAG_PEGC_256_COLOR)
@@ -541,13 +545,25 @@ impl GraphicsEngine {
                             400
                         };
 
-                        render_scale_pass(
-                            &mut encoder,
-                            self.resources.color_target(),
-                            &self.scale,
-                            native_height,
-                            self.descriptor_resources.pipeline_layout(),
-                        );
+                        if render_instructions.crt {
+                            encoder.begin_debug_label(c"CRT Pass", [0.0, 1.0, 0.0, 1.0]);
+                            render_crt_pass(
+                                &mut encoder,
+                                self.resources.color_target(),
+                                &self.crt,
+                                native_height,
+                                self.descriptor_resources.pipeline_layout(),
+                            );
+                        } else {
+                            encoder.begin_debug_label(c"Scale Pass", [0.0, 1.0, 0.0, 1.0]);
+                            render_scale_pass(
+                                &mut encoder,
+                                self.resources.color_target(),
+                                &self.scale,
+                                native_height,
+                                self.descriptor_resources.pipeline_layout(),
+                            );
+                        }
                         encoder.end_debug_label();
                     }
 

--- a/crates/graphics_engine/src/passes.rs
+++ b/crates/graphics_engine/src/passes.rs
@@ -1,14 +1,49 @@
+use jay_ash::vk;
+
 use crate::plumbing::RenderingEncoder;
 
 mod blitter;
 mod clear;
 mod compose;
+mod crt;
 mod scale;
 
 pub(crate) use blitter::*;
 pub(crate) use clear::*;
 pub(crate) use compose::{Compose, render_compose_pass};
+pub(crate) use crt::{Crt, render_crt_pass};
 pub(crate) use scale::{Scale, render_scale_pass};
+
+pub(crate) struct UpscalePushConstants {
+    content_height: f32,
+    output_size: [f32; 2],
+    source_size: [f32; 2],
+}
+
+impl UpscalePushConstants {
+    pub(crate) fn new(
+        output_extent: vk::Extent2D,
+        source_width: u32,
+        source_height: u32,
+        content_height: u32,
+    ) -> Self {
+        Self {
+            content_height: content_height as f32,
+            output_size: [output_extent.width as f32, output_extent.height as f32],
+            source_size: [source_width as f32, source_height as f32],
+        }
+    }
+
+    pub(crate) fn to_le_bytes(&self) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        bytes[0..4].copy_from_slice(&self.content_height.to_le_bytes());
+        bytes[8..12].copy_from_slice(&self.output_size[0].to_le_bytes());
+        bytes[12..16].copy_from_slice(&self.output_size[1].to_le_bytes());
+        bytes[16..20].copy_from_slice(&self.source_size[0].to_le_bytes());
+        bytes[20..24].copy_from_slice(&self.source_size[1].to_le_bytes());
+        bytes
+    }
+}
 
 pub(crate) trait Renderer {
     type DrawData;

--- a/crates/graphics_engine/src/passes/crt.rs
+++ b/crates/graphics_engine/src/passes/crt.rs
@@ -1,19 +1,19 @@
 #[allow(clippy::module_inception)]
-mod scale;
+mod crt;
 
 use jay_ash::vk;
 
-pub(crate) use self::scale::Scale;
+pub(crate) use self::crt::Crt;
 use crate::{
     passes::{Renderer, UpscalePushConstants},
     plumbing::{ColorTargetImage, CommandEncoder},
 };
 
-/// Renders the scale pass (Stage 2): native-resolution to window-resolution color target.
-pub(crate) fn render_scale_pass(
+/// Renders the CRT pass (Stage 2): native-resolution to window-resolution color target.
+pub(crate) fn render_crt_pass(
     encoder: &mut CommandEncoder,
     color_target: &ColorTargetImage,
-    scale: &Scale,
+    crt: &Crt,
     native_height: u32,
     pipeline_layout: vk::PipelineLayout,
 ) {
@@ -86,7 +86,7 @@ pub(crate) fn render_scale_pass(
             &push_constants.to_le_bytes(),
         );
 
-        scale.render(&rendering_encoder, ());
+        crt.render(&rendering_encoder, ());
     }
 
     encoder.image_barrier(

--- a/crates/graphics_engine/src/passes/crt/crt.rs
+++ b/crates/graphics_engine/src/passes/crt/crt.rs
@@ -1,0 +1,56 @@
+use common::Context as _;
+use jay_ash::vk;
+
+use crate::{
+    passes::Renderer,
+    pipeline_loader::PipelineLoader,
+    plumbing::{
+        GraphicsPipeline, PipelineBlendState, PipelineConfig, PipelineMultisampleState,
+        RenderingEncoder,
+    },
+};
+
+static CRT_SPV: &[u8] = include_bytes!(concat!(
+    env!("OUT_DIR"),
+    "/shaders_compiled/passes/crt/crt.spv"
+));
+
+pub(crate) struct Crt {
+    pipeline: GraphicsPipeline,
+}
+
+impl Crt {
+    pub(crate) fn new(
+        pipeline_loader: &PipelineLoader,
+        pipeline_layout: vk::PipelineLayout,
+    ) -> crate::Result<Self> {
+        let pipeline = pipeline_loader
+            .compile_graphics_pipeline(
+                "crt",
+                CRT_SPV,
+                c"vs_main",
+                c"fs_main",
+                &PipelineConfig {
+                    color_formats: vec![vk::Format::R8G8B8A8_SRGB],
+                    depth_format: None,
+                    blend_state: PipelineBlendState::default(),
+                    multisample_state: PipelineMultisampleState::default(),
+                    specialization_info: None,
+                    vertex_input: None,
+                    pipeline_layout,
+                },
+            )
+            .context("Can't load crt pipeline")?;
+
+        Ok(Self { pipeline })
+    }
+}
+
+impl Renderer for Crt {
+    type DrawData = ();
+
+    fn render(&self, encoder: &RenderingEncoder<'_>, _draw_data: Self::DrawData) {
+        encoder.bind_pipeline(&self.pipeline);
+        encoder.draw(3, 1, 0, 0);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,7 @@ Options:
       --cdrom <PATH>            CD-ROM disc image CUE file (repeatable, PC-9821 only)
       --audio-volume <FLOAT>    Audio volume 0.0-1.0
       --aspect-mode <MODE>      Display aspect mode: 4:3 or 1:1
+      --crt <on|off>            Enable CRT effect (default: on)
       --window-mode <MODE>      Window mode: windowed or fullscreen
       --force-gdc-clock <2.5|5> Force GDC clock to 2.5 or 5 MHz (default: auto)
       --bios-rom <PATH>         Path to BIOS ROM file
@@ -330,16 +331,24 @@ fn parse_convert_hdd_args(args: &mut impl Iterator<Item = String>) -> crate::Res
 }
 
 pub fn parse_args() -> crate::Result<Action> {
+    parse_args_from(std::env::args().skip(1), true)
+}
+
+fn parse_args_from(
+    args: impl IntoIterator<Item = String>,
+    load_global_config: bool,
+) -> crate::Result<Action> {
     let mut config = EmulatorConfig::default();
 
-    if let Some(global_path) = global_config_path()
+    if load_global_config
+        && let Some(global_path) = global_config_path()
         && global_path.exists()
     {
         apply_config_file(&mut config, &global_path)?;
         info!("Loaded global config: {}", global_path.display());
     }
 
-    let mut args = std::env::args().skip(1);
+    let mut args = args.into_iter();
 
     while let Some(arg) = args.next() {
         if arg == "create-fdd" {
@@ -395,6 +404,10 @@ pub fn parse_args() -> crate::Result<Action> {
             "--aspect-mode" => {
                 let val = value(&flag)?;
                 config.aspect_mode = val.parse::<AspectMode>().map_err(StringError)?;
+            }
+            "--crt" => {
+                let val = value(&flag)?;
+                config.crt = parse_on_off(&val, &flag)?;
             }
             "--window-mode" => {
                 let val = value(&flag)?;
@@ -479,6 +492,7 @@ pub struct EmulatorConfig {
     pub hdd2: Option<PathBuf>,
     pub cdrom: Vec<PathBuf>,
     pub aspect_mode: AspectMode,
+    pub crt: bool,
     pub window_mode: WindowMode,
     pub audio_volume: f32,
     pub bios_rom: Option<PathBuf>,
@@ -506,6 +520,7 @@ impl Default for EmulatorConfig {
             hdd2: None,
             cdrom: Vec::new(),
             aspect_mode: AspectMode::Aspect4By3,
+            crt: true,
             window_mode: WindowMode::Windowed,
             audio_volume: 1.0,
             bios_rom: None,
@@ -558,6 +573,11 @@ fn apply_config_file(config: &mut EmulatorConfig, path: &Path) -> crate::Result<
             "aspect-mode" => match val.parse::<AspectMode>() {
                 Ok(mode) => config.aspect_mode = mode,
                 Err(_) => warn!("Unknown aspect mode in config: {val}"),
+            },
+            "crt" => match val {
+                "on" => config.crt = true,
+                "off" => config.crt = false,
+                _ => warn!("Invalid crt in config: {val}, expected on or off"),
             },
             "window-mode" => match val.parse::<WindowMode>() {
                 Ok(mode) => config.window_mode = mode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,8 @@ struct Application {
     cdrom_index: Option<usize>,
     /// Active image selection screen, if open.
     image_selector: Option<ImageSelector>,
+    /// Whether the CRT effect is enabled.
+    crt_enabled: bool,
     /// Whether the window is currently in fullscreen mode.
     fullscreen: bool,
     /// Accumulated emulation busy time in the current measurement window.
@@ -378,6 +380,7 @@ impl Application {
         }
 
         let cpu_hz = machine.cpu_clock_hz();
+        let crt_enabled = config.crt;
 
         let graphics_engine = GraphicsEngine::new(
             platform_extensions,
@@ -389,6 +392,7 @@ impl Application {
         let scale_factor = window.display_scale();
 
         info!("Window created with scale factor: {scale_factor}");
+        info!("CRT effect set to {}", on_off(crt_enabled));
 
         Ok(Self {
             machine,
@@ -414,6 +418,7 @@ impl Application {
             cdrom_entries,
             cdrom_index,
             image_selector: None,
+            crt_enabled,
             fullscreen: config.window_mode == WindowMode::Fullscreen,
             busy_duration: Duration::ZERO,
             window_title_last_update: Instant::now(),
@@ -532,6 +537,8 @@ impl Application {
                                 self.fullscreen = !self.fullscreen;
                             }
                         }
+                    } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::F1) {
+                        self.toggle_crt();
                     } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::F9) {
                         self.open_or_toggle_selector(MediaType::Floppy(0));
                     } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::F10) {
@@ -733,6 +740,11 @@ impl Application {
         }
     }
 
+    fn toggle_crt(&mut self) {
+        self.crt_enabled = !self.crt_enabled;
+        info!("CRT effect set to {}", on_off(self.crt_enabled));
+    }
+
     fn handle_selector_key(&mut self, scancode: Option<Scancode>, alt_gui_held: bool) {
         let Some(code) = scancode else { return };
 
@@ -861,11 +873,16 @@ impl Application {
             .render_frame(Some(&RenderInstructions {
                 display_snapshot,
                 pegc_snapshot,
+                crt: self.crt_enabled,
             }))
             .context("Graphics engine failed to render frame")?;
 
         Ok(())
     }
+}
+
+const fn on_off(enabled: bool) -> &'static str {
+    if enabled { "on" } else { "off" }
 }
 
 /// Returns the current host local time as a 6-byte BCD buffer for the µPD4990A RTC.


### PR DESCRIPTION
Implemented a single pass CRT shader, that aims to approximate a 90s RGB CRT. This effect helps with diffusing harsh dithering. Because of that I will activate it on default. People can activate / deactivate it at runtime with GUI+ALT+F1. There is also a config / cli (--crt) option for it.

Example without:

<img width="2115" height="1677" alt="Screenshot_20260414_182902" src="https://github.com/user-attachments/assets/f332828c-58f4-4101-a8cb-388f6de3cf82" />


Example with:

<img width="2115" height="1677" alt="Screenshot_20260414_182914" src="https://github.com/user-attachments/assets/85a684c8-d188-4150-9021-2bc72478ef8a" />
