### PR TITLE
fix(os): sync hardware cursor state bidirectionally across HLE OS syscall dispatch

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -27,7 +27,7 @@ pub use jis::{
 };
 pub use os::{
     AudioChannelInfo, CdAudioState, CdAudioStatus, CdromIo, CdromTrackInfo, CdromTrackType,
-    ConsoleIo, CpuAccess, DiskIo, DriveIo, MemoryAccess,
+    ConsoleIo, CpuAccess, CursorAccess, DiskIo, DriveIo, HardwareCursorState, MemoryAccess,
 };
 pub use stack_vec::StackVec;
 pub use trace::{NoTracing, OsBootStage, Tracing};

--- a/crates/common/src/os.rs
+++ b/crates/common/src/os.rs
@@ -209,6 +209,32 @@ pub struct AudioChannelInfo {
     pub volume: [u8; 4],
 }
 
+/// Snapshot of the master GDC text cursor the HLE BIOS manages.
+///
+/// Shared between the BIOS (authoritative owner of the GDC) and the HLE OS
+/// (owner of its IOSYS cursor bookkeeping) so the two can be reconciled at
+/// each syscall boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HardwareCursorState {
+    /// Whether the cursor is displayed on screen.
+    pub visible: bool,
+    /// Row (0-based character row; ead / 80).
+    pub row: u8,
+    /// Column (0-based character column; ead % 80).
+    pub col: u8,
+}
+
+/// Read/write access to the BIOS-owned hardware text cursor state.
+///
+/// Used by the HLE OS to reconcile its IOSYS cursor tracking with whatever
+/// the BIOS has done since the previous DOS syscall.
+pub trait CursorAccess {
+    /// Returns the current hardware cursor state.
+    fn read(&self) -> HardwareCursorState;
+    /// Writes the hardware cursor state.
+    fn write(&mut self, state: HardwareCursorState);
+}
+
 /// Console I/O for commands and the shell.
 pub trait ConsoleIo {
     /// Write a character to the console at the current cursor position.

--- a/crates/machine/src/bus.rs
+++ b/crates/machine/src/bus.rs
@@ -1311,6 +1311,16 @@ impl<T: Tracing> Pc9801Bus<T> {
         self.read_byte_with_access_page(physical_address)
     }
 
+    /// Sets the master-GDC text cursor position to (row, col).
+    ///
+    /// Intended for test harnesses that need to position the text cursor
+    /// without going through INT 18H AH=13h. Writes only the GDC execute
+    /// address (ead) - callers that also need the HLE OS IOSYS fields
+    /// updated must do that separately.
+    pub fn set_text_cursor_position(&mut self, row: u8, col: u8) {
+        self.gdc_master.state.ead = u32::from(row) * 80 + u32::from(col);
+    }
+
     /// Returns a reference to the raw text VRAM contents (16 KB).
     pub fn text_vram(&self) -> &[u8] {
         self.memory.state.text_vram.as_slice()

--- a/crates/machine/src/bus/bios.rs
+++ b/crates/machine/src/bus/bios.rs
@@ -10,7 +10,7 @@ use device::{floppy::D88MediaType, i8253_pit::PIT_FLAG_I, upd7220_gdc::GdcScroll
 
 use super::{
     BootDevice, Pc9801Bus,
-    os_adapter::{OsCpuAccess, OsDiskIo, OsMemoryAccess},
+    os_adapter::{OsCpuAccess, OsCursorAccess, OsDiskIo, OsMemoryAccess},
 };
 use crate::{Tracing, memory::Pc9801Memory};
 
@@ -143,15 +143,16 @@ impl<T: Tracing> Pc9801Bus<T> {
                         sasi: &mut self.sasi,
                         ide: &mut self.ide,
                     };
+                    let mut cursor_access = OsCursorAccess(&mut self.gdc_master.state);
                     neetan_os.dispatch(
                         vector,
                         &mut cpu_access,
                         &mut mem_access,
                         &mut disk_io,
+                        &mut cursor_access,
                         &mut self.tracer,
                     );
                     self.os = Some(neetan_os);
-                    self.sync_cursor();
                 }
             }
             0xD2 => {}
@@ -164,17 +165,6 @@ impl<T: Tracing> Pc9801Bus<T> {
             0xF1 | 0xF2 => self.hle_bootstrap(cpu),
             _ => {}
         }
-    }
-
-    /// Sync HLE OS software cursor to GDC hardware cursor.
-    fn sync_cursor(&mut self) {
-        let iosys = os::tables::IOSYS_BASE as usize;
-        let cursor_y = self.memory.state.ram[iosys + os::tables::IOSYS_OFF_CURSOR_Y as usize];
-        let cursor_x = self.memory.state.ram[iosys + os::tables::IOSYS_OFF_CURSOR_X as usize];
-        self.gdc_master.state.ead = cursor_y as u32 * 80 + cursor_x as u32;
-        let cursor_visible =
-            self.memory.state.ram[iosys + os::tables::IOSYS_OFF_CURSOR_VISIBLE as usize];
-        self.gdc_master.state.cursor_display = cursor_visible != 0;
     }
 
     pub(super) fn set_iret_cf(&mut self, cpu: &impl Cpu, error: bool) {

--- a/crates/machine/src/bus/os_adapter.rs
+++ b/crates/machine/src/bus/os_adapter.rs
@@ -5,11 +5,11 @@
 
 use common::{
     AudioChannelInfo, CdAudioState, CdAudioStatus, CdromIo, CdromTrackInfo, CdromTrackType, Cpu,
-    CpuAccess, DiskIo, MemoryAccess,
+    CpuAccess, CursorAccess, DiskIo, HardwareCursorState, MemoryAccess,
 };
 use device::{
     cd_audio::CdAudioState as DeviceCdAudioState, cdrom::TrackType, ide::IdeController,
-    sasi::SasiController, upd765a_fdc::FloppyController,
+    sasi::SasiController, upd765a_fdc::FloppyController, upd7220_gdc::GdcState,
 };
 
 use crate::memory::Pc9801Memory;
@@ -196,6 +196,24 @@ impl MemoryAccess for OsMemoryAccess<'_> {
 
     fn enable_umb_region(&mut self) {
         self.0.enable_umb_region();
+    }
+}
+
+pub(super) struct OsCursorAccess<'a>(pub &'a mut GdcState);
+
+impl CursorAccess for OsCursorAccess<'_> {
+    fn read(&self) -> HardwareCursorState {
+        let ead = self.0.ead;
+        HardwareCursorState {
+            visible: self.0.cursor_display,
+            row: (ead / 80) as u8,
+            col: (ead % 80) as u8,
+        }
+    }
+
+    fn write(&mut self, state: HardwareCursorState) {
+        self.0.cursor_display = state.visible;
+        self.0.ead = u32::from(state.row) * 80 + u32::from(state.col);
     }
 }
 

--- a/crates/os/src/lib.rs
+++ b/crates/os/src/lib.rs
@@ -29,7 +29,8 @@ use std::collections::BTreeMap;
 
 pub use common::{
     AudioChannelInfo, CdAudioState, CdAudioStatus, CdromIo, CdromTrackInfo, CdromTrackType,
-    ConsoleIo, CpuAccess, DiskIo, DriveIo, MemoryAccess, OsBootStage, Tracing,
+    ConsoleIo, CpuAccess, CursorAccess, DiskIo, DriveIo, HardwareCursorState, MemoryAccess,
+    OsBootStage, Tracing,
 };
 
 /// Information about a discovered drive for CDS/DPB/DAUA population.
@@ -326,6 +327,23 @@ impl Default for NeetanOs {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn sync_hardware_cursor_to_iosys(cursor: &impl CursorAccess, memory: &mut dyn MemoryAccess) {
+    let state = cursor.read();
+    memory.write_byte(
+        tables::IOSYS_BASE + tables::IOSYS_OFF_CURSOR_VISIBLE,
+        u8::from(state.visible),
+    );
+    memory.write_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_CURSOR_Y, state.row);
+    memory.write_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_CURSOR_X, state.col);
+}
+
+fn sync_iosys_to_hardware_cursor(cursor: &mut impl CursorAccess, memory: &dyn MemoryAccess) {
+    let visible = memory.read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_CURSOR_VISIBLE) != 0;
+    let row = memory.read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_CURSOR_Y);
+    let col = memory.read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_CURSOR_X);
+    cursor.write(HardwareCursorState { visible, row, col });
 }
 
 impl NeetanOs {
@@ -836,7 +854,28 @@ impl NeetanOs {
     /// `vector`: interrupt number (0x20-0x2F, 0x33, 0xDC).
     /// Returns `true` if the interrupt was handled, `false` if the vector
     /// should fall through to the default IRET behavior.
+    ///
+    /// Reconciles the BIOS-owned hardware cursor with the HLE OS IOSYS cursor
+    /// tracking at entry and exit: the OS overwrites its IOSYS copy from the
+    /// hardware first (so it does not act on stale state), runs the syscall,
+    /// then writes any OS-side cursor changes back to the hardware.
     pub fn dispatch(
+        &mut self,
+        vector: u8,
+        cpu: &mut dyn CpuAccess,
+        memory: &mut dyn MemoryAccess,
+        device: &mut (impl DiskIo + CdromIo),
+        cursor: &mut impl CursorAccess,
+        tracer: &mut impl Tracing,
+    ) -> bool {
+        sync_hardware_cursor_to_iosys(cursor, memory);
+        tracer.trace_os_dispatch(vector, cpu, memory);
+        let result = self.dispatch_inner(vector, cpu, memory, device, tracer);
+        sync_iosys_to_hardware_cursor(cursor, memory);
+        result
+    }
+
+    fn dispatch_inner(
         &mut self,
         vector: u8,
         cpu: &mut dyn CpuAccess,
@@ -844,7 +883,6 @@ impl NeetanOs {
         device: &mut (impl DiskIo + CdromIo),
         tracer: &mut impl Tracing,
     ) -> bool {
-        tracer.trace_os_dispatch(vector, cpu, memory);
         match vector {
             0x20 => {
                 tracer.trace_int20h(cpu, memory);

--- a/crates/os/tests/dos620.rs
+++ b/crates/os/tests/dos620.rs
@@ -31,6 +31,9 @@ mod compatibility;
 #[path = "dos620/escape_sequences.rs"]
 mod escape_sequences;
 
+#[path = "dos620/cursor_sync.rs"]
+mod cursor_sync;
+
 #[path = "dos620/syscalls_int21h.rs"]
 mod syscalls_int21h;
 

--- a/crates/os/tests/dos620/cursor_sync.rs
+++ b/crates/os/tests/dos620/cursor_sync.rs
@@ -1,0 +1,105 @@
+//! Bidirectional cursor sync across HLE OS syscall dispatch.
+//!
+//! The BIOS owns the master GDC cursor state and the HLE OS owns the IOSYS
+//! cursor fields. `NeetanOs::dispatch` reconciles them at entry (GDC -> IOSYS)
+//! and exit (IOSYS -> GDC) so BIOS-side updates survive intervening DOS calls
+//! and OS-side updates (e.g. ANSI ESC sequences) propagate to the hardware.
+
+use crate::harness;
+
+#[test]
+fn bios_hide_cursor_survives_dos_syscall() {
+    let mut machine = harness::boot_hle();
+
+    // Show the cursor via BIOS, hide it via BIOS, then trigger a harmless
+    // HLE DOS syscall (INT 2Ah is a no-op stub but still goes through the
+    // NeetanOs dispatch path). Without the pre-dispatch GDC -> IOSYS sync,
+    // the post-dispatch IOSYS -> GDC sync would read a stale IOSYS
+    // (cursor_visible = 1, initialised at boot) and revert the BIOS hide.
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xB4, 0x11, 0xCD, 0x18,     // INT 18h AH=11h  (show cursor)
+        0xB4, 0x12, 0xCD, 0x18,     // INT 18h AH=12h  (hide cursor)
+        0xCD, 0x2A,                 // INT 2Ah         (no-op HLE DOS syscall)
+        0xFA, 0xF4,                 // CLI; HLT
+    ];
+    harness::inject_and_run(&mut machine, code);
+
+    let state = machine.save_state();
+    assert!(
+        !state.gdc_master.cursor_display,
+        "BIOS AH=12h hide must survive intervening HLE DOS syscall dispatch",
+    );
+}
+
+#[test]
+fn bios_cursor_position_survives_dos_syscall() {
+    let mut machine = harness::boot_hle();
+
+    // AH=13h sets the master-GDC cursor position (DX is the byte offset;
+    // ead = DX / 2). DX=0x0140 -> ead = 0xA0 = row 2, col 0. Without the
+    // pre-dispatch sync, the post-dispatch IOSYS -> GDC sync would read
+    // IOSYS_OFF_CURSOR_X/Y (still 0, initialised at boot) and move the
+    // hardware cursor back to (0, 0).
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xB4, 0x13, 0xBA, 0x40, 0x01, 0xCD, 0x18,   // INT 18h AH=13h DX=0x0140
+        0xCD, 0x2A,                                 // INT 2Ah (no-op)
+        0xFA, 0xF4,                                 // CLI; HLT
+    ];
+    harness::inject_and_run(&mut machine, code);
+
+    let state = machine.save_state();
+    assert_eq!(
+        state.gdc_master.ead, 0xA0,
+        "BIOS AH=13h cursor position must survive intervening HLE DOS syscall dispatch",
+    );
+}
+
+#[test]
+fn os_cursor_show_escape_propagates_to_gdc() {
+    let mut machine = harness::boot_hle();
+
+    // Hide the cursor via BIOS, then feed ESC[>5l through INT 29h. The
+    // HLE OS ESC handler sets IOSYS_OFF_CURSOR_VISIBLE = 0x01. The
+    // post-dispatch IOSYS -> GDC sync must propagate the change back to
+    // the master GDC.
+    let mut code: Vec<u8> = vec![
+        0xB4, 0x12, 0xCD, 0x18, // INT 18h AH=12h (hide cursor)
+    ];
+    for byte in [0x1B, b'[', b'>', b'5', b'l'] {
+        code.extend_from_slice(&[0xB0, byte, 0xCD, 0x29]); // MOV AL,byte; INT 29h
+    }
+    code.extend_from_slice(&[0xFA, 0xF4]); // CLI; HLT
+    harness::inject_and_run(&mut machine, &code);
+
+    let state = machine.save_state();
+    assert!(
+        state.gdc_master.cursor_display,
+        "OS-level ESC[>5l must reach the hardware via post-dispatch sync",
+    );
+}
+
+#[test]
+fn os_cursor_hide_escape_propagates_to_gdc() {
+    let mut machine = harness::boot_hle();
+
+    // Show the cursor via BIOS, then feed ESC[>5h through INT 29h. The
+    // HLE OS ESC handler sets IOSYS_OFF_CURSOR_VISIBLE = 0x00. The
+    // post-dispatch IOSYS -> GDC sync must propagate the change back to
+    // the master GDC.
+    let mut code: Vec<u8> = vec![
+        0xB4, 0x11, 0xCD, 0x18, // INT 18h AH=11h (show cursor)
+    ];
+    for byte in [0x1B, b'[', b'>', b'5', b'h'] {
+        code.extend_from_slice(&[0xB0, byte, 0xCD, 0x29]);
+    }
+    code.extend_from_slice(&[0xFA, 0xF4]);
+    harness::inject_and_run(&mut machine, &code);
+
+    let state = machine.save_state();
+    assert!(
+        !state.gdc_master.cursor_display,
+        "OS-level ESC[>5h must reach the hardware via post-dispatch sync",
+    );
+}

--- a/crates/os/tests/dos620/escape_sequences.rs
+++ b/crates/os/tests/dos620/escape_sequences.rs
@@ -15,8 +15,7 @@ fn write_ascii_text(machine: &mut machine::Pc9801Ra, row: u32, col: u32, text: &
 }
 
 fn set_cursor(machine: &mut machine::Pc9801Ra, row: u8, col: u8) {
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_Y, &[row]);
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_X, &[col]);
+    harness::set_cursor_position(&mut machine.bus, row, col);
 }
 
 fn cursor(machine: &machine::Pc9801Ra) -> (u8, u8) {

--- a/crates/os/tests/dos620/harness.rs
+++ b/crates/os/tests/dos620/harness.rs
@@ -3,7 +3,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use common::{Bus, JisChar, Machine as _, MachineModel};
+use common::{Bus, JisChar, Machine as _, MachineModel, Tracing};
 use device::{
     disk::{HddFormat, HddGeometry, HddImage},
     floppy::d88::{D88Disk, D88MediaType, D88Sector},
@@ -835,6 +835,16 @@ pub fn write_bytes(bus: &mut impl Bus, addr: u32, data: &[u8]) {
     for (i, &byte) in data.iter().enumerate() {
         bus.write_byte(addr + i as u32, byte);
     }
+}
+
+/// Sets both IOSYS and GDC text cursor position so the HLE OS dispatch
+/// pre-sync does not clobber the test setup with stale GDC state.
+pub fn set_cursor_position<T: Tracing>(bus: &mut machine::Pc9801Bus<T>, row: u8, col: u8) {
+    const IOSYS_CURSOR_Y: u32 = 0x0600 + 0x0110;
+    const IOSYS_CURSOR_X: u32 = 0x0600 + 0x011C;
+    bus.set_text_cursor_position(row, col);
+    bus.write_byte(IOSYS_CURSOR_Y, row);
+    bus.write_byte(IOSYS_CURSOR_X, col);
 }
 
 pub fn inject_and_run(machine: &mut machine::Pc9801Ra, code: &[u8]) {

--- a/crates/os/tests/dos620/syscalls_intdch.rs
+++ b/crates/os/tests/dos620/syscalls_intdch.rs
@@ -206,8 +206,7 @@ fn fnkey_write_then_read_roundtrip() {
 #[test]
 fn intdch_10h_04h_cursor_down_one_line() {
     let mut machine = harness::boot_hle();
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_Y, &[5]);
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_X, &[10]);
+    harness::set_cursor_position(&mut machine.bus, 5, 10);
     #[rustfmt::skip]
     let code: &[u8] = &[
         0xB9, 0x10, 0x00,       // MOV CX, 0010h (CL=10h)
@@ -225,8 +224,7 @@ fn intdch_10h_04h_cursor_down_one_line() {
 #[test]
 fn intdch_10h_05h_cursor_up_one_line() {
     let mut machine = harness::boot_hle();
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_Y, &[5]);
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_X, &[10]);
+    harness::set_cursor_position(&mut machine.bus, 5, 10);
     #[rustfmt::skip]
     let code: &[u8] = &[
         0xB9, 0x10, 0x00,       // MOV CX, 0010h (CL=10h)
@@ -244,8 +242,7 @@ fn intdch_10h_05h_cursor_up_one_line() {
 #[test]
 fn intdch_10h_06h_cursor_up_n_lines() {
     let mut machine = harness::boot_hle();
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_Y, &[10]);
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_X, &[5]);
+    harness::set_cursor_position(&mut machine.bus, 10, 5);
     #[rustfmt::skip]
     let code: &[u8] = &[
         0xB9, 0x10, 0x00,       // MOV CX, 0010h (CL=10h)
@@ -264,8 +261,7 @@ fn intdch_10h_06h_cursor_up_n_lines() {
 #[test]
 fn intdch_10h_07h_cursor_down_n_lines() {
     let mut machine = harness::boot_hle();
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_Y, &[5]);
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_X, &[10]);
+    harness::set_cursor_position(&mut machine.bus, 5, 10);
     #[rustfmt::skip]
     let code: &[u8] = &[
         0xB9, 0x10, 0x00,       // MOV CX, 0010h (CL=10h)
@@ -284,8 +280,7 @@ fn intdch_10h_07h_cursor_down_n_lines() {
 #[test]
 fn intdch_10h_08h_cursor_right_n_cols() {
     let mut machine = harness::boot_hle();
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_Y, &[5]);
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_X, &[10]);
+    harness::set_cursor_position(&mut machine.bus, 5, 10);
     #[rustfmt::skip]
     let code: &[u8] = &[
         0xB9, 0x10, 0x00,       // MOV CX, 0010h (CL=10h)
@@ -304,8 +299,7 @@ fn intdch_10h_08h_cursor_right_n_cols() {
 #[test]
 fn intdch_10h_09h_cursor_left_n_cols() {
     let mut machine = harness::boot_hle();
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_Y, &[5]);
-    harness::write_bytes(&mut machine.bus, IOSYS_CURSOR_X, &[10]);
+    harness::set_cursor_position(&mut machine.bus, 5, 10);
     #[rustfmt::skip]
     let code: &[u8] = &[
         0xB9, 0x10, 0x00,       // MOV CX, 0010h (CL=10h)


### PR DESCRIPTION
This fixes the blinking cursor that was visible on games like Yuno, Dōkyūsei 2 and Princess Maker 2 when using the HLE OS.