### PR TITLE
feature: add cycle-count accurate 8086 CPU emulation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,9 @@
 [submodule "crates/cpu/tests/SingleStepTests/z80"]
 	path = crates/cpu/tests/SingleStepTests/z80
 	url = https://github.com/hasenbanck/z80
+[submodule "crates/cpu/tests/SingleStepTests/8088"]
+	path = crates/cpu/tests/SingleStepTests/8088
+	url = https://github.com/SingleStepTests/8088
+[submodule "crates/cpu/tests/SingleStepTests/8086"]
+	path = crates/cpu/tests/SingleStepTests/8086
+	url = https://github.com/SingleStepTests/8086

--- a/README.md
+++ b/README.md
@@ -352,7 +352,9 @@ Following projects provided references for our implementation and test vectors. 
 neetan:
 
 - [MAME](https://www.mamedev.org/) 
+- [MartyPC](https://github.com/dbalsom/martypc)
 - [NP21W](https://simk98.github.io/np21w/)
+- [SingleStepTests](https://github.com/SingleStepTests)
 - [undoc98](https://www.webtech.co.jp/company/doc/undocumented_mem/index.html)
 
 We ported the Yamaha OPN and OPL emulation from the amazing YMFM project to our own Rust port:

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -35,6 +35,8 @@ pub use trace::{NoTracing, OsBootStage, Tracing};
 /// CPU generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CpuType {
+    /// Intel 8086.
+    I8086,
     /// NEC V30 (µPD70116).
     V30,
     /// Intel 80286.
@@ -333,6 +335,7 @@ const EVENT_KIND_COUNT: usize = 21;
 /// appropriate mask for the emulated CPU generation:
 ///
 /// - Z80: 16-bit (64 Kib address space)
+/// - i8086: 20-bit (1 MB address space)
 /// - V30: 20-bit (1 MB address space)
 /// - i286: 24-bit (16 MB address space)
 /// - i386+: full 32-bit (4 GB address space)

--- a/crates/cpu/src/i8086.rs
+++ b/crates/cpu/src/i8086.rs
@@ -1,0 +1,1075 @@
+//! Implements the Intel 8086 CPU emulator.
+
+mod alu;
+mod biu;
+mod execute;
+mod execute_group;
+mod flags;
+mod interrupt;
+mod modrm;
+mod muldiv_timing;
+mod rep;
+mod state;
+mod string_ops;
+
+use std::ops::{Deref, DerefMut};
+
+use biu::{
+    ADDRESS_MASK, BusPendingType, BusStatus, FetchState, OperandSize, QUEUE_SIZE, QueueOp,
+    QueueType, TCycle, TaCycle, TransferSize,
+};
+use common::Cpu as _;
+pub use flags::I8086Flags;
+use rep::RepType;
+pub use state::I8086State;
+
+use crate::{SegReg16, WordReg};
+
+/// PC-9801F 8086 CPU clock at 5 MHz.
+pub const PC9801F_CPU_CLOCK_5MHZ: u32 = 5_000_000;
+
+/// PC-9801F 8086 CPU clock at 8 MHz.
+pub const PC9801F_CPU_CLOCK_8MHZ: u32 = 8_000_000;
+
+/// Intel 8086 CPU emulator.
+pub struct I8086 {
+    /// Embedded state for save/restore.
+    pub state: I8086State,
+
+    prev_ip: u16,
+    opcode_start_ip: u16,
+    seg_prefix: bool,
+    prefix_seg: SegReg16,
+
+    halted: bool,
+    pending_irq: u8,
+    no_interrupt: u8,
+    inhibit_all: u8,
+
+    rep_ip: u16,
+    rep_restart_ip: u16,
+    rep_seg_prefix: bool,
+    rep_prefix_seg: SegReg16,
+    rep_prefix: bool,
+    rep_opcode: u8,
+    rep_type: u8,
+    rep_active: bool,
+
+    cycles_remaining: i64,
+    run_start_cycle: u64,
+    run_budget: u64,
+
+    ea: u32,
+    eo: u16,
+    effective_address_segment: SegReg16,
+    modrm_displacement: u16,
+    modrm_has_displacement: bool,
+
+    instruction_queue: [u8; 6],
+    instruction_queue_len: usize,
+    instruction_preload: Option<u8>,
+    instruction_entry_queue_bytes: u8,
+    prefetch_ip: u16,
+    step_finish_cycle: StepFinishCycle,
+    nx: bool,
+    rni: bool,
+    queue_op: QueueOp,
+    last_queue_op: QueueOp,
+
+    // T-state BIU state (ported from MartyPC).
+    t_cycle: TCycle,
+    ta_cycle: TaCycle,
+    bus_status: BusStatus,
+    bus_status_latch: BusStatus,
+    pl_status: BusStatus,
+    bus_pending: BusPendingType,
+    fetch_state: FetchState,
+    transfer_size: TransferSize,
+    operand_size: OperandSize,
+    transfer_n: u32,
+    final_transfer: bool,
+    bhe: bool,
+    address_bus: u32,
+    address_latch: u32,
+    data_bus: u16,
+    cycle_num: u64,
+}
+
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+enum StepFinishCycle {
+    #[default]
+    WithFetchCycle,
+    PreloadedOnly,
+    TerminalWritebackFetchCycle,
+    TerminalWritebackRni,
+    TerminalWritebackInlineCommit,
+}
+
+impl Deref for I8086 {
+    type Target = I8086State;
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+impl DerefMut for I8086 {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.state
+    }
+}
+
+impl Default for I8086 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl I8086 {
+    /// Creates a new I8086 CPU in its reset state.
+    pub fn new() -> Self {
+        let mut cpu = Self {
+            state: I8086State::default(),
+            prev_ip: 0,
+            opcode_start_ip: 0,
+            seg_prefix: false,
+            prefix_seg: SegReg16::DS,
+            halted: false,
+            pending_irq: 0,
+            no_interrupt: 0,
+            inhibit_all: 0,
+            rep_ip: 0,
+            rep_restart_ip: 0,
+            rep_seg_prefix: false,
+            rep_prefix_seg: SegReg16::DS,
+            rep_prefix: false,
+            rep_opcode: 0,
+            rep_type: 0,
+            rep_active: false,
+            cycles_remaining: 0,
+            run_start_cycle: 0,
+            run_budget: 0,
+            ea: 0,
+            eo: 0,
+            effective_address_segment: SegReg16::DS,
+            modrm_displacement: 0,
+            modrm_has_displacement: false,
+            instruction_queue: [0; 6],
+            instruction_queue_len: 0,
+            instruction_preload: None,
+            instruction_entry_queue_bytes: 0,
+            prefetch_ip: 0,
+            step_finish_cycle: StepFinishCycle::WithFetchCycle,
+            nx: false,
+            rni: false,
+            queue_op: QueueOp::Idle,
+            last_queue_op: QueueOp::Idle,
+            t_cycle: TCycle::Ti,
+            ta_cycle: TaCycle::Td,
+            bus_status: BusStatus::Passive,
+            bus_status_latch: BusStatus::Passive,
+            pl_status: BusStatus::Passive,
+            bus_pending: BusPendingType::None,
+            fetch_state: FetchState::Normal,
+            transfer_size: TransferSize::Byte,
+            operand_size: OperandSize::Operand8,
+            transfer_n: 1,
+            final_transfer: false,
+            bhe: false,
+            address_bus: 0,
+            address_latch: 0,
+            data_bus: 0,
+            cycle_num: 0,
+        };
+        cpu.reset();
+        cpu
+    }
+
+    /// Spend `cycles` internal EU cycles (not bus transfers). Each cycle
+    /// advances the BIU T-state machine by one tick.
+    #[inline(always)]
+    fn clk(&mut self, bus: &mut impl common::Bus, cycles: i32) {
+        if cycles > 0 {
+            self.cycles(bus, cycles as u32);
+        }
+    }
+
+    #[inline(always)]
+    fn clk_modrm(
+        &mut self,
+        bus: &mut impl common::Bus,
+        modrm: u8,
+        reg_cycles: i32,
+        mem_cycles: i32,
+    ) {
+        if modrm >= 0xC0 {
+            self.clk(bus, reg_cycles);
+        } else {
+            self.clk(bus, mem_cycles);
+        }
+    }
+
+    #[inline(always)]
+    fn clk_modrm_word(
+        &mut self,
+        bus: &mut impl common::Bus,
+        modrm: u8,
+        reg_cycles: i32,
+        mem_cycles: i32,
+    ) {
+        if modrm >= 0xC0 {
+            self.clk(bus, reg_cycles);
+        } else {
+            // 8086 handles word alignment at the T-state level via
+            // `biu_read_u16`/`biu_write_u16`, so no additional penalty is
+            // added here.
+            self.clk(bus, mem_cycles);
+        }
+    }
+
+    #[inline(always)]
+    fn clk_muldiv_modrm(&mut self, bus: &mut impl common::Bus, modrm: u8, base_cycles: i32) {
+        if modrm >= 0xC0 {
+            self.clk(bus, base_cycles + 1);
+        } else {
+            self.clk(bus, base_cycles);
+        }
+    }
+
+    #[inline(always)]
+    fn clk_eaload(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 2);
+    }
+
+    #[inline(always)]
+    fn clk_eadone(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 2);
+    }
+
+    #[inline(always)]
+    fn fetch(&mut self, bus: &mut impl common::Bus) -> u8 {
+        let value = self.biu_queue_read(bus, QueueType::Subsequent);
+        self.ip = self.ip.wrapping_add(1);
+        value
+    }
+
+    #[inline(always)]
+    fn fetch_interrupt_vector(&mut self, bus: &mut impl common::Bus) -> u8 {
+        if !self.instruction_entry_queue_full() {
+            return self.fetch(bus);
+        }
+
+        let value = self.queue_pop();
+        self.queue_op = QueueOp::Subsequent;
+        self.cycle(bus);
+        self.biu_fetch_on_queue_read();
+        self.cycle(bus);
+        self.ip = self.ip.wrapping_add(1);
+        value
+    }
+
+    #[inline(always)]
+    fn fetch_first(&mut self, bus: &mut impl common::Bus) -> u8 {
+        let value = self.biu_queue_read(bus, QueueType::First);
+        self.ip = self.ip.wrapping_add(1);
+        value
+    }
+
+    #[inline(always)]
+    fn fetchword(&mut self, bus: &mut impl common::Bus) -> u16 {
+        let low = self.fetch(bus) as u16;
+        let high = self.fetch(bus) as u16;
+        low | (high << 8)
+    }
+
+    #[inline(always)]
+    fn default_segment(&self, seg: SegReg16) -> SegReg16 {
+        if self.seg_prefix && matches!(seg, SegReg16::DS | SegReg16::SS) {
+            self.prefix_seg
+        } else {
+            seg
+        }
+    }
+
+    #[inline(always)]
+    fn default_base(&self, seg: SegReg16) -> u32 {
+        self.seg_base(self.default_segment(seg))
+    }
+
+    #[inline(always)]
+    fn seg_base(&self, seg: SegReg16) -> u32 {
+        (self.sregs[seg as usize] as u32) << 4
+    }
+
+    #[inline(always)]
+    fn set_effective_address(&mut self, seg: SegReg16, offset: u16) {
+        self.effective_address_segment = self.default_segment(seg);
+        self.eo = offset;
+        self.ea = self
+            .seg_base(self.effective_address_segment)
+            .wrapping_add(offset as u32)
+            & ADDRESS_MASK;
+    }
+
+    /// Reads a word from memory at `ea + delta`, wrapping the offset
+    /// within the segment boundary (offset 0xFFFF wraps to 0x0000).
+    #[inline(always)]
+    fn seg_read_word_at(&mut self, bus: &mut impl common::Bus, delta: u16) -> u16 {
+        let offset = self.eo.wrapping_add(delta);
+        self.biu_read_u16(bus, self.effective_address_segment, offset)
+    }
+
+    /// Reads a word from memory at the current EA, wrapping the offset
+    /// within the segment boundary (offset 0xFFFF wraps to 0x0000).
+    #[inline(always)]
+    fn seg_read_word(&mut self, bus: &mut impl common::Bus) -> u16 {
+        self.seg_read_word_at(bus, 0)
+    }
+
+    /// Writes a word to memory at the current EA, wrapping the offset
+    /// within the segment boundary (offset 0xFFFF wraps to 0x0000).
+    #[inline(always)]
+    fn seg_write_word(&mut self, bus: &mut impl common::Bus, value: u16) {
+        let offset = self.eo;
+        self.biu_write_u16(bus, self.effective_address_segment, offset, value);
+    }
+
+    /// Reads a word from `seg:offset`, wrapping the offset within 16 bits.
+    #[inline(always)]
+    fn read_word_seg(&mut self, bus: &mut impl common::Bus, seg: SegReg16, offset: u16) -> u16 {
+        self.biu_read_u16(bus, seg, offset)
+    }
+
+    /// Writes a word to `seg:offset`, wrapping the offset within 16 bits.
+    #[inline(always)]
+    fn write_word_seg(
+        &mut self,
+        bus: &mut impl common::Bus,
+        seg: SegReg16,
+        offset: u16,
+        value: u16,
+    ) {
+        self.biu_write_u16(bus, seg, offset, value);
+    }
+
+    #[inline(always)]
+    fn read_memory_byte(&mut self, bus: &mut impl common::Bus, address: u32) -> u8 {
+        self.biu_read_u8_physical(bus, address)
+    }
+
+    #[inline(always)]
+    fn write_memory_byte(&mut self, bus: &mut impl common::Bus, address: u32, value: u8) {
+        self.biu_write_u8_physical(bus, address, value);
+    }
+
+    #[inline(always)]
+    fn read_memory_word(&mut self, bus: &mut impl common::Bus, address: u32) -> u16 {
+        self.biu_read_u16_physical(bus, address)
+    }
+
+    #[inline(always)]
+    fn read_io_byte(&mut self, bus: &mut impl common::Bus, port: u16) -> u8 {
+        self.biu_io_read_u8(bus, port)
+    }
+
+    #[inline(always)]
+    fn write_io_byte(&mut self, bus: &mut impl common::Bus, port: u16, value: u8) {
+        self.biu_io_write_u8(bus, port, value);
+    }
+
+    #[inline(always)]
+    fn read_io_word(&mut self, bus: &mut impl common::Bus, port: u16) -> u16 {
+        self.biu_io_read_u16(bus, port)
+    }
+
+    #[inline(always)]
+    fn write_io_word(&mut self, bus: &mut impl common::Bus, port: u16, value: u16) {
+        self.biu_io_write_u16(bus, port, value);
+    }
+
+    /// Reset queue and pipeline state without advancing the bus. Called by
+    /// the CPU trait's `set_cs`/`set_ip` which have no bus access.
+    fn flush_prefetch_queue(&mut self) {
+        self.prefetch_ip = self.ip;
+        self.queue_flush();
+        self.step_finish_cycle = StepFinishCycle::WithFetchCycle;
+        self.nx = false;
+        self.rni = false;
+        self.queue_op = QueueOp::Idle;
+        self.last_queue_op = QueueOp::Idle;
+        self.t_cycle = TCycle::Ti;
+        self.ta_cycle = TaCycle::Td;
+        self.bus_status = BusStatus::Passive;
+        self.bus_status_latch = BusStatus::Passive;
+        self.pl_status = BusStatus::Passive;
+        self.bus_pending = BusPendingType::None;
+        self.fetch_state = FetchState::Normal;
+    }
+
+    /// Flush the queue and start a fetch cycle via the BIU. Used by the EU
+    /// after jumps, interrupts, and RET-class instructions.
+    fn flush_and_fetch(&mut self, bus: &mut impl common::Bus) {
+        self.prefetch_ip = self.ip;
+        self.biu_queue_flush(bus);
+    }
+
+    fn flush_and_fetch_early(&mut self, bus: &mut impl common::Bus) {
+        self.prefetch_ip = self.ip;
+        self.biu_queue_flush_early(bus);
+    }
+
+    fn set_ip_and_flush(&mut self, bus: &mut impl common::Bus, ip: u16) {
+        self.ip = ip;
+        self.flush_and_fetch(bus);
+    }
+
+    fn set_cs_ip_and_flush(&mut self, bus: &mut impl common::Bus, cs: u16, ip: u16) {
+        self.sregs[SegReg16::CS as usize] = cs;
+        self.ip = ip;
+        self.flush_and_fetch(bus);
+    }
+
+    fn finish_step_timing(&mut self, bus: &mut impl common::Bus) {
+        if self.halted || self.rep_active {
+            self.step_finish_cycle = StepFinishCycle::WithFetchCycle;
+            return;
+        }
+
+        match self.step_finish_cycle {
+            StepFinishCycle::WithFetchCycle => self.biu_fetch_next(bus),
+            StepFinishCycle::PreloadedOnly => self.biu_preload_next(bus),
+            StepFinishCycle::TerminalWritebackFetchCycle => {
+                self.finish_terminal_writeback_with_fetch(bus);
+            }
+            StepFinishCycle::TerminalWritebackRni => self.finish_terminal_writeback_rni(bus),
+            StepFinishCycle::TerminalWritebackInlineCommit => {
+                self.biu_commit_pending_write_inline(bus);
+            }
+        }
+        self.step_finish_cycle = StepFinishCycle::WithFetchCycle;
+    }
+
+    fn reset_instruction_timing(&mut self) {
+        self.modrm_displacement = 0;
+        self.modrm_has_displacement = false;
+        self.step_finish_cycle = StepFinishCycle::WithFetchCycle;
+    }
+
+    #[inline(always)]
+    fn finish_on_terminal_writeback(&mut self, modrm: u8) {
+        if modrm < 0xC0 {
+            self.step_finish_cycle = StepFinishCycle::TerminalWritebackRni;
+        }
+    }
+
+    #[inline(always)]
+    fn finish_on_terminal_writeback_inline_commit(&mut self, modrm: u8) {
+        if modrm < 0xC0 {
+            self.step_finish_cycle = StepFinishCycle::TerminalWritebackInlineCommit;
+        }
+    }
+
+    fn finish_on_terminal_writeback_with_fetch(&mut self, modrm: u8) {
+        if modrm < 0xC0 {
+            self.step_finish_cycle = StepFinishCycle::TerminalWritebackFetchCycle;
+        }
+    }
+
+    fn finish_terminal_writeback_with_fetch(&mut self, bus: &mut impl common::Bus) {
+        self.biu_bus_wait_finish(bus);
+        self.biu_fetch_next(bus);
+    }
+
+    fn finish_terminal_writeback_rni(&mut self, bus: &mut impl common::Bus) {
+        self.biu_bus_wait_finish(bus);
+        self.biu_preload_next(bus);
+    }
+
+    #[inline(always)]
+    fn instruction_started_at_odd_address(&self) -> bool {
+        self.prev_ip & 1 == 1
+    }
+
+    #[inline(always)]
+    fn opcode_started_at_odd_address(&self) -> bool {
+        self.opcode_start_ip & 1 == 1
+    }
+
+    #[inline(always)]
+    fn odd_queue_start_penalty(&self) -> i32 {
+        i32::from(self.instruction_started_at_odd_address())
+    }
+
+    #[inline(always)]
+    fn queue_resident_eu_cycles(&self, total_cycles: i32, trailing_bytes: i32) -> i32 {
+        total_cycles - trailing_bytes - 2
+    }
+
+    #[inline(always)]
+    fn instruction_entry_queue_full(&self) -> bool {
+        debug_assert!(usize::from(self.instruction_entry_queue_bytes) <= QUEUE_SIZE);
+        usize::from(self.instruction_entry_queue_bytes) == QUEUE_SIZE
+    }
+
+    /// If IP is odd after the last queue read, the next opcode byte is already
+    /// present as the high byte of the prefetched 16-bit word.
+    #[inline(always)]
+    fn next_instruction_uses_prefetched_high_byte(&self) -> bool {
+        self.ip & 1 == 1 && self.queue_len() > 0
+    }
+
+    #[inline(always)]
+    fn terminal_writeback_sees_full_queue(&self) -> bool {
+        self.queue_len() == QUEUE_SIZE
+            && self.instruction_preload.is_none()
+            && self.fetch_state == FetchState::PausedFull
+            && self.pl_status == BusStatus::Passive
+    }
+
+    #[inline(always)]
+    fn mov_rm_reg_store_uses_terminal_writeback_rni(&self, modrm: u8) -> bool {
+        if !self.terminal_writeback_sees_full_queue() {
+            return false;
+        }
+
+        if !self.seg_prefix {
+            return self.has_disp16_double_register_base(modrm);
+        }
+
+        self.has_disp16_single_register_base(modrm)
+            || self.has_mod0_single_register_base(modrm)
+            || (self.has_disp16_double_register_base(modrm)
+                && !self.has_disp16_cycle4_double_register_base(modrm))
+    }
+
+    #[inline(always)]
+    fn mov_rm_sreg_uses_inline_commit(&self, modrm: u8) -> bool {
+        if !self.terminal_writeback_sees_full_queue() {
+            return false;
+        }
+
+        match modrm & 0xC7 {
+            0x06 => true,
+            0x80..=0x87 => !self.seg_prefix || !matches!(modrm & 0xC7, 0x80 | 0x83),
+            0x04..=0x07 => self.seg_prefix,
+            _ => false,
+        }
+    }
+
+    #[inline(always)]
+    fn mov_rm_sreg_uses_terminal_writeback_with_fetch(&self, modrm: u8) -> bool {
+        match modrm & 0xC7 {
+            0x06 | 0x84..=0x87 => !self.terminal_writeback_sees_full_queue(),
+            0x44..=0x47 => self.terminal_writeback_sees_full_queue(),
+            0x80 | 0x83 => self.terminal_writeback_sees_full_queue() && self.seg_prefix,
+            _ => false,
+        }
+    }
+
+    #[inline(always)]
+    fn far_indirect_transfer_uses_preloaded_handoff(&self, modrm: u8) -> bool {
+        if self.queue_len() == 5 && self.ip & 1 == 1 {
+            return self.has_simple_disp16_base(modrm);
+        }
+
+        if self.queue_len() != QUEUE_SIZE || self.ip & 1 != 0 {
+            return false;
+        }
+
+        self.has_disp8_single_register_base(modrm)
+            || (modrm & 0xC7) == 0x06
+            || (!self.seg_prefix && self.has_disp16_single_register_base(modrm))
+            || (self.seg_prefix && self.has_disp16_cycle4_double_register_base(modrm))
+    }
+
+    #[inline(always)]
+    fn far_immediate_jump_uses_preloaded_finish(&self) -> bool {
+        self.seg_prefix && self.next_instruction_uses_prefetched_high_byte()
+    }
+
+    #[inline(always)]
+    fn far_immediate_call_uses_drained_queue_handoff(&self) -> bool {
+        self.queue_len() == 0
+            && self.instruction_preload.is_none()
+            && self.fetch_state == FetchState::Normal
+            && self.pl_status == BusStatus::CodeFetch
+            && self.bus_status_latch == BusStatus::CodeFetch
+            && self.t_cycle == TCycle::T3
+            && self.ta_cycle == TaCycle::Ts
+    }
+
+    #[inline(always)]
+    fn charge_seg_prefix_cycle(&mut self, _bus: &mut impl common::Bus) {}
+
+    #[inline(always)]
+    fn corr(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 1);
+    }
+
+    #[inline(always)]
+    fn nearcall_routine(&mut self, bus: &mut impl common::Bus, new_ip: u16, early_fetch: bool) {
+        let return_ip = self.ip;
+        self.clk(bus, 1);
+        self.ip = new_ip;
+        if early_fetch {
+            self.flush_and_fetch_early(bus);
+        } else {
+            self.flush_and_fetch(bus);
+        }
+        self.clk(bus, 3);
+        self.push(bus, return_ip);
+    }
+
+    #[inline(always)]
+    fn farcall_routine(
+        &mut self,
+        bus: &mut impl common::Bus,
+        new_cs: u16,
+        new_ip: u16,
+        jump: bool,
+        early_fetch: bool,
+    ) {
+        if jump {
+            self.clk(bus, 1);
+        }
+        self.biu_fetch_suspend(bus);
+        self.clk(bus, 2);
+        self.corr(bus);
+        self.clk(bus, 1);
+        let return_cs = self.sregs[SegReg16::CS as usize];
+        self.push(bus, return_cs);
+        self.sregs[SegReg16::CS as usize] = new_cs;
+        self.clk(bus, 2);
+        self.nearcall_routine(bus, new_ip, early_fetch);
+    }
+
+    fn farret_routine(&mut self, bus: &mut impl common::Bus, far: bool) {
+        self.clk(bus, 1);
+        let ip = self.pop(bus);
+        self.ip = ip;
+        self.biu_fetch_suspend(bus);
+        self.clk(bus, 3);
+
+        if far {
+            self.clk(bus, 1);
+            let cs = self.pop(bus);
+            self.sregs[SegReg16::CS as usize] = cs;
+        }
+
+        self.flush_and_fetch(bus);
+        self.clk(bus, 2);
+    }
+
+    #[inline(always)]
+    fn odd_opcode_start_penalty(&self) -> i32 {
+        i32::from(self.opcode_started_at_odd_address())
+    }
+
+    #[inline(always)]
+    fn opcode_start_penalty_2(&self) -> i32 {
+        2 * self.odd_opcode_start_penalty()
+    }
+
+    #[inline(always)]
+    fn opcode_even_penalty_2(&self) -> i32 {
+        if self.opcode_started_at_odd_address() {
+            0
+        } else {
+            2
+        }
+    }
+
+    /// Installs prefetched instruction bytes and advances the BIU fetch pointer.
+    pub fn install_prefetch_queue(&mut self, bytes: &[u8]) {
+        assert!(
+            bytes.len() <= self.instruction_queue.len(),
+            "8086 prefetch queue overflow"
+        );
+        self.instruction_queue = [0; 6];
+        self.instruction_queue[..bytes.len()].copy_from_slice(bytes);
+        self.instruction_queue_len = bytes.len();
+        self.instruction_preload = None;
+        self.prefetch_ip = self.ip.wrapping_add(bytes.len() as u16);
+        self.step_finish_cycle = StepFinishCycle::WithFetchCycle;
+        self.nx = false;
+        self.rni = false;
+        self.queue_op = QueueOp::Idle;
+        self.last_queue_op = QueueOp::Idle;
+        self.fetch_state = FetchState::Normal;
+        self.t_cycle = TCycle::Ti;
+        self.ta_cycle = TaCycle::Td;
+        self.bus_status = BusStatus::Passive;
+        self.bus_status_latch = BusStatus::Passive;
+        self.pl_status = BusStatus::Passive;
+        self.bus_pending = BusPendingType::None;
+    }
+
+    fn push(&mut self, bus: &mut impl common::Bus, value: u16) {
+        let sp = self.regs.word(WordReg::SP).wrapping_sub(2);
+        self.regs.set_word(WordReg::SP, sp);
+        self.write_word_seg(bus, SegReg16::SS, sp, value);
+    }
+
+    fn pop(&mut self, bus: &mut impl common::Bus) -> u16 {
+        let sp = self.regs.word(WordReg::SP);
+        let value = self.read_word_seg(bus, SegReg16::SS, sp);
+        self.regs.set_word(WordReg::SP, sp.wrapping_add(2));
+        value
+    }
+
+    fn execute_one(&mut self, bus: &mut impl common::Bus) {
+        self.prev_ip = self.ip;
+        self.reset_instruction_timing();
+        self.instruction_entry_queue_bytes =
+            (self.queue_len() + usize::from(self.instruction_preload.is_some())) as u8;
+
+        if self.pending_irq != 0 {
+            self.check_interrupts(bus);
+        }
+        if self.no_interrupt > 0 {
+            self.no_interrupt -= 1;
+        }
+        if self.inhibit_all > 0 {
+            self.inhibit_all -= 1;
+        }
+
+        self.seg_prefix = false;
+
+        if self.rep_active {
+            self.continue_rep(bus);
+        } else {
+            let mut pending_rep: Option<RepType> = None;
+            let mut opcode = self.fetch_first(bus);
+            loop {
+                match opcode {
+                    0x26 => {
+                        self.seg_prefix = true;
+                        self.prefix_seg = SegReg16::ES;
+                        self.clk(bus, 1);
+                        opcode = self.fetch(bus);
+                    }
+                    0x2E => {
+                        self.seg_prefix = true;
+                        self.prefix_seg = SegReg16::CS;
+                        self.clk(bus, 1);
+                        opcode = self.fetch(bus);
+                    }
+                    0x36 => {
+                        self.seg_prefix = true;
+                        self.prefix_seg = SegReg16::SS;
+                        self.clk(bus, 1);
+                        opcode = self.fetch(bus);
+                    }
+                    0x3E => {
+                        self.seg_prefix = true;
+                        self.prefix_seg = SegReg16::DS;
+                        self.clk(bus, 1);
+                        opcode = self.fetch(bus);
+                    }
+                    0xF0 | 0xF1 => {
+                        self.inhibit_all = 1;
+                        self.clk(bus, 1);
+                        opcode = self.fetch(bus);
+                    }
+                    0xF2 => {
+                        pending_rep = Some(RepType::RepNe);
+                        self.clk(bus, 1);
+                        opcode = self.fetch(bus);
+                    }
+                    0xF3 => {
+                        pending_rep = Some(RepType::RepE);
+                        self.clk(bus, 1);
+                        opcode = self.fetch(bus);
+                    }
+                    _ => {
+                        self.opcode_start_ip = self.ip.wrapping_sub(1);
+                        if let Some(rep_type) = pending_rep {
+                            self.start_rep_with_opcode(rep_type, opcode, bus);
+                        } else {
+                            self.dispatch(opcode, bus);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Executes exactly one logical instruction (should only be used in tests).
+    ///
+    /// Sets `cycles_remaining` to `i64::MAX` so that REP-prefixed string
+    /// instructions run to completion in a single call instead of pausing
+    /// mid-loop when the cycle budget runs out. This is necessary because
+    /// `execute_one` resumes a paused REP via `continue_rep`, which would
+    /// otherwise split a single logical instruction across multiple calls.
+    pub fn step(&mut self, bus: &mut impl common::Bus) {
+        self.cycles_remaining = i64::MAX;
+        self.execute_one(bus);
+        self.finish_step_timing(bus);
+    }
+
+    /// Returns the number of cycles consumed by the last `step()` call.
+    pub fn cycles_consumed(&self) -> u64 {
+        (i64::MAX - self.cycles_remaining) as u64
+    }
+
+    /// Returns the last computed effective address (for alignment checks).
+    pub fn last_ea(&self) -> u32 {
+        self.ea
+    }
+
+    /// Signals a maskable interrupt request (IRQ).
+    pub fn signal_irq(&mut self) {
+        self.pending_irq |= crate::PENDING_IRQ;
+    }
+
+    /// Signals a non-maskable interrupt (NMI).
+    pub fn signal_nmi(&mut self) {
+        self.pending_irq |= crate::PENDING_NMI;
+    }
+}
+
+impl common::Cpu for I8086 {
+    fn run_for(&mut self, cycles_to_run: u64, bus: &mut impl common::Bus) -> u64 {
+        let start_cycle = bus.current_cycle();
+        self.run_start_cycle = start_cycle;
+        self.run_budget = cycles_to_run;
+        self.cycles_remaining = cycles_to_run as i64;
+
+        while self.cycles_remaining > 0 {
+            if self.halted {
+                if bus.has_nmi() {
+                    self.pending_irq |= crate::PENDING_NMI;
+                }
+                if self.flags.if_flag {
+                    if bus.has_irq() {
+                        self.pending_irq |= crate::PENDING_IRQ;
+                    }
+                } else {
+                    self.pending_irq &= !crate::PENDING_IRQ;
+                }
+                if self.pending_irq != 0 {
+                    self.halted = false;
+                } else {
+                    let consumed = (cycles_to_run as i64 - self.cycles_remaining) as u64;
+                    bus.set_current_cycle(start_cycle + consumed);
+                    return consumed;
+                }
+            }
+
+            self.execute_one(bus);
+            if !self.rep_active {
+                self.finish_step_timing(bus);
+            }
+            self.cycles_remaining -= bus.drain_wait_cycles();
+
+            let consumed = cycles_to_run as i64 - self.cycles_remaining;
+            bus.set_current_cycle(start_cycle + consumed as u64);
+
+            if bus.has_nmi() {
+                self.pending_irq |= crate::PENDING_NMI;
+            }
+            if bus.has_irq() {
+                self.pending_irq |= crate::PENDING_IRQ;
+            } else {
+                self.pending_irq &= !crate::PENDING_IRQ;
+            }
+
+            if bus.reset_pending() {
+                break;
+            }
+            if bus.cpu_should_yield() {
+                break;
+            }
+        }
+
+        let actual = (cycles_to_run as i64 - self.cycles_remaining) as u64;
+        bus.set_current_cycle(start_cycle + actual);
+        actual
+    }
+
+    fn reset(&mut self) {
+        self.state = I8086State::default();
+        self.sregs[SegReg16::CS as usize] = 0xFFFF;
+        self.prev_ip = 0;
+        self.opcode_start_ip = 0;
+        self.halted = false;
+        self.pending_irq = 0;
+        self.no_interrupt = 0;
+        self.inhibit_all = 0;
+        self.rep_active = false;
+        self.rep_restart_ip = 0;
+        self.rep_prefix = false;
+        self.seg_prefix = false;
+        self.ea = 0;
+        self.eo = 0;
+        self.effective_address_segment = SegReg16::DS;
+        self.modrm_displacement = 0;
+        self.modrm_has_displacement = false;
+        self.instruction_queue_len = 0;
+        self.instruction_preload = None;
+        self.instruction_entry_queue_bytes = 0;
+        self.prefetch_ip = self.ip;
+        self.step_finish_cycle = StepFinishCycle::WithFetchCycle;
+        self.nx = false;
+        self.rni = false;
+        self.queue_op = QueueOp::Idle;
+        self.last_queue_op = QueueOp::Idle;
+        self.t_cycle = TCycle::Ti;
+        self.ta_cycle = TaCycle::Td;
+        self.bus_status = BusStatus::Passive;
+        self.bus_status_latch = BusStatus::Passive;
+        self.pl_status = BusStatus::Passive;
+        self.bus_pending = BusPendingType::None;
+        self.fetch_state = FetchState::Normal;
+        self.transfer_size = TransferSize::Byte;
+        self.operand_size = OperandSize::Operand8;
+        self.transfer_n = 1;
+        self.final_transfer = false;
+        self.bhe = false;
+        self.address_bus = 0;
+        self.address_latch = 0;
+        self.data_bus = 0;
+        self.cycle_num = 0;
+        self.reset_instruction_timing();
+    }
+
+    fn halted(&self) -> bool {
+        self.halted
+    }
+
+    fn ax(&self) -> u16 {
+        self.state.ax()
+    }
+
+    fn set_ax(&mut self, v: u16) {
+        self.state.set_ax(v);
+    }
+
+    fn bx(&self) -> u16 {
+        self.state.bx()
+    }
+
+    fn set_bx(&mut self, v: u16) {
+        self.state.set_bx(v);
+    }
+
+    fn cx(&self) -> u16 {
+        self.state.cx()
+    }
+
+    fn set_cx(&mut self, v: u16) {
+        self.state.set_cx(v);
+    }
+
+    fn dx(&self) -> u16 {
+        self.state.dx()
+    }
+
+    fn set_dx(&mut self, v: u16) {
+        self.state.set_dx(v);
+    }
+
+    fn sp(&self) -> u16 {
+        self.state.sp()
+    }
+
+    fn set_sp(&mut self, v: u16) {
+        self.state.set_sp(v);
+    }
+
+    fn bp(&self) -> u16 {
+        self.state.bp()
+    }
+
+    fn set_bp(&mut self, v: u16) {
+        self.state.set_bp(v);
+    }
+
+    fn si(&self) -> u16 {
+        self.state.si()
+    }
+
+    fn set_si(&mut self, v: u16) {
+        self.state.set_si(v);
+    }
+
+    fn di(&self) -> u16 {
+        self.state.di()
+    }
+
+    fn set_di(&mut self, v: u16) {
+        self.state.set_di(v);
+    }
+
+    fn es(&self) -> u16 {
+        self.state.es()
+    }
+
+    fn set_es(&mut self, v: u16) {
+        self.state.set_es(v);
+    }
+
+    fn cs(&self) -> u16 {
+        self.state.cs()
+    }
+
+    fn set_cs(&mut self, v: u16) {
+        self.state.set_cs(v);
+        self.flush_prefetch_queue();
+    }
+
+    fn ss(&self) -> u16 {
+        self.state.ss()
+    }
+
+    fn set_ss(&mut self, v: u16) {
+        self.state.set_ss(v);
+    }
+
+    fn ds(&self) -> u16 {
+        self.state.ds()
+    }
+
+    fn set_ds(&mut self, v: u16) {
+        self.state.set_ds(v);
+    }
+
+    fn ip(&self) -> u16 {
+        self.state.ip
+    }
+
+    fn set_ip(&mut self, v: u16) {
+        self.state.ip = v;
+        self.flush_prefetch_queue();
+    }
+
+    fn flags(&self) -> u16 {
+        self.state.compressed_flags()
+    }
+
+    fn set_flags(&mut self, v: u16) {
+        self.state.set_compressed_flags(v);
+    }
+
+    fn cpu_type(&self) -> common::CpuType {
+        common::CpuType::I8086
+    }
+
+    fn load_segment_real_mode(&mut self, seg: common::SegmentRegister, selector: u16) {
+        match seg {
+            common::SegmentRegister::ES => self.state.set_es(selector),
+            common::SegmentRegister::CS => self.state.set_cs(selector),
+            common::SegmentRegister::SS => self.state.set_ss(selector),
+            common::SegmentRegister::DS => self.state.set_ds(selector),
+        }
+    }
+
+    fn segment_base(&self, seg: common::SegmentRegister) -> u32 {
+        match seg {
+            common::SegmentRegister::ES => u32::from(self.state.es()) << 4,
+            common::SegmentRegister::CS => u32::from(self.state.cs()) << 4,
+            common::SegmentRegister::SS => u32::from(self.state.ss()) << 4,
+            common::SegmentRegister::DS => u32::from(self.state.ds()) << 4,
+        }
+    }
+}

--- a/crates/cpu/src/i8086/alu.rs
+++ b/crates/cpu/src/i8086/alu.rs
@@ -1,0 +1,447 @@
+use super::I8086;
+
+impl I8086 {
+    #[inline(always)]
+    pub(super) fn alu_add_byte(&mut self, dst: u8, src: u8) -> u8 {
+        let result = dst as u32 + src as u32;
+        self.flags.set_cf_byte(result);
+        self.flags.set_of_add_byte(result, src as u32, dst as u32);
+        self.flags.set_af(result, src as u32, dst as u32);
+        self.flags.set_szpf_byte(result);
+        result as u8
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_add_word(&mut self, dst: u16, src: u16) -> u16 {
+        let result = dst as u32 + src as u32;
+        self.flags.set_cf_word(result);
+        self.flags.set_of_add_word(result, src as u32, dst as u32);
+        self.flags.set_af(result, src as u32, dst as u32);
+        self.flags.set_szpf_word(result);
+        result as u16
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_adc_byte(&mut self, dst: u8, src: u8, cf: u32) -> u8 {
+        let result = dst as u32 + src as u32 + cf;
+        self.flags.set_cf_byte(result);
+        self.flags.set_of_add_byte(result, src as u32, dst as u32);
+        self.flags.set_af(result, src as u32, dst as u32);
+        self.flags.set_szpf_byte(result);
+        result as u8
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_adc_word(&mut self, dst: u16, src: u16, cf: u32) -> u16 {
+        let result = dst as u32 + src as u32 + cf;
+        self.flags.set_cf_word(result);
+        self.flags.set_of_add_word(result, src as u32, dst as u32);
+        self.flags.set_af(result, src as u32, dst as u32);
+        self.flags.set_szpf_word(result);
+        result as u16
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_sbb_byte(&mut self, dst: u8, src: u8, cf: u32) -> u8 {
+        let result = (dst as u32).wrapping_sub(src as u32).wrapping_sub(cf);
+        self.flags.set_cf_byte(result);
+        self.flags.set_of_sub_byte(result, src as u32, dst as u32);
+        self.flags.set_af(result, src as u32, dst as u32);
+        self.flags.set_szpf_byte(result);
+        result as u8
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_sbb_word(&mut self, dst: u16, src: u16, cf: u32) -> u16 {
+        let result = (dst as u32).wrapping_sub(src as u32).wrapping_sub(cf);
+        self.flags.set_cf_word(result);
+        self.flags.set_of_sub_word(result, src as u32, dst as u32);
+        self.flags.set_af(result, src as u32, dst as u32);
+        self.flags.set_szpf_word(result);
+        result as u16
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_sub_byte(&mut self, dst: u8, src: u8) -> u8 {
+        let result = (dst as u32).wrapping_sub(src as u32);
+        self.flags.set_cf_byte(result);
+        self.flags.set_of_sub_byte(result, src as u32, dst as u32);
+        self.flags.set_af(result, src as u32, dst as u32);
+        self.flags.set_szpf_byte(result);
+        result as u8
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_sub_word(&mut self, dst: u16, src: u16) -> u16 {
+        let result = (dst as u32).wrapping_sub(src as u32);
+        self.flags.set_cf_word(result);
+        self.flags.set_of_sub_word(result, src as u32, dst as u32);
+        self.flags.set_af(result, src as u32, dst as u32);
+        self.flags.set_szpf_word(result);
+        result as u16
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_or_byte(&mut self, dst: u8, src: u8) -> u8 {
+        let result = dst | src;
+        self.flags.carry_val = 0;
+        self.flags.overflow_val = 0;
+        self.flags.aux_val = 0;
+        self.flags.set_szpf_byte(result as u32);
+        result
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_or_word(&mut self, dst: u16, src: u16) -> u16 {
+        let result = dst | src;
+        self.flags.carry_val = 0;
+        self.flags.overflow_val = 0;
+        self.flags.aux_val = 0;
+        self.flags.set_szpf_word(result as u32);
+        result
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_and_byte(&mut self, dst: u8, src: u8) -> u8 {
+        let result = dst & src;
+        self.flags.carry_val = 0;
+        self.flags.overflow_val = 0;
+        self.flags.aux_val = 0;
+        self.flags.set_szpf_byte(result as u32);
+        result
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_and_word(&mut self, dst: u16, src: u16) -> u16 {
+        let result = dst & src;
+        self.flags.carry_val = 0;
+        self.flags.overflow_val = 0;
+        self.flags.aux_val = 0;
+        self.flags.set_szpf_word(result as u32);
+        result
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_xor_byte(&mut self, dst: u8, src: u8) -> u8 {
+        let result = dst ^ src;
+        self.flags.carry_val = 0;
+        self.flags.overflow_val = 0;
+        self.flags.aux_val = 0;
+        self.flags.set_szpf_byte(result as u32);
+        result
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_xor_word(&mut self, dst: u16, src: u16) -> u16 {
+        let result = dst ^ src;
+        self.flags.carry_val = 0;
+        self.flags.overflow_val = 0;
+        self.flags.aux_val = 0;
+        self.flags.set_szpf_word(result as u32);
+        result
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_inc_byte(&mut self, val: u8) -> u8 {
+        let result = val as u32 + 1;
+        self.flags.set_of_add_byte(result, 1, val as u32);
+        self.flags.set_af(result, 1, val as u32);
+        self.flags.set_szpf_byte(result);
+        result as u8
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_inc_word(&mut self, val: u16) -> u16 {
+        let result = val as u32 + 1;
+        self.flags.set_of_add_word(result, 1, val as u32);
+        self.flags.set_af(result, 1, val as u32);
+        self.flags.set_szpf_word(result);
+        result as u16
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_dec_byte(&mut self, val: u8) -> u8 {
+        let result = (val as u32).wrapping_sub(1);
+        self.flags.set_of_sub_byte(result, 1, val as u32);
+        self.flags.set_af(result, 1, val as u32);
+        self.flags.set_szpf_byte(result);
+        result as u8
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_dec_word(&mut self, val: u16) -> u16 {
+        let result = (val as u32).wrapping_sub(1);
+        self.flags.set_of_sub_word(result, 1, val as u32);
+        self.flags.set_af(result, 1, val as u32);
+        self.flags.set_szpf_word(result);
+        result as u16
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_neg_byte(&mut self, val: u8) -> u8 {
+        let result = 0u32.wrapping_sub(val as u32);
+        self.flags.carry_val = if val != 0 { 1 } else { 0 };
+        self.flags.set_of_sub_byte(result, val as u32, 0);
+        self.flags.set_af(result, val as u32, 0);
+        self.flags.set_szpf_byte(result);
+        result as u8
+    }
+
+    #[inline(always)]
+    pub(super) fn alu_neg_word(&mut self, val: u16) -> u16 {
+        let result = 0u32.wrapping_sub(val as u32);
+        self.flags.carry_val = if val != 0 { 1 } else { 0 };
+        self.flags.set_of_sub_word(result, val as u32, 0);
+        self.flags.set_af(result, val as u32, 0);
+        self.flags.set_szpf_word(result);
+        result as u16
+    }
+
+    pub(super) fn alu_shl_byte(&mut self, val: u8, count: u8) -> u8 {
+        if count == 0 {
+            return val;
+        }
+        let result = if count < 8 {
+            (val as u32) << count
+        } else {
+            0u32
+        };
+        self.flags.carry_val = if count <= 8 {
+            ((val as u32) << (count - 1)) & 0x80
+        } else {
+            0
+        };
+        self.flags.overflow_val = (((result >> 7) & 1) ^ self.flags.cf_val()) * 0x80;
+        self.flags.aux_val = 0;
+        self.flags.set_szpf_byte(result);
+        result as u8
+    }
+
+    pub(super) fn alu_shl_word(&mut self, val: u16, count: u8) -> u16 {
+        if count == 0 {
+            return val;
+        }
+        let result = if count < 16 {
+            (val as u32) << count
+        } else {
+            0u32
+        };
+        self.flags.carry_val = if count <= 16 {
+            ((val as u32) << (count - 1)) & 0x8000
+        } else {
+            0
+        };
+        self.flags.overflow_val = (((result >> 15) & 1) ^ self.flags.cf_val()) * 0x8000;
+        self.flags.aux_val = 0;
+        self.flags.set_szpf_word(result);
+        result as u16
+    }
+
+    pub(super) fn alu_shr_byte(&mut self, val: u8, count: u8) -> u8 {
+        if count == 0 {
+            return val;
+        }
+        self.flags.overflow_val = if count == 1 { val as u32 & 0x80 } else { 0 };
+        let result = if count < 8 {
+            self.flags.carry_val = ((val >> (count - 1)) & 1) as u32;
+            val >> count
+        } else {
+            self.flags.carry_val = if count == 8 { (val >> 7) as u32 } else { 0 };
+            0u8
+        };
+        self.flags.aux_val = 0;
+        self.flags.set_szpf_byte(result as u32);
+        result
+    }
+
+    pub(super) fn alu_shr_word(&mut self, val: u16, count: u8) -> u16 {
+        if count == 0 {
+            return val;
+        }
+        self.flags.overflow_val = if count == 1 { val as u32 & 0x8000 } else { 0 };
+        let result = if count < 16 {
+            self.flags.carry_val = ((val >> (count - 1)) & 1) as u32;
+            val >> count
+        } else {
+            self.flags.carry_val = if count == 16 { (val >> 15) as u32 } else { 0 };
+            0u16
+        };
+        self.flags.aux_val = 0;
+        self.flags.set_szpf_word(result as u32);
+        result
+    }
+
+    pub(super) fn alu_sar_byte(&mut self, val: u8, count: u8) -> u8 {
+        if count == 0 {
+            return val;
+        }
+        self.flags.overflow_val = 0;
+        let signed = val as i8;
+        let result = if count < 8 {
+            self.flags.carry_val = ((signed >> (count - 1)) & 1) as u32;
+            (signed >> count) as u8
+        } else {
+            self.flags.carry_val = if signed < 0 { 1 } else { 0 };
+            (signed >> 7) as u8
+        };
+        self.flags.aux_val = 0;
+        self.flags.set_szpf_byte(result as u32);
+        result
+    }
+
+    pub(super) fn alu_sar_word(&mut self, val: u16, count: u8) -> u16 {
+        if count == 0 {
+            return val;
+        }
+        self.flags.overflow_val = 0;
+        let signed = val as i16;
+        let result = if count < 16 {
+            self.flags.carry_val = ((signed >> (count - 1)) & 1) as u32;
+            (signed >> count) as u16
+        } else {
+            self.flags.carry_val = if signed < 0 { 1 } else { 0 };
+            (signed >> 15) as u16
+        };
+        self.flags.aux_val = 0;
+        self.flags.set_szpf_word(result as u32);
+        result
+    }
+
+    pub(super) fn alu_rol_byte(&mut self, val: u8, count: u8) -> u8 {
+        if count == 0 {
+            return val;
+        }
+        let count = count & 7;
+        let result = if count == 0 {
+            self.flags.carry_val = (val & 1) as u32;
+            val
+        } else {
+            let r = val.rotate_left(count as u32);
+            self.flags.carry_val = (r & 1) as u32;
+            r
+        };
+        self.flags.overflow_val = ((result >> 7) ^ (result & 1)) as u32 * 0x80;
+        result
+    }
+
+    pub(super) fn alu_rol_word(&mut self, val: u16, count: u8) -> u16 {
+        if count == 0 {
+            return val;
+        }
+        let count = count & 15;
+        let result = if count == 0 {
+            self.flags.carry_val = (val & 1) as u32;
+            val
+        } else {
+            let r = val.rotate_left(count as u32);
+            self.flags.carry_val = (r & 1) as u32;
+            r
+        };
+        self.flags.overflow_val = ((result >> 15) ^ (result & 1)) as u32 * 0x8000;
+        result
+    }
+
+    pub(super) fn alu_ror_byte(&mut self, val: u8, count: u8) -> u8 {
+        if count == 0 {
+            return val;
+        }
+        let count = count & 7;
+        let result = if count == 0 {
+            self.flags.carry_val = ((val >> 7) & 1) as u32;
+            val
+        } else {
+            let r = val.rotate_right(count as u32);
+            self.flags.carry_val = ((r >> 7) & 1) as u32;
+            r
+        };
+        self.flags.overflow_val = ((result ^ (result << 1)) & 0x80) as u32;
+        result
+    }
+
+    pub(super) fn alu_ror_word(&mut self, val: u16, count: u8) -> u16 {
+        if count == 0 {
+            return val;
+        }
+        let count = count & 15;
+        let result = if count == 0 {
+            self.flags.carry_val = ((val >> 15) & 1) as u32;
+            val
+        } else {
+            let r = val.rotate_right(count as u32);
+            self.flags.carry_val = ((r >> 15) & 1) as u32;
+            r
+        };
+        self.flags.overflow_val = ((result ^ (result << 1)) & 0x8000) as u32;
+        result
+    }
+
+    pub(super) fn alu_rcl_byte(&mut self, val: u8, count: u8) -> u8 {
+        if count == 0 {
+            return val;
+        }
+        let count = count % 9;
+        if count == 0 {
+            self.flags.overflow_val = ((val as u32 >> 7) ^ self.flags.cf_val()) * 0x80;
+            return val;
+        }
+        let cf = self.flags.cf_val();
+        let wide = (val as u32) | (cf << 8);
+        let rotated = (wide << count) | (wide >> (9 - count));
+        let result = rotated as u8;
+        self.flags.carry_val = (rotated >> 8) & 1;
+        self.flags.overflow_val = ((result as u32 >> 7) ^ self.flags.carry_val) * 0x80;
+        result
+    }
+
+    pub(super) fn alu_rcl_word(&mut self, val: u16, count: u8) -> u16 {
+        if count == 0 {
+            return val;
+        }
+        let count = count % 17;
+        if count == 0 {
+            self.flags.overflow_val = ((val as u32 >> 15) ^ self.flags.cf_val()) * 0x8000;
+            return val;
+        }
+        let cf = self.flags.cf_val();
+        let wide = (val as u32) | (cf << 16);
+        let rotated = (wide << count) | (wide >> (17 - count));
+        let result = rotated as u16;
+        self.flags.carry_val = (rotated >> 16) & 1;
+        self.flags.overflow_val = ((result as u32 >> 15) ^ self.flags.carry_val) * 0x8000;
+        result
+    }
+
+    pub(super) fn alu_rcr_byte(&mut self, val: u8, count: u8) -> u8 {
+        if count == 0 {
+            return val;
+        }
+        let count = count % 9;
+        if count == 0 {
+            self.flags.overflow_val = ((val ^ (val << 1)) & 0x80) as u32;
+            return val;
+        }
+        let cf = self.flags.cf_val();
+        let wide = (val as u32) | (cf << 8);
+        let result = ((wide >> count) | (wide << (9 - count))) as u8;
+        self.flags.carry_val = (wide >> (count - 1)) & 1;
+        self.flags.overflow_val = ((result ^ (result << 1)) & 0x80) as u32;
+        result
+    }
+
+    pub(super) fn alu_rcr_word(&mut self, val: u16, count: u8) -> u16 {
+        if count == 0 {
+            return val;
+        }
+        let count = count % 17;
+        if count == 0 {
+            self.flags.overflow_val = (val as u32 ^ ((val as u32) << 1)) & 0x8000;
+            return val;
+        }
+        let cf = self.flags.cf_val();
+        let wide = (val as u32) | (cf << 16);
+        let result = ((wide >> count) | (wide << (17 - count))) as u16;
+        self.flags.carry_val = (wide >> (count - 1)) & 1;
+        self.flags.overflow_val = (result as u32 ^ ((result as u32) << 1)) & 0x8000;
+        result
+    }
+}

--- a/crates/cpu/src/i8086/biu.rs
+++ b/crates/cpu/src/i8086/biu.rs
@@ -1,0 +1,1042 @@
+//! T-state cycle-accurate Bus Interface Unit for the 8086.
+//!
+//! This module implements the 8086 BIU's T-state and Ta-state machine.
+//!
+//! The implementation was heavily influenced by the 8088 core in MartyPC,
+//! which is licensed under the permissive MIT license.
+//!
+//! The model tracks every bus cycle at T-state granularity so that EU/BIU
+//! interactions (prefetch aborts, bus wait-for-T4, queue policy throttling)
+//! produce cycle-exact counts matching real hardware.
+
+use common::Bus;
+
+use super::I8086;
+use crate::SegReg16;
+
+/// 8086 instruction queue capacity.
+pub const QUEUE_SIZE: usize = 6;
+/// 8086 prefetch fetch width (16-bit bus fetches one word per m-cycle).
+pub const FETCH_SIZE: usize = 2;
+/// Queue length at which the BIU applies the first policy throttle.
+pub const POLICY_LEN0: usize = QUEUE_SIZE - 2;
+/// Queue length at which the BIU applies the second policy throttle.
+pub const POLICY_LEN1: usize = QUEUE_SIZE - 3;
+/// 20-bit physical address wrap mask (8086 has 1 MiB of address space).
+pub const ADDRESS_MASK: u32 = 0xFFFFF;
+/// Number of T-states the BIU waits after hitting a policy throttle.
+const POLICY_THROTTLE_DELAY: u8 = 3;
+/// Safety bound on the inner T-state poll loops used by the BIU helpers.
+const BIU_LOOP_GUARD: u32 = 64;
+
+/// Main bus cycle T-state.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub enum TCycle {
+    Tinit,
+    #[default]
+    Ti,
+    T1,
+    T2,
+    T3,
+    Tw,
+    T4,
+}
+
+/// Pipelined address cycle Ta-state.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub enum TaCycle {
+    Tr,
+    Ts,
+    T0,
+    #[default]
+    Td,
+    Ta,
+}
+
+/// Bus cycle status (mapped to S0-S2 pins).
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub enum BusStatus {
+    IoRead,
+    IoWrite,
+    CodeFetch,
+    MemRead,
+    MemWrite,
+    #[default]
+    Passive,
+}
+
+/// Prefetch state machine.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub enum FetchState {
+    #[default]
+    Normal,
+    PausedFull,
+    Delayed(u8),
+    Suspended,
+}
+
+/// EU bus request pending type.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub enum BusPendingType {
+    #[default]
+    None,
+    EuEarly,
+    EuLate,
+}
+
+/// Bus transfer size for a single m-cycle.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub enum TransferSize {
+    #[default]
+    Byte,
+    Word,
+}
+
+/// Operand size spanning one or two m-cycles (8086 word-aligned = 1 m-cycle).
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub enum OperandSize {
+    #[default]
+    Operand8,
+    Operand16,
+}
+
+/// Whether a queue read is the first byte of an instruction or a subsequent byte.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum QueueType {
+    First,
+    Subsequent,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub enum QueueOp {
+    #[default]
+    Idle,
+    First,
+    Flush,
+    Subsequent,
+}
+
+impl I8086 {
+    #[inline(always)]
+    pub(super) fn queue_len(&self) -> usize {
+        self.instruction_queue_len
+    }
+
+    #[inline(always)]
+    pub(super) fn queue_has_room_for_fetch(&self) -> bool {
+        self.instruction_queue_len + FETCH_SIZE <= QUEUE_SIZE
+    }
+
+    #[inline(always)]
+    pub(super) fn queue_at_policy_len(&self) -> bool {
+        self.instruction_queue_len == POLICY_LEN0 || self.instruction_queue_len == POLICY_LEN1
+    }
+
+    #[inline(always)]
+    pub(super) fn queue_at_policy_threshold(&self) -> bool {
+        self.instruction_queue_len == POLICY_LEN1
+    }
+
+    #[inline(always)]
+    pub(super) fn queue_pop(&mut self) -> u8 {
+        debug_assert!(self.instruction_queue_len > 0, "queue underrun");
+        let value = self.instruction_queue[0];
+        if self.instruction_queue_len > 1 {
+            self.instruction_queue
+                .copy_within(1..self.instruction_queue_len, 0);
+        }
+        self.instruction_queue_len -= 1;
+        value
+    }
+
+    #[inline(always)]
+    pub(super) fn queue_push8(&mut self, byte: u8) -> u16 {
+        debug_assert!(self.instruction_queue_len < QUEUE_SIZE, "queue overrun");
+        self.instruction_queue[self.instruction_queue_len] = byte;
+        self.instruction_queue_len += 1;
+        1
+    }
+
+    /// Push a 16-bit word into the queue at an even address. If `a0` is true,
+    /// only the high byte of the word is pushed (odd address fetch).
+    pub(super) fn queue_push16(&mut self, word: u16, a0: bool) -> u16 {
+        if a0 {
+            self.queue_push8((word >> 8) as u8);
+            1
+        } else {
+            self.queue_push8((word & 0xFF) as u8);
+            self.queue_push8((word >> 8) as u8);
+            2
+        }
+    }
+
+    pub(super) fn queue_flush(&mut self) {
+        self.instruction_queue_len = 0;
+        self.instruction_preload = None;
+        self.fetch_state = FetchState::Normal;
+        self.queue_op = QueueOp::Flush;
+    }
+
+    /// Advance the CPU by one T-state. This is the unit of time used by the
+    /// T-state BIU. Every EU or BIU operation ultimately reduces to a sequence
+    /// of `cycle` calls.
+    pub(super) fn cycle(&mut self, bus: &mut impl Bus) {
+        // Tinit is a synthetic state used to indicate "bus cycle just started".
+        if self.t_cycle == TCycle::Tinit {
+            self.t_cycle = TCycle::T1;
+        }
+
+        self.cycles_remaining -= 1;
+        self.cycle_num = self.cycle_num.wrapping_add(1);
+
+        // Phase 1: Operate on the current (latched) T-state.
+        match self.bus_status_latch {
+            BusStatus::Passive => {
+                self.transfer_n = 0;
+                match self.fetch_state {
+                    FetchState::Delayed(0) => {
+                        self.fetch_state = FetchState::Normal;
+                        self.biu_make_fetch_decision();
+                    }
+                    FetchState::PausedFull if self.queue_has_room_for_fetch() => {
+                        self.biu_make_fetch_decision();
+                    }
+                    _ => {}
+                }
+            }
+            BusStatus::MemRead
+            | BusStatus::MemWrite
+            | BusStatus::IoRead
+            | BusStatus::IoWrite
+            | BusStatus::CodeFetch => match self.t_cycle {
+                TCycle::Tinit => unreachable!("Tinit was translated to T1 above"),
+                TCycle::Ti => {
+                    self.biu_make_fetch_decision();
+                }
+                TCycle::T1 => {}
+                TCycle::T2 => {
+                    if self.final_transfer {
+                        self.biu_make_fetch_decision();
+                    }
+                }
+                TCycle::T3 | TCycle::Tw => {
+                    // With zero wait states, the transfer always completes on T3.
+                    self.biu_do_bus_transfer(bus);
+                }
+                TCycle::T4 => {
+                    if self.bus_status_latch == BusStatus::CodeFetch {
+                        let inc = match self.transfer_size {
+                            TransferSize::Byte => self.queue_push8(self.data_bus as u8),
+                            TransferSize::Word => {
+                                self.queue_push16(self.data_bus, self.prefetch_ip & 1 == 1)
+                            }
+                        };
+                        self.prefetch_ip = self.prefetch_ip.wrapping_add(inc);
+                    }
+                    if self.final_transfer {
+                        self.biu_make_fetch_decision();
+                    }
+                }
+            },
+        }
+
+        // Phase 2: Advance the fetch delay counter (except during wait states).
+        if let FetchState::Delayed(count) = self.fetch_state
+            && self.t_cycle != TCycle::Tw
+            && count > 0
+        {
+            self.fetch_state = FetchState::Delayed(count - 1);
+        }
+
+        // Phase 3: Advance the Ta-cycle (address cycle pipeline).
+        self.ta_cycle = match self.ta_cycle {
+            TaCycle::Tr => TaCycle::Ts,
+            TaCycle::Ts => TaCycle::T0,
+            TaCycle::T0 => match (self.pl_status, self.bus_pending) {
+                (BusStatus::CodeFetch, BusPendingType::None) => {
+                    if matches!(self.t_cycle, TCycle::Ti | TCycle::T4)
+                        && self.fetch_state != FetchState::Suspended
+                    {
+                        self.biu_bus_begin_fetch();
+                        TaCycle::Td
+                    } else {
+                        TaCycle::T0
+                    }
+                }
+                (BusStatus::CodeFetch, BusPendingType::EuLate) => {
+                    if matches!(self.t_cycle, TCycle::Ti | TCycle::T4) {
+                        self.biu_fetch_abort();
+                        self.ta_cycle
+                    } else {
+                        TaCycle::T0
+                    }
+                }
+                _ => {
+                    if matches!(self.t_cycle, TCycle::Ti | TCycle::T4) {
+                        self.t_cycle = TCycle::Tinit;
+                        TaCycle::Td
+                    } else {
+                        TaCycle::T0
+                    }
+                }
+            },
+            TaCycle::Td => TaCycle::Td,
+            TaCycle::Ta => TaCycle::Ta,
+        };
+
+        // Phase 4: Advance the main T-cycle.
+        self.t_cycle = match self.t_cycle {
+            TCycle::Tinit => TCycle::T1,
+            TCycle::Ti => match self.bus_status_latch {
+                BusStatus::Passive => TCycle::Ti,
+                _ => TCycle::T1,
+            },
+            TCycle::T1 => match self.bus_status_latch {
+                BusStatus::Passive => TCycle::T1,
+                _ => TCycle::T2,
+            },
+            TCycle::T2 => TCycle::T3,
+            TCycle::Tw | TCycle::T3 => {
+                // No wait states are simulated; always proceed to T4.
+                self.biu_bus_end();
+                TCycle::T4
+            }
+            TCycle::T4 => {
+                self.bus_status_latch = BusStatus::Passive;
+                TCycle::Ti
+            }
+        };
+
+        self.last_queue_op = self.queue_op;
+        self.queue_op = QueueOp::Idle;
+    }
+
+    #[inline]
+    pub(super) fn cycles(&mut self, bus: &mut impl Bus, count: u32) {
+        for _ in 0..count {
+            self.cycle(bus);
+        }
+    }
+
+    fn biu_bus_end(&mut self) {
+        // Reset command signals (placeholder; we don't model the 8288).
+    }
+
+    /// Extract the byte currently on the active data-bus lane. When BHE is
+    /// asserted the byte lives in the high half of `data_bus`, otherwise in
+    /// the low half.
+    #[inline(always)]
+    fn biu_byte_on_lane(&self) -> u8 {
+        if self.bhe {
+            (self.data_bus >> 8) as u8
+        } else {
+            self.data_bus as u8
+        }
+    }
+
+    /// Zero-extend the byte on the active data-bus lane into the low byte of
+    /// a u16. Used when combining two byte transfers into a word result.
+    #[inline(always)]
+    fn biu_byte_on_lane_as_low_half(&self) -> u16 {
+        if self.bhe {
+            self.data_bus >> 8
+        } else {
+            self.data_bus & 0x00FF
+        }
+    }
+
+    /// Shift the byte on the active data-bus lane into the high byte of a
+    /// u16. Used when combining two byte transfers into a word result.
+    #[inline(always)]
+    fn biu_byte_on_lane_as_high_half(&self) -> u16 {
+        if self.bhe {
+            self.data_bus & 0xFF00
+        } else {
+            self.data_bus << 8
+        }
+    }
+
+    /// If BHE is asserted, shift the byte held in the low half of `data_bus`
+    /// into the high half so it sits on the active bus lane for an odd-address
+    /// byte transfer.
+    #[inline(always)]
+    fn biu_align_byte_to_lane(&mut self) {
+        if self.bhe {
+            self.data_bus <<= 8;
+        }
+    }
+
+    fn biu_do_bus_transfer(&mut self, bus: &mut impl Bus) {
+        match (self.bus_status_latch, self.transfer_size) {
+            (BusStatus::CodeFetch, TransferSize::Byte) => {
+                self.data_bus = bus.read_byte(self.address_latch & ADDRESS_MASK) as u16;
+            }
+            (BusStatus::CodeFetch, TransferSize::Word) => {
+                let base = self.address_latch & !1;
+                let lo = bus.read_byte(base & ADDRESS_MASK) as u16;
+                let hi = bus.read_byte(base.wrapping_add(1) & ADDRESS_MASK) as u16;
+                self.data_bus = lo | (hi << 8);
+            }
+            (BusStatus::MemRead, TransferSize::Byte) => {
+                let byte = bus.read_byte(self.address_latch & ADDRESS_MASK);
+                self.data_bus = byte as u16;
+                self.biu_align_byte_to_lane();
+            }
+            (BusStatus::MemRead, TransferSize::Word) => {
+                let base = self.address_latch & !1;
+                let lo = bus.read_byte(base & ADDRESS_MASK) as u16;
+                let hi = bus.read_byte(base.wrapping_add(1) & ADDRESS_MASK) as u16;
+                self.data_bus = lo | (hi << 8);
+            }
+            (BusStatus::MemWrite, TransferSize::Byte) => {
+                let byte = self.biu_byte_on_lane();
+                bus.write_byte(self.address_latch & ADDRESS_MASK, byte);
+            }
+            (BusStatus::MemWrite, TransferSize::Word) => {
+                let base = self.address_latch & !1;
+                bus.write_byte(base & ADDRESS_MASK, self.data_bus as u8);
+                bus.write_byte(
+                    base.wrapping_add(1) & ADDRESS_MASK,
+                    (self.data_bus >> 8) as u8,
+                );
+            }
+            (BusStatus::IoRead, TransferSize::Byte) => {
+                let port = (self.address_latch & 0xFFFF) as u16;
+                let byte = bus.io_read_byte(port);
+                self.data_bus = byte as u16;
+                self.biu_align_byte_to_lane();
+            }
+            (BusStatus::IoRead, TransferSize::Word) => {
+                let port = (self.address_latch & 0xFFFF) as u16;
+                self.data_bus = bus.io_read_word(port);
+            }
+            (BusStatus::IoWrite, TransferSize::Byte) => {
+                let port = (self.address_latch & 0xFFFF) as u16;
+                let byte = self.biu_byte_on_lane();
+                bus.io_write_byte(port, byte);
+            }
+            (BusStatus::IoWrite, TransferSize::Word) => {
+                let port = (self.address_latch & 0xFFFF) as u16;
+                bus.io_write_word(port, self.data_bus);
+            }
+            _ => {}
+        }
+        self.bus_status = BusStatus::Passive;
+    }
+
+    fn biu_address_start(&mut self, new_bus_status: BusStatus) {
+        self.ta_cycle = if self.ta_cycle == TaCycle::Ta {
+            TaCycle::Ts
+        } else {
+            TaCycle::Tr
+        };
+        self.pl_status = new_bus_status;
+    }
+
+    fn biu_bus_begin_fetch(&mut self) {
+        if self.queue_has_room_for_fetch() {
+            self.operand_size = match FETCH_SIZE {
+                1 => OperandSize::Operand8,
+                _ => OperandSize::Operand16,
+            };
+            self.fetch_state = FetchState::Normal;
+            self.pl_status = BusStatus::Passive;
+            self.bus_status = BusStatus::CodeFetch;
+            self.bus_status_latch = BusStatus::CodeFetch;
+            self.t_cycle = TCycle::Tinit;
+            let cs_base = self.seg_base(SegReg16::CS);
+            self.address_latch = cs_base.wrapping_add(self.prefetch_ip as u32) & ADDRESS_MASK;
+            self.address_bus = self.address_latch;
+            self.transfer_size = if self.prefetch_ip & 1 == 0 {
+                TransferSize::Word
+            } else {
+                TransferSize::Byte
+            };
+            self.transfer_n = 1;
+            self.final_transfer = true;
+        }
+    }
+
+    fn biu_fetch_abort(&mut self) {
+        self.ta_cycle = TaCycle::Ta;
+    }
+
+    pub(super) fn biu_fetch_suspend(&mut self, bus: &mut impl Bus) {
+        self.fetch_state = FetchState::Suspended;
+        if self.bus_status_latch == BusStatus::CodeFetch {
+            self.biu_bus_wait_finish(bus);
+        }
+        self.ta_cycle = TaCycle::Td;
+        self.pl_status = BusStatus::Passive;
+    }
+
+    pub(super) fn biu_queue_flush(&mut self, bus: &mut impl Bus) {
+        let _ = bus;
+        self.queue_flush();
+        self.fetch_state = FetchState::Normal;
+        self.biu_fetch_start();
+    }
+
+    pub(super) fn biu_queue_flush_early(&mut self, bus: &mut impl Bus) {
+        let _ = bus;
+        self.queue_flush();
+        self.fetch_state = FetchState::Normal;
+        self.biu_fetch_start();
+        if self.pl_status == BusStatus::CodeFetch && self.ta_cycle == TaCycle::Tr {
+            self.ta_cycle = TaCycle::Ts;
+        }
+    }
+
+    fn biu_fetch_start(&mut self) {
+        if self.bus_pending == BusPendingType::EuEarly || self.pl_status == BusStatus::CodeFetch {
+            return;
+        }
+        match self.fetch_state {
+            FetchState::Delayed(_) => {}
+            _ => {
+                self.fetch_state = FetchState::Normal;
+                self.biu_address_start(BusStatus::CodeFetch);
+            }
+        }
+    }
+
+    fn biu_make_fetch_decision(&mut self) {
+        if !self.queue_has_room_for_fetch() {
+            self.fetch_state = FetchState::PausedFull;
+            return;
+        }
+        if self.bus_pending == BusPendingType::EuEarly {
+            return;
+        }
+        if self.fetch_state == FetchState::Suspended {
+            return;
+        }
+        if self.queue_at_policy_len() && self.bus_status_latch == BusStatus::CodeFetch {
+            if self.ta_cycle == TaCycle::Td && !matches!(self.fetch_state, FetchState::Delayed(_)) {
+                self.fetch_state = FetchState::Delayed(POLICY_THROTTLE_DELAY);
+            }
+        } else if self.ta_cycle == TaCycle::Td {
+            self.biu_fetch_start();
+        }
+    }
+
+    #[inline]
+    pub(super) fn biu_bus_wait_finish(&mut self, bus: &mut impl Bus) {
+        if self.bus_status_latch != BusStatus::Passive {
+            let mut guard = 0u32;
+            while self.t_cycle != TCycle::T4 && guard < BIU_LOOP_GUARD {
+                self.cycle(bus);
+                guard += 1;
+            }
+        }
+    }
+
+    pub(super) fn biu_commit_pending_write_inline(&mut self, bus: &mut impl Bus) {
+        if matches!(
+            self.bus_status_latch,
+            BusStatus::MemWrite | BusStatus::IoWrite
+        ) && matches!(self.t_cycle, TCycle::T3 | TCycle::Tw)
+        {
+            self.biu_do_bus_transfer(bus);
+            self.biu_bus_end();
+            self.bus_status = BusStatus::Passive;
+            self.bus_status_latch = BusStatus::Passive;
+            self.t_cycle = TCycle::Ti;
+            self.transfer_n = 0;
+        }
+    }
+
+    #[inline]
+    fn biu_bus_wait_until_tx(&mut self, bus: &mut impl Bus) {
+        if matches!(
+            self.bus_status_latch,
+            BusStatus::MemRead
+                | BusStatus::MemWrite
+                | BusStatus::IoRead
+                | BusStatus::IoWrite
+                | BusStatus::CodeFetch
+        ) {
+            let mut guard = 0u32;
+            while self.t_cycle != TCycle::T3 && guard < BIU_LOOP_GUARD {
+                self.cycle(bus);
+                guard += 1;
+            }
+        }
+    }
+
+    #[inline]
+    fn biu_bus_wait_delay(&mut self, bus: &mut impl Bus) -> bool {
+        match self.fetch_state {
+            FetchState::Delayed(0) => {
+                self.ta_cycle = TaCycle::Td;
+                true
+            }
+            FetchState::Delayed(delay) => {
+                self.cycles(bus, delay as u32);
+                self.ta_cycle = TaCycle::Ta;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    #[inline]
+    fn biu_bus_wait_address(&mut self, bus: &mut impl Bus) {
+        let mut guard = 0u32;
+        while !matches!(self.ta_cycle, TaCycle::Td | TaCycle::Ta) && guard < BIU_LOOP_GUARD {
+            self.cycle(bus);
+            guard += 1;
+        }
+    }
+
+    /// Begin an EU bus m-cycle. Handles bus-cycle synchronisation, fetch
+    /// aborts, and address cycle setup before starting T1.
+    #[allow(clippy::too_many_arguments)]
+    fn biu_bus_begin(
+        &mut self,
+        bus: &mut impl Bus,
+        new_bus_status: BusStatus,
+        address: u32,
+        data: u16,
+        size: TransferSize,
+        op_size: OperandSize,
+        first: bool,
+    ) {
+        debug_assert_ne!(
+            new_bus_status,
+            BusStatus::CodeFetch,
+            "biu_bus_begin cannot start a code fetch"
+        );
+
+        let mut fetch_abort = false;
+
+        match self.t_cycle {
+            TCycle::Ti => {
+                self.biu_address_start(new_bus_status);
+            }
+            TCycle::T1 | TCycle::T2 => {
+                self.bus_pending = BusPendingType::EuEarly;
+                self.biu_address_start(new_bus_status);
+            }
+            _ => {
+                if self.pl_status == BusStatus::CodeFetch {
+                    self.bus_pending = BusPendingType::EuLate;
+                    fetch_abort = true;
+                } else if !self.final_transfer {
+                    self.bus_pending = BusPendingType::EuEarly;
+                }
+            }
+        }
+
+        self.biu_bus_wait_finish(bus);
+
+        let was_delay = self.biu_bus_wait_delay(bus);
+
+        self.biu_bus_wait_address(bus);
+
+        if was_delay || fetch_abort {
+            self.biu_address_start(new_bus_status);
+            self.biu_bus_wait_address(bus);
+        }
+
+        if self.t_cycle == TCycle::T4 && self.bus_status_latch != BusStatus::CodeFetch {
+            self.cycle(bus);
+        }
+
+        match size {
+            TransferSize::Word => {
+                self.transfer_n = 1;
+                self.final_transfer = true;
+            }
+            TransferSize::Byte => {
+                if first {
+                    match op_size {
+                        OperandSize::Operand8 => {
+                            self.transfer_n = 1;
+                            self.final_transfer = true;
+                        }
+                        OperandSize::Operand16 => {
+                            self.transfer_n = 1;
+                            self.final_transfer = false;
+                        }
+                    }
+                } else {
+                    self.transfer_n = 2;
+                    self.final_transfer = true;
+                }
+            }
+        }
+
+        self.bhe = matches!(size, TransferSize::Word) || (address & 1 != 0);
+        self.bus_pending = BusPendingType::None;
+        self.pl_status = BusStatus::Passive;
+        self.bus_status = new_bus_status;
+        self.bus_status_latch = new_bus_status;
+        self.t_cycle = TCycle::Tinit;
+        self.address_bus = address;
+        self.address_latch = address;
+        self.data_bus = data;
+        self.transfer_size = size;
+        self.operand_size = op_size;
+
+        if matches!(size, TransferSize::Byte) {
+            self.biu_align_byte_to_lane();
+        }
+    }
+
+    pub(super) fn biu_read_u8_physical(&mut self, bus: &mut impl Bus, address: u32) -> u8 {
+        let wrapped_address = address & ADDRESS_MASK;
+        self.biu_bus_begin(
+            bus,
+            BusStatus::MemRead,
+            wrapped_address,
+            0,
+            TransferSize::Byte,
+            OperandSize::Operand8,
+            true,
+        );
+        self.biu_bus_wait_finish(bus);
+        self.biu_byte_on_lane()
+    }
+
+    pub(super) fn biu_write_u8_physical(&mut self, bus: &mut impl Bus, address: u32, byte: u8) {
+        let wrapped_address = address & ADDRESS_MASK;
+        self.biu_bus_begin(
+            bus,
+            BusStatus::MemWrite,
+            wrapped_address,
+            byte as u16,
+            TransferSize::Byte,
+            OperandSize::Operand8,
+            true,
+        );
+        self.biu_bus_wait_until_tx(bus);
+    }
+
+    /// Read a word in a single aligned m-cycle.
+    fn biu_read_word_aligned(
+        &mut self,
+        bus: &mut impl Bus,
+        status: BusStatus,
+        address: u32,
+    ) -> u16 {
+        self.biu_bus_begin(
+            bus,
+            status,
+            address,
+            0,
+            TransferSize::Word,
+            OperandSize::Operand16,
+            true,
+        );
+        self.biu_bus_wait_finish(bus);
+        self.data_bus
+    }
+
+    /// Read a word that spans two byte m-cycles because the operand is at an
+    /// odd address. The caller provides the two byte addresses.
+    fn biu_read_word_unaligned(
+        &mut self,
+        bus: &mut impl Bus,
+        status: BusStatus,
+        lo_address: u32,
+        hi_address: u32,
+    ) -> u16 {
+        self.biu_bus_begin(
+            bus,
+            status,
+            lo_address,
+            0,
+            TransferSize::Byte,
+            OperandSize::Operand16,
+            true,
+        );
+        self.biu_bus_wait_finish(bus);
+        let lo = self.biu_byte_on_lane_as_low_half();
+
+        self.biu_bus_begin(
+            bus,
+            status,
+            hi_address,
+            0,
+            TransferSize::Byte,
+            OperandSize::Operand16,
+            false,
+        );
+        self.biu_bus_wait_finish(bus);
+        let hi = self.biu_byte_on_lane_as_high_half();
+        lo | hi
+    }
+
+    /// Write a word in a single aligned m-cycle.
+    fn biu_write_word_aligned(
+        &mut self,
+        bus: &mut impl Bus,
+        status: BusStatus,
+        address: u32,
+        word: u16,
+    ) {
+        self.biu_bus_begin(
+            bus,
+            status,
+            address,
+            word,
+            TransferSize::Word,
+            OperandSize::Operand16,
+            true,
+        );
+        self.biu_bus_wait_until_tx(bus);
+    }
+
+    /// Write a word that spans two byte m-cycles because the operand is at an
+    /// odd address. The caller provides both byte addresses.
+    fn biu_write_word_unaligned(
+        &mut self,
+        bus: &mut impl Bus,
+        status: BusStatus,
+        lo_address: u32,
+        hi_address: u32,
+        word: u16,
+    ) {
+        self.biu_bus_begin(
+            bus,
+            status,
+            lo_address,
+            word & 0x00FF,
+            TransferSize::Byte,
+            OperandSize::Operand16,
+            true,
+        );
+        self.biu_bus_wait_until_tx(bus);
+
+        self.biu_bus_begin(
+            bus,
+            status,
+            hi_address,
+            (word >> 8) & 0x00FF,
+            TransferSize::Byte,
+            OperandSize::Operand16,
+            false,
+        );
+        self.biu_bus_wait_until_tx(bus);
+    }
+
+    /// Read a 16-bit word from `seg:offset`. Odd-aligned accesses split into
+    /// two byte transfers; aligned accesses complete in one m-cycle.
+    pub(super) fn biu_read_u16(&mut self, bus: &mut impl Bus, seg: SegReg16, offset: u16) -> u16 {
+        let lo_address = self.seg_base(seg).wrapping_add(offset as u32) & ADDRESS_MASK;
+        if offset & 1 == 0 {
+            self.biu_read_word_aligned(bus, BusStatus::MemRead, lo_address)
+        } else {
+            let hi_address = self
+                .seg_base(seg)
+                .wrapping_add(offset.wrapping_add(1) as u32)
+                & ADDRESS_MASK;
+            self.biu_read_word_unaligned(bus, BusStatus::MemRead, lo_address, hi_address)
+        }
+    }
+
+    pub(super) fn biu_read_u16_physical(&mut self, bus: &mut impl Bus, address: u32) -> u16 {
+        let wrapped_address = address & ADDRESS_MASK;
+        if wrapped_address & 1 == 0 {
+            self.biu_read_word_aligned(bus, BusStatus::MemRead, wrapped_address)
+        } else {
+            let next_wrapped_address = wrapped_address.wrapping_add(1) & ADDRESS_MASK;
+            self.biu_read_word_unaligned(
+                bus,
+                BusStatus::MemRead,
+                wrapped_address,
+                next_wrapped_address,
+            )
+        }
+    }
+
+    /// Write a 16-bit word to `seg:offset`.
+    pub(super) fn biu_write_u16(
+        &mut self,
+        bus: &mut impl Bus,
+        seg: SegReg16,
+        offset: u16,
+        word: u16,
+    ) {
+        let lo_address = self.seg_base(seg).wrapping_add(offset as u32) & ADDRESS_MASK;
+        if offset & 1 == 0 {
+            self.biu_write_word_aligned(bus, BusStatus::MemWrite, lo_address, word);
+        } else {
+            let hi_address = self
+                .seg_base(seg)
+                .wrapping_add(offset.wrapping_add(1) as u32)
+                & ADDRESS_MASK;
+            self.biu_write_word_unaligned(bus, BusStatus::MemWrite, lo_address, hi_address, word);
+        }
+    }
+
+    pub(super) fn biu_io_read_u8(&mut self, bus: &mut impl Bus, port: u16) -> u8 {
+        self.biu_bus_begin(
+            bus,
+            BusStatus::IoRead,
+            port as u32,
+            0,
+            TransferSize::Byte,
+            OperandSize::Operand8,
+            true,
+        );
+        self.biu_bus_wait_finish(bus);
+        self.biu_byte_on_lane()
+    }
+
+    pub(super) fn biu_io_write_u8(&mut self, bus: &mut impl Bus, port: u16, byte: u8) {
+        self.biu_bus_begin(
+            bus,
+            BusStatus::IoWrite,
+            port as u32,
+            byte as u16,
+            TransferSize::Byte,
+            OperandSize::Operand8,
+            true,
+        );
+        self.biu_bus_wait_until_tx(bus);
+    }
+
+    pub(super) fn biu_io_read_u16(&mut self, bus: &mut impl Bus, port: u16) -> u16 {
+        let lo_address = port as u32;
+        if port & 1 == 0 {
+            self.biu_read_word_aligned(bus, BusStatus::IoRead, lo_address)
+        } else {
+            let hi_address = port.wrapping_add(1) as u32;
+            self.biu_read_word_unaligned(bus, BusStatus::IoRead, lo_address, hi_address)
+        }
+    }
+
+    pub(super) fn biu_io_write_u16(&mut self, bus: &mut impl Bus, port: u16, word: u16) {
+        let lo_address = port as u32;
+        if port & 1 == 0 {
+            self.biu_write_word_aligned(bus, BusStatus::IoWrite, lo_address, word);
+        } else {
+            let hi_address = port.wrapping_add(1) as u32;
+            self.biu_write_word_unaligned(bus, BusStatus::IoWrite, lo_address, hi_address, word);
+        }
+    }
+
+    /// Read one instruction byte from the queue, cycling if empty.
+    pub(super) fn biu_queue_read(&mut self, bus: &mut impl Bus, dtype: QueueType) -> u8 {
+        // Cancel fetch delay if queue is at threshold.
+        if matches!(self.fetch_state, FetchState::Delayed(_)) && self.queue_at_policy_threshold() {
+            self.fetch_state = FetchState::Delayed(0);
+        }
+
+        if let Some(preload) = self.instruction_preload.take() {
+            self.last_queue_op = QueueOp::First;
+            self.nx = false;
+            self.biu_fetch_on_queue_read();
+            return preload;
+        }
+
+        let byte = if self.queue_len() > 0 {
+            let b = self.queue_pop();
+            self.biu_fetch_on_queue_read();
+            b
+        } else {
+            self.ensure_fetch_in_flight();
+            let mut guard = 0u32;
+            while self.queue_len() == 0 && guard < BIU_LOOP_GUARD {
+                self.cycle(bus);
+                guard += 1;
+            }
+            if self.queue_len() > 0 {
+                self.queue_pop()
+            } else {
+                0
+            }
+        };
+
+        self.queue_op = match dtype {
+            QueueType::First => QueueOp::First,
+            QueueType::Subsequent => QueueOp::Subsequent,
+        };
+        self.cycle(bus);
+        byte
+    }
+
+    /// Schedule a code fetch if no fetch/address cycle is currently in
+    /// flight. Used as a safety valve in wait-for-queue loops.
+    fn ensure_fetch_in_flight(&mut self) {
+        if self.bus_status_latch == BusStatus::Passive
+            && self.pl_status != BusStatus::CodeFetch
+            && !matches!(self.fetch_state, FetchState::Delayed(_))
+        {
+            self.biu_fetch_start();
+        }
+    }
+
+    pub(super) fn biu_fetch_on_queue_read(&mut self) {
+        if self.bus_status == BusStatus::Passive && self.queue_has_room_for_fetch() {
+            match self.fetch_state {
+                FetchState::Suspended => {
+                    self.ta_cycle = TaCycle::Td;
+                }
+                FetchState::PausedFull => {
+                    if self.t_cycle == TCycle::Ti {
+                        self.ta_cycle = TaCycle::Td;
+                    } else {
+                        return;
+                    }
+                }
+                _ => {}
+            }
+            self.biu_fetch_start();
+        }
+    }
+
+    pub(super) fn biu_fetch_next(&mut self, bus: &mut impl Bus) {
+        self.ensure_fetch_in_flight();
+
+        let mut guard = 0u32;
+        while self.queue_len() == 0 && self.instruction_preload.is_none() && guard < BIU_LOOP_GUARD
+        {
+            if self.nx {
+                self.nx = false;
+                self.rni = false;
+            }
+            self.cycle(bus);
+            guard += 1;
+        }
+
+        if self.instruction_preload.is_none() && self.queue_len() > 0 {
+            let byte = self.queue_pop();
+            self.instruction_preload = Some(byte);
+            self.queue_op = QueueOp::First;
+            self.biu_fetch_on_queue_read();
+        }
+
+        if self.nx {
+            self.nx = false;
+        }
+        if self.rni {
+            self.rni = false;
+        }
+
+        self.cycle(bus);
+    }
+
+    /// Preload the next instruction's first byte without spending the trailing
+    /// finish cycle.
+    pub(super) fn biu_preload_next(&mut self, bus: &mut impl Bus) {
+        self.ensure_fetch_in_flight();
+        let mut guard = 0u32;
+        while self.queue_len() == 0 && self.instruction_preload.is_none() && guard < BIU_LOOP_GUARD
+        {
+            if self.nx {
+                self.nx = false;
+                self.rni = false;
+            }
+            self.cycle(bus);
+            guard += 1;
+        }
+        if self.instruction_preload.is_none() && self.queue_len() > 0 {
+            let byte = self.queue_pop();
+            self.instruction_preload = Some(byte);
+            self.biu_fetch_on_queue_read();
+        }
+    }
+}

--- a/crates/cpu/src/i8086/execute.rs
+++ b/crates/cpu/src/i8086/execute.rs
@@ -1,0 +1,1773 @@
+use super::{
+    I8086, StepFinishCycle,
+    biu::{ADDRESS_MASK, FetchState},
+};
+use crate::{ByteReg, SegReg16, WordReg};
+
+impl I8086 {
+    pub(super) fn dispatch(&mut self, opcode: u8, bus: &mut impl common::Bus) {
+        match opcode {
+            // ADD
+            0x00 => self.add_br8(bus),
+            0x01 => self.add_wr16(bus),
+            0x02 => self.add_r8b(bus),
+            0x03 => self.add_r16w(bus),
+            0x04 => self.add_ald8(bus),
+            0x05 => self.add_axd16(bus),
+            0x06 => self.push_seg(SegReg16::ES, bus),
+            0x07 => {
+                self.pop_seg(SegReg16::ES, bus);
+                self.inhibit_all = 1;
+            }
+
+            // OR
+            0x08 => self.or_br8(bus),
+            0x09 => self.or_wr16(bus),
+            0x0A => self.or_r8b(bus),
+            0x0B => self.or_r16w(bus),
+            0x0C => self.or_ald8(bus),
+            0x0D => self.or_axd16(bus),
+            0x0E => self.push_seg(SegReg16::CS, bus),
+            0x0F => self.pop_cs(bus),
+
+            // ADC
+            0x10 => self.adc_br8(bus),
+            0x11 => self.adc_wr16(bus),
+            0x12 => self.adc_r8b(bus),
+            0x13 => self.adc_r16w(bus),
+            0x14 => self.adc_ald8(bus),
+            0x15 => self.adc_axd16(bus),
+            0x16 => self.push_seg(SegReg16::SS, bus),
+            0x17 => {
+                self.pop_seg(SegReg16::SS, bus);
+                self.inhibit_all = 1;
+            }
+
+            // SBB
+            0x18 => self.sbb_br8(bus),
+            0x19 => self.sbb_wr16(bus),
+            0x1A => self.sbb_r8b(bus),
+            0x1B => self.sbb_r16w(bus),
+            0x1C => self.sbb_ald8(bus),
+            0x1D => self.sbb_axd16(bus),
+            0x1E => self.push_seg(SegReg16::DS, bus),
+            0x1F => {
+                self.pop_seg(SegReg16::DS, bus);
+                self.inhibit_all = 1;
+            }
+
+            // AND
+            0x20 => self.and_br8(bus),
+            0x21 => self.and_wr16(bus),
+            0x22 => self.and_r8b(bus),
+            0x23 => self.and_r16w(bus),
+            0x24 => self.and_ald8(bus),
+            0x25 => self.and_axd16(bus),
+            0x26 => self.segment_prefix(bus, SegReg16::ES),
+            0x27 => self.daa(bus),
+
+            // SUB
+            0x28 => self.sub_br8(bus),
+            0x29 => self.sub_wr16(bus),
+            0x2A => self.sub_r8b(bus),
+            0x2B => self.sub_r16w(bus),
+            0x2C => self.sub_ald8(bus),
+            0x2D => self.sub_axd16(bus),
+            0x2E => self.segment_prefix(bus, SegReg16::CS),
+            0x2F => self.das(bus),
+
+            // XOR
+            0x30 => self.xor_br8(bus),
+            0x31 => self.xor_wr16(bus),
+            0x32 => self.xor_r8b(bus),
+            0x33 => self.xor_r16w(bus),
+            0x34 => self.xor_ald8(bus),
+            0x35 => self.xor_axd16(bus),
+            0x36 => self.segment_prefix(bus, SegReg16::SS),
+            0x37 => self.aaa(bus),
+
+            // CMP
+            0x38 => self.cmp_br8(bus),
+            0x39 => self.cmp_wr16(bus),
+            0x3A => self.cmp_r8b(bus),
+            0x3B => self.cmp_r16w(bus),
+            0x3C => self.cmp_ald8(bus),
+            0x3D => self.cmp_axd16(bus),
+            0x3E => self.segment_prefix(bus, SegReg16::DS),
+            0x3F => self.aas(bus),
+
+            // INC word registers
+            0x40 => self.inc_word_reg(bus, WordReg::AX),
+            0x41 => self.inc_word_reg(bus, WordReg::CX),
+            0x42 => self.inc_word_reg(bus, WordReg::DX),
+            0x43 => self.inc_word_reg(bus, WordReg::BX),
+            0x44 => self.inc_word_reg(bus, WordReg::SP),
+            0x45 => self.inc_word_reg(bus, WordReg::BP),
+            0x46 => self.inc_word_reg(bus, WordReg::SI),
+            0x47 => self.inc_word_reg(bus, WordReg::DI),
+
+            // DEC word registers
+            0x48 => self.dec_word_reg(bus, WordReg::AX),
+            0x49 => self.dec_word_reg(bus, WordReg::CX),
+            0x4A => self.dec_word_reg(bus, WordReg::DX),
+            0x4B => self.dec_word_reg(bus, WordReg::BX),
+            0x4C => self.dec_word_reg(bus, WordReg::SP),
+            0x4D => self.dec_word_reg(bus, WordReg::BP),
+            0x4E => self.dec_word_reg(bus, WordReg::SI),
+            0x4F => self.dec_word_reg(bus, WordReg::DI),
+
+            // PUSH word registers
+            0x50 => self.push_word_reg(WordReg::AX, bus),
+            0x51 => self.push_word_reg(WordReg::CX, bus),
+            0x52 => self.push_word_reg(WordReg::DX, bus),
+            0x53 => self.push_word_reg(WordReg::BX, bus),
+            0x54 => self.push_sp(bus),
+            0x55 => self.push_word_reg(WordReg::BP, bus),
+            0x56 => self.push_word_reg(WordReg::SI, bus),
+            0x57 => self.push_word_reg(WordReg::DI, bus),
+
+            // POP word registers
+            0x58 => self.pop_word_reg(WordReg::AX, bus),
+            0x59 => self.pop_word_reg(WordReg::CX, bus),
+            0x5A => self.pop_word_reg(WordReg::DX, bus),
+            0x5B => self.pop_word_reg(WordReg::BX, bus),
+            0x5C => self.pop_word_reg(WordReg::SP, bus),
+            0x5D => self.pop_word_reg(WordReg::BP, bus),
+            0x5E => self.pop_word_reg(WordReg::SI, bus),
+            0x5F => self.pop_word_reg(WordReg::DI, bus),
+
+            // Jcc aliases on 8086
+            0x60 => self.jcc(bus, self.flags.of()),
+            0x61 => self.jcc(bus, !self.flags.of()),
+            0x62 => self.jcc(bus, self.flags.cf()),
+            0x63 => self.jcc(bus, !self.flags.cf()),
+            0x64 => self.jcc(bus, self.flags.zf()),
+            0x65 => self.jcc(bus, !self.flags.zf()),
+            0x66 => self.jcc(bus, self.flags.cf() || self.flags.zf()),
+            0x67 => self.jcc_swapped(bus, !self.flags.cf() && !self.flags.zf()),
+            0x68 => self.jcc(bus, self.flags.sf()),
+            0x69 => self.jcc(bus, !self.flags.sf()),
+            0x6A => self.jcc(bus, self.flags.pf()),
+            0x6B => self.jcc(bus, !self.flags.pf()),
+            0x6C => self.jcc(bus, self.flags.sf() != self.flags.of()),
+            0x6D => self.jcc_swapped(bus, self.flags.sf() == self.flags.of()),
+            0x6E => self.jcc(bus, self.flags.zf() || (self.flags.sf() != self.flags.of())),
+            0x6F => self.jcc_swapped(
+                bus,
+                !self.flags.zf() && (self.flags.sf() == self.flags.of()),
+            ),
+
+            // Jcc (short jumps)
+            0x70 => self.jcc(bus, self.flags.of()),
+            0x71 => self.jcc(bus, !self.flags.of()),
+            0x72 => self.jcc(bus, self.flags.cf()),
+            0x73 => self.jcc(bus, !self.flags.cf()),
+            0x74 => self.jcc(bus, self.flags.zf()),
+            0x75 => self.jcc(bus, !self.flags.zf()),
+            0x76 => self.jcc(bus, self.flags.cf() || self.flags.zf()),
+            0x77 => self.jcc_swapped(bus, !self.flags.cf() && !self.flags.zf()),
+            0x78 => self.jcc(bus, self.flags.sf()),
+            0x79 => self.jcc(bus, !self.flags.sf()),
+            0x7A => self.jcc(bus, self.flags.pf()),
+            0x7B => self.jcc(bus, !self.flags.pf()),
+            0x7C => self.jcc(bus, self.flags.sf() != self.flags.of()),
+            0x7D => self.jcc_swapped(bus, self.flags.sf() == self.flags.of()),
+            0x7E => self.jcc(bus, self.flags.zf() || (self.flags.sf() != self.flags.of())),
+            0x7F => self.jcc_swapped(
+                bus,
+                !self.flags.zf() && (self.flags.sf() == self.flags.of()),
+            ),
+
+            // Group 1
+            0x80 => self.group_80(bus),
+            0x81 => self.group_81(bus),
+            0x82 => self.group_82(bus),
+            0x83 => self.group_83(bus),
+
+            // TEST
+            0x84 => self.test_br8(bus),
+            0x85 => self.test_wr16(bus),
+
+            // XCHG
+            0x86 => self.xchg_br8(bus),
+            0x87 => self.xchg_wr16(bus),
+
+            // MOV r/m, reg
+            0x88 => self.mov_br8(bus),
+            0x89 => self.mov_wr16(bus),
+            0x8A => self.mov_r8b(bus),
+            0x8B => self.mov_r16w(bus),
+
+            // MOV r/m, sreg / LEA / MOV sreg, r/m
+            0x8C => self.mov_rm_sreg(bus),
+            0x8D => self.lea(bus),
+            0x8E => self.mov_sreg_rm(bus),
+            0x8F => self.pop_rm(bus),
+
+            // XCHG AX, reg / NOP
+            0x90 => self.clk(bus, self.queue_resident_eu_cycles(3, 0)),
+            0x91 => self.xchg_aw(bus, WordReg::CX),
+            0x92 => self.xchg_aw(bus, WordReg::DX),
+            0x93 => self.xchg_aw(bus, WordReg::BX),
+            0x94 => self.xchg_aw(bus, WordReg::SP),
+            0x95 => self.xchg_aw(bus, WordReg::BP),
+            0x96 => self.xchg_aw(bus, WordReg::SI),
+            0x97 => self.xchg_aw(bus, WordReg::DI),
+
+            // CBW, CWD
+            0x98 => self.cbw(bus),
+            0x99 => self.cwd(bus),
+
+            // CALL far, WAIT
+            0x9A => self.call_far(bus),
+            0x9B => self.clk(bus, 2), // WAIT
+            0x9C => self.pushf(bus),
+            0x9D => self.popf(bus),
+            0x9E => self.sahf(bus),
+            0x9F => self.lahf(bus),
+
+            // MOV AL/AX, [addr] and [addr], AL/AX
+            0xA0 => self.mov_al_moffs(bus),
+            0xA1 => self.mov_aw_moffs(bus),
+            0xA2 => self.mov_moffs_al(bus),
+            0xA3 => self.mov_moffs_aw(bus),
+
+            // String ops
+            0xA4 => self.movsb(bus),
+            0xA5 => self.movsw(bus),
+            0xA6 => self.cmpsb(bus),
+            0xA7 => self.cmpsw(bus),
+
+            // TEST AL/AX, imm
+            0xA8 => self.test_al_imm8(bus),
+            0xA9 => self.test_aw_imm16(bus),
+
+            // STOS, LODS, SCAS
+            0xAA => self.stosb(bus),
+            0xAB => self.stosw(bus),
+            0xAC => self.lodsb(bus),
+            0xAD => self.lodsw(bus),
+            0xAE => self.scasb(bus),
+            0xAF => self.scasw(bus),
+
+            // MOV byte reg, imm8
+            0xB0 => self.mov_byte_reg_imm(ByteReg::AL, bus),
+            0xB1 => self.mov_byte_reg_imm(ByteReg::CL, bus),
+            0xB2 => self.mov_byte_reg_imm(ByteReg::DL, bus),
+            0xB3 => self.mov_byte_reg_imm(ByteReg::BL, bus),
+            0xB4 => self.mov_byte_reg_imm(ByteReg::AH, bus),
+            0xB5 => self.mov_byte_reg_imm(ByteReg::CH, bus),
+            0xB6 => self.mov_byte_reg_imm(ByteReg::DH, bus),
+            0xB7 => self.mov_byte_reg_imm(ByteReg::BH, bus),
+
+            // MOV word reg, imm16
+            0xB8 => self.mov_word_reg_imm(WordReg::AX, bus),
+            0xB9 => self.mov_word_reg_imm(WordReg::CX, bus),
+            0xBA => self.mov_word_reg_imm(WordReg::DX, bus),
+            0xBB => self.mov_word_reg_imm(WordReg::BX, bus),
+            0xBC => self.mov_word_reg_imm(WordReg::SP, bus),
+            0xBD => self.mov_word_reg_imm(WordReg::BP, bus),
+            0xBE => self.mov_word_reg_imm(WordReg::SI, bus),
+            0xBF => self.mov_word_reg_imm(WordReg::DI, bus),
+
+            // RET near aliases on 8086
+            0xC0 => self.ret_near_imm(bus),
+            0xC1 => self.ret_near(bus),
+
+            // RET near imm16, RET near
+            0xC2 => self.ret_near_imm(bus),
+            0xC3 => self.ret_near(bus),
+
+            // LES, LDS
+            0xC4 => self.les(bus),
+            0xC5 => self.lds(bus),
+
+            // MOV r/m, imm
+            0xC6 => self.mov_rm_imm8(bus),
+            0xC7 => self.mov_rm_imm16(bus),
+
+            // RET far aliases on 8086
+            0xC8 => self.ret_far_imm(bus),
+            0xC9 => self.ret_far(bus),
+
+            // RET far imm16, RET far
+            0xCA => self.ret_far_imm(bus),
+            0xCB => self.ret_far(bus),
+
+            // INT 3, INT imm8, INTO, IRET
+            0xCC => self.int3(bus),
+            0xCD => self.int_imm(bus),
+            0xCE => self.into(bus),
+            0xCF => self.iret(bus),
+
+            // Shift/rotate groups
+            0xD0 => self.group_d0(bus),
+            0xD1 => self.group_d1(bus),
+            0xD2 => self.group_d2(bus),
+            0xD3 => self.group_d3(bus),
+
+            // AAM, AAD
+            0xD4 => self.aam(bus),
+            0xD5 => self.aad(bus),
+
+            // SALC / SETALC
+            0xD6 => self.salc(bus),
+
+            // XLAT
+            0xD7 => self.xlat(bus),
+
+            // FPU escape (NOP on I8086)
+            0xD8..=0xDF => self.fpu_escape(bus),
+
+            // LOOPNE, LOOPE, LOOP, JCXZ
+            0xE0 => self.loopne(bus),
+            0xE1 => self.loope(bus),
+            0xE2 => self.loop_(bus),
+            0xE3 => self.jcxz(bus),
+
+            // IN, OUT
+            0xE4 => self.in_al_imm(bus),
+            0xE5 => self.in_aw_imm(bus),
+            0xE6 => self.out_imm_al(bus),
+            0xE7 => self.out_imm_aw(bus),
+
+            // CALL near, JMP near, JMP far, JMP short
+            0xE8 => self.call_near(bus),
+            0xE9 => self.jmp_near(bus),
+            0xEA => self.jmp_far(bus),
+            0xEB => self.jmp_short(bus),
+
+            // IN, OUT (DX port)
+            0xEC => self.in_al_dw(bus),
+            0xED => self.in_aw_dw(bus),
+            0xEE => self.out_dw_al(bus),
+            0xEF => self.out_dw_aw(bus),
+
+            0xF0 => self.lock_prefix(bus),
+            0xF1 => self.lock_prefix(bus),
+
+            // REPNE, REPE
+            0xF2 => self.repne(bus),
+            0xF3 => self.repe(bus),
+
+            // HLT
+            0xF4 => self.hlt(bus),
+
+            // CMC
+            0xF5 => self.cmc(bus),
+
+            // Group 3 byte/word
+            0xF6 => self.group_f6(bus),
+            0xF7 => self.group_f7(bus),
+
+            // CLC, STC, CLI, STI, CLD, STD
+            0xF8 => self.clc(bus),
+            0xF9 => self.stc(bus),
+            0xFA => self.cli(bus),
+            0xFB => self.sti(bus),
+            0xFC => self.cld(bus),
+            0xFD => self.std(bus),
+
+            // Group 4/5
+            0xFE => self.group_fe(bus),
+            0xFF => self.group_ff(bus),
+        }
+    }
+
+    fn add_br8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.byte(self.reg_byte(modrm));
+        let dst = self.get_rm_byte(modrm, bus);
+        let result = self.alu_add_byte(dst, src);
+        self.putback_rm_byte(modrm, result, bus);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn add_wr16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.word(self.reg_word(modrm));
+        let dst = self.get_rm_word(modrm, bus);
+        let result = self.alu_add_word(dst, src);
+        self.putback_rm_word(modrm, result, bus);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn add_r8b(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.byte(self.reg_byte(modrm));
+        let src = self.get_rm_byte(modrm, bus);
+        let result = self.alu_add_byte(dst, src);
+        let reg = self.reg_byte(modrm);
+        self.regs.set_byte(reg, result);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn add_r16w(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.word(self.reg_word(modrm));
+        let src = self.get_rm_word(modrm, bus);
+        let result = self.alu_add_word(dst, src);
+        let reg = self.reg_word(modrm);
+        self.regs.set_word(reg, result);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn add_ald8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetch(bus);
+        let dst = self.regs.byte(ByteReg::AL);
+        let result = self.alu_add_byte(dst, src);
+        self.regs.set_byte(ByteReg::AL, result);
+        self.clk(bus, 1);
+    }
+
+    fn add_axd16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetchword(bus);
+        let dst = self.regs.word(WordReg::AX);
+        let result = self.alu_add_word(dst, src);
+        self.regs.set_word(WordReg::AX, result);
+    }
+
+    fn or_br8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.byte(self.reg_byte(modrm));
+        let dst = self.get_rm_byte(modrm, bus);
+        let result = self.alu_or_byte(dst, src);
+        self.putback_rm_byte(modrm, result, bus);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn or_wr16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.word(self.reg_word(modrm));
+        let dst = self.get_rm_word(modrm, bus);
+        let result = self.alu_or_word(dst, src);
+        self.putback_rm_word(modrm, result, bus);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn or_r8b(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.byte(self.reg_byte(modrm));
+        let src = self.get_rm_byte(modrm, bus);
+        let result = self.alu_or_byte(dst, src);
+        let reg = self.reg_byte(modrm);
+        self.regs.set_byte(reg, result);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn or_r16w(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.word(self.reg_word(modrm));
+        let src = self.get_rm_word(modrm, bus);
+        let result = self.alu_or_word(dst, src);
+        let reg = self.reg_word(modrm);
+        self.regs.set_word(reg, result);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn or_ald8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetch(bus);
+        let dst = self.regs.byte(ByteReg::AL);
+        let result = self.alu_or_byte(dst, src);
+        self.regs.set_byte(ByteReg::AL, result);
+        self.clk(bus, 1);
+    }
+
+    fn or_axd16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetchword(bus);
+        let dst = self.regs.word(WordReg::AX);
+        let result = self.alu_or_word(dst, src);
+        self.regs.set_word(WordReg::AX, result);
+    }
+
+    fn adc_br8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.byte(self.reg_byte(modrm));
+        let dst = self.get_rm_byte(modrm, bus);
+        let cf = self.flags.cf_val();
+        let result = self.alu_adc_byte(dst, src, cf);
+        self.putback_rm_byte(modrm, result, bus);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn adc_wr16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.word(self.reg_word(modrm));
+        let dst = self.get_rm_word(modrm, bus);
+        let cf = self.flags.cf_val();
+        let result = self.alu_adc_word(dst, src, cf);
+        self.putback_rm_word(modrm, result, bus);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn adc_r8b(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.byte(self.reg_byte(modrm));
+        let src = self.get_rm_byte(modrm, bus);
+        let cf = self.flags.cf_val();
+        let result = self.alu_adc_byte(dst, src, cf);
+        let reg = self.reg_byte(modrm);
+        self.regs.set_byte(reg, result);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn adc_r16w(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.word(self.reg_word(modrm));
+        let src = self.get_rm_word(modrm, bus);
+        let cf = self.flags.cf_val();
+        let result = self.alu_adc_word(dst, src, cf);
+        let reg = self.reg_word(modrm);
+        self.regs.set_word(reg, result);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn adc_ald8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetch(bus);
+        let dst = self.regs.byte(ByteReg::AL);
+        let cf = self.flags.cf_val();
+        let result = self.alu_adc_byte(dst, src, cf);
+        self.regs.set_byte(ByteReg::AL, result);
+        self.clk(bus, 1);
+    }
+
+    fn adc_axd16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetchword(bus);
+        let dst = self.regs.word(WordReg::AX);
+        let cf = self.flags.cf_val();
+        let result = self.alu_adc_word(dst, src, cf);
+        self.regs.set_word(WordReg::AX, result);
+    }
+
+    fn sbb_br8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.byte(self.reg_byte(modrm));
+        let dst = self.get_rm_byte(modrm, bus);
+        let cf = self.flags.cf_val();
+        let result = self.alu_sbb_byte(dst, src, cf);
+        self.putback_rm_byte(modrm, result, bus);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn sbb_wr16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.word(self.reg_word(modrm));
+        let dst = self.get_rm_word(modrm, bus);
+        let cf = self.flags.cf_val();
+        let result = self.alu_sbb_word(dst, src, cf);
+        self.putback_rm_word(modrm, result, bus);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn sbb_r8b(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.byte(self.reg_byte(modrm));
+        let src = self.get_rm_byte(modrm, bus);
+        let cf = self.flags.cf_val();
+        let result = self.alu_sbb_byte(dst, src, cf);
+        let reg = self.reg_byte(modrm);
+        self.regs.set_byte(reg, result);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn sbb_r16w(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.word(self.reg_word(modrm));
+        let src = self.get_rm_word(modrm, bus);
+        let cf = self.flags.cf_val();
+        let result = self.alu_sbb_word(dst, src, cf);
+        let reg = self.reg_word(modrm);
+        self.regs.set_word(reg, result);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn sbb_ald8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetch(bus);
+        let dst = self.regs.byte(ByteReg::AL);
+        let cf = self.flags.cf_val();
+        let result = self.alu_sbb_byte(dst, src, cf);
+        self.regs.set_byte(ByteReg::AL, result);
+        self.clk(bus, 1);
+    }
+
+    fn sbb_axd16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetchword(bus);
+        let dst = self.regs.word(WordReg::AX);
+        let cf = self.flags.cf_val();
+        let result = self.alu_sbb_word(dst, src, cf);
+        self.regs.set_word(WordReg::AX, result);
+    }
+
+    fn and_br8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.byte(self.reg_byte(modrm));
+        let dst = self.get_rm_byte(modrm, bus);
+        let result = self.alu_and_byte(dst, src);
+        self.putback_rm_byte(modrm, result, bus);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn and_wr16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.word(self.reg_word(modrm));
+        let dst = self.get_rm_word(modrm, bus);
+        let result = self.alu_and_word(dst, src);
+        self.putback_rm_word(modrm, result, bus);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn and_r8b(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.byte(self.reg_byte(modrm));
+        let src = self.get_rm_byte(modrm, bus);
+        let result = self.alu_and_byte(dst, src);
+        let reg = self.reg_byte(modrm);
+        self.regs.set_byte(reg, result);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn and_r16w(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.word(self.reg_word(modrm));
+        let src = self.get_rm_word(modrm, bus);
+        let result = self.alu_and_word(dst, src);
+        let reg = self.reg_word(modrm);
+        self.regs.set_word(reg, result);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn and_ald8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetch(bus);
+        let dst = self.regs.byte(ByteReg::AL);
+        let result = self.alu_and_byte(dst, src);
+        self.regs.set_byte(ByteReg::AL, result);
+        self.clk(bus, 1);
+    }
+
+    fn and_axd16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetchword(bus);
+        let dst = self.regs.word(WordReg::AX);
+        let result = self.alu_and_word(dst, src);
+        self.regs.set_word(WordReg::AX, result);
+    }
+
+    fn sub_br8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.byte(self.reg_byte(modrm));
+        let dst = self.get_rm_byte(modrm, bus);
+        let result = self.alu_sub_byte(dst, src);
+        self.putback_rm_byte(modrm, result, bus);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn sub_wr16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.word(self.reg_word(modrm));
+        let dst = self.get_rm_word(modrm, bus);
+        let result = self.alu_sub_word(dst, src);
+        self.putback_rm_word(modrm, result, bus);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn sub_r8b(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.byte(self.reg_byte(modrm));
+        let src = self.get_rm_byte(modrm, bus);
+        let result = self.alu_sub_byte(dst, src);
+        let reg = self.reg_byte(modrm);
+        self.regs.set_byte(reg, result);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn sub_r16w(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.word(self.reg_word(modrm));
+        let src = self.get_rm_word(modrm, bus);
+        let result = self.alu_sub_word(dst, src);
+        let reg = self.reg_word(modrm);
+        self.regs.set_word(reg, result);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn sub_ald8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetch(bus);
+        let dst = self.regs.byte(ByteReg::AL);
+        let result = self.alu_sub_byte(dst, src);
+        self.regs.set_byte(ByteReg::AL, result);
+        self.clk(bus, 1);
+    }
+
+    fn sub_axd16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetchword(bus);
+        let dst = self.regs.word(WordReg::AX);
+        let result = self.alu_sub_word(dst, src);
+        self.regs.set_word(WordReg::AX, result);
+    }
+
+    fn xor_br8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.byte(self.reg_byte(modrm));
+        let dst = self.get_rm_byte(modrm, bus);
+        let result = self.alu_xor_byte(dst, src);
+        self.putback_rm_byte(modrm, result, bus);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn xor_wr16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.word(self.reg_word(modrm));
+        let dst = self.get_rm_word(modrm, bus);
+        let result = self.alu_xor_word(dst, src);
+        self.putback_rm_word(modrm, result, bus);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles + 2);
+    }
+
+    fn xor_r8b(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.byte(self.reg_byte(modrm));
+        let src = self.get_rm_byte(modrm, bus);
+        let result = self.alu_xor_byte(dst, src);
+        let reg = self.reg_byte(modrm);
+        self.regs.set_byte(reg, result);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn xor_r16w(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.word(self.reg_word(modrm));
+        let src = self.get_rm_word(modrm, bus);
+        let result = self.alu_xor_word(dst, src);
+        let reg = self.reg_word(modrm);
+        self.regs.set_word(reg, result);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn xor_ald8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetch(bus);
+        let dst = self.regs.byte(ByteReg::AL);
+        let result = self.alu_xor_byte(dst, src);
+        self.regs.set_byte(ByteReg::AL, result);
+        self.clk(bus, 1);
+    }
+
+    fn xor_axd16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetchword(bus);
+        let dst = self.regs.word(WordReg::AX);
+        let result = self.alu_xor_word(dst, src);
+        self.regs.set_word(WordReg::AX, result);
+    }
+
+    fn cmp_br8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.byte(self.reg_byte(modrm));
+        let dst = self.get_rm_byte(modrm, bus);
+        self.alu_sub_byte(dst, src);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn cmp_wr16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.word(self.reg_word(modrm));
+        let dst = self.get_rm_word(modrm, bus);
+        self.alu_sub_word(dst, src);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn cmp_r8b(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.byte(self.reg_byte(modrm));
+        let src = self.get_rm_byte(modrm, bus);
+        self.alu_sub_byte(dst, src);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn cmp_r16w(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.regs.word(self.reg_word(modrm));
+        let src = self.get_rm_word(modrm, bus);
+        self.alu_sub_word(dst, src);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn cmp_ald8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetch(bus);
+        let dst = self.regs.byte(ByteReg::AL);
+        self.alu_sub_byte(dst, src);
+        self.clk(bus, 1);
+    }
+
+    fn cmp_axd16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetchword(bus);
+        let dst = self.regs.word(WordReg::AX);
+        self.alu_sub_word(dst, src);
+    }
+
+    fn inc_word_reg(&mut self, bus: &mut impl common::Bus, reg: WordReg) {
+        let val = self.regs.word(reg);
+        let result = self.alu_inc_word(val);
+        self.regs.set_word(reg, result);
+        self.clk(bus, self.queue_resident_eu_cycles(2, 0));
+    }
+
+    fn dec_word_reg(&mut self, bus: &mut impl common::Bus, reg: WordReg) {
+        let val = self.regs.word(reg);
+        let result = self.alu_dec_word(val);
+        self.regs.set_word(reg, result);
+        self.clk(bus, self.queue_resident_eu_cycles(2, 0));
+    }
+
+    fn push_word_reg(&mut self, reg: WordReg, bus: &mut impl common::Bus) {
+        let val = self.regs.word(reg);
+        self.push(bus, val);
+        self.clk(bus, 3 + self.odd_queue_start_penalty());
+    }
+
+    pub(super) fn push_sp(&mut self, bus: &mut impl common::Bus) {
+        let sp = self.regs.word(WordReg::SP).wrapping_sub(2);
+        self.regs.set_word(WordReg::SP, sp);
+        self.write_word_seg(bus, SegReg16::SS, sp, sp);
+        self.clk(bus, 3 + self.odd_queue_start_penalty());
+    }
+
+    fn pop_word_reg(&mut self, reg: WordReg, bus: &mut impl common::Bus) {
+        let val = self.pop(bus);
+        self.regs.set_word(reg, val);
+        self.clk(bus, 0);
+    }
+
+    fn push_seg(&mut self, seg: SegReg16, bus: &mut impl common::Bus) {
+        let val = self.sregs[seg as usize];
+        self.push(bus, val);
+        self.clk(bus, 3 + self.odd_queue_start_penalty());
+    }
+
+    fn pop_seg(&mut self, seg: SegReg16, bus: &mut impl common::Bus) {
+        let val = self.pop(bus);
+        self.sregs[seg as usize] = val;
+        self.clk(bus, 0);
+    }
+
+    fn pop_cs(&mut self, bus: &mut impl common::Bus) {
+        self.pop_seg(SegReg16::CS, bus);
+    }
+
+    fn jcc(&mut self, bus: &mut impl common::Bus, condition: bool) {
+        let disp = self.fetch(bus) as i8;
+        if condition {
+            self.set_ip_and_flush(bus, self.ip.wrapping_add(disp as u16));
+            let total_cycles = if self.opcode_started_at_odd_address() {
+                17
+            } else {
+                19
+            };
+            self.clk(bus, self.queue_resident_eu_cycles(total_cycles, 1));
+        } else {
+            self.clk(bus, self.queue_resident_eu_cycles(4, 1));
+        }
+    }
+
+    fn jcc_swapped(&mut self, bus: &mut impl common::Bus, condition: bool) {
+        let disp = self.fetch(bus) as i8;
+        if condition {
+            self.set_ip_and_flush(bus, self.ip.wrapping_add(disp as u16));
+            let total_cycles = if self.opcode_started_at_odd_address() {
+                17
+            } else {
+                19
+            };
+            self.clk(bus, self.queue_resident_eu_cycles(total_cycles, 1));
+        } else {
+            self.clk(bus, self.queue_resident_eu_cycles(4, 1));
+        }
+    }
+
+    fn test_br8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.byte(self.reg_byte(modrm));
+        let dst = self.get_rm_byte(modrm, bus);
+        self.alu_and_byte(dst, src);
+        self.clk_modrm(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn test_wr16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let prefix_cycles = 0;
+        let modrm = self.fetch_modrm(bus);
+        let src = self.regs.word(self.reg_word(modrm));
+        let dst = self.get_rm_word(modrm, bus);
+        self.alu_and_word(dst, src);
+        self.clk_modrm_word(bus, modrm, prefix_cycles, prefix_cycles);
+    }
+
+    fn test_al_imm8(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetch(bus);
+        let dst = self.regs.byte(ByteReg::AL);
+        self.alu_and_byte(dst, src);
+        self.clk(bus, 1);
+    }
+
+    fn test_aw_imm16(&mut self, bus: &mut impl common::Bus) {
+        self.charge_seg_prefix_cycle(bus);
+        let src = self.fetchword(bus);
+        let dst = self.regs.word(WordReg::AX);
+        self.alu_and_word(dst, src);
+    }
+
+    fn xchg_br8(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let reg = self.reg_byte(modrm);
+        let reg_val = self.regs.byte(reg);
+        let rm_val = self.get_rm_byte(modrm, bus);
+        self.regs.set_byte(reg, rm_val);
+        self.putback_rm_byte(modrm, reg_val, bus);
+        self.clk_modrm(bus, modrm, 1, 3);
+    }
+
+    fn xchg_wr16(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let reg = self.reg_word(modrm);
+        let reg_val = self.regs.word(reg);
+        let rm_val = self.get_rm_word(modrm, bus);
+        self.regs.set_word(reg, rm_val);
+        self.putback_rm_word(modrm, reg_val, bus);
+        self.clk_modrm_word(bus, modrm, 1, 3);
+    }
+
+    fn xchg_aw(&mut self, bus: &mut impl common::Bus, reg: WordReg) {
+        let aw = self.regs.word(WordReg::AX);
+        let val = self.regs.word(reg);
+        self.regs.set_word(WordReg::AX, val);
+        self.regs.set_word(reg, aw);
+        self.clk(bus, self.queue_resident_eu_cycles(3, 0));
+    }
+
+    fn mov_br8(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let val = self.regs.byte(self.reg_byte(modrm));
+        if modrm >= 0xC0 {
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+            self.putback_rm_byte(modrm, val, bus);
+        } else {
+            self.resolve_rm_address(modrm);
+            self.charge_rm_eadone(modrm, bus);
+            self.putback_rm_byte(modrm, val, bus);
+            if self.mov_rm_reg_store_uses_terminal_writeback_rni(modrm) {
+                self.finish_on_terminal_writeback(modrm);
+            } else {
+                self.finish_on_terminal_writeback_with_fetch(modrm);
+            }
+        }
+        self.clk_modrm(bus, modrm, 0, 1);
+    }
+
+    fn mov_wr16(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let val = self.regs.word(self.reg_word(modrm));
+        if modrm >= 0xC0 {
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+            self.putback_rm_word(modrm, val, bus);
+        } else {
+            self.resolve_rm_address(modrm);
+            self.charge_rm_eadone(modrm, bus);
+            self.putback_rm_word(modrm, val, bus);
+            if self.mov_rm_reg_store_uses_terminal_writeback_rni(modrm) {
+                self.finish_on_terminal_writeback(modrm);
+            } else {
+                self.finish_on_terminal_writeback_with_fetch(modrm);
+            }
+        }
+        self.clk_modrm_word(bus, modrm, 0, 0);
+    }
+
+    fn mov_r8b(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let val = self.get_rm_byte(modrm, bus);
+        let reg = self.reg_byte(modrm);
+        self.regs.set_byte(reg, val);
+        self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        self.clk_modrm(bus, modrm, 0, 0);
+    }
+
+    fn mov_r16w(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let val = self.get_rm_word(modrm, bus);
+        let reg = self.reg_word(modrm);
+        self.regs.set_word(reg, val);
+        self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        self.clk_modrm_word(bus, modrm, 0, 0);
+    }
+
+    fn mov_rm_sreg(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let seg = SegReg16::from_index((modrm >> 3) & 3);
+        let val = self.sregs[seg as usize];
+        if modrm >= 0xC0 {
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+            self.putback_rm_word(modrm, val, bus);
+        } else {
+            self.resolve_rm_address(modrm);
+            self.charge_rm_eadone(modrm, bus);
+            self.putback_rm_word(modrm, val, bus);
+            if self.mov_rm_sreg_uses_inline_commit(modrm) {
+                self.finish_on_terminal_writeback_inline_commit(modrm);
+            } else if self.mov_rm_sreg_uses_terminal_writeback_with_fetch(modrm) {
+                self.finish_on_terminal_writeback_with_fetch(modrm);
+            }
+        }
+        self.clk_modrm_word(bus, modrm, 0, 0);
+    }
+
+    fn mov_sreg_rm(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let val = self.get_rm_word(modrm, bus);
+        let seg = SegReg16::from_index((modrm >> 3) & 3);
+        self.sregs[seg as usize] = val;
+        self.inhibit_all = 1;
+        self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        self.clk_modrm_word(bus, modrm, 0, 0);
+    }
+
+    fn lea(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        self.calc_ea(modrm);
+        self.charge_rm_eadone(modrm, bus);
+        let reg = self.reg_word(modrm);
+        let val = self.eo;
+        self.regs.set_word(reg, val);
+        self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+    }
+
+    fn pop_rm(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        if modrm < 0xC0 {
+            self.resolve_rm_address(modrm);
+            self.charge_rm_eadone(modrm, bus);
+        }
+        self.clk(bus, 1);
+        let val = self.pop(bus);
+        self.clk(bus, 1);
+        if modrm >= 0xC0 {
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        } else {
+            self.clk(bus, 1);
+        }
+        self.putback_rm_word(modrm, val, bus);
+        self.finish_on_terminal_writeback(modrm);
+    }
+
+    fn cbw(&mut self, bus: &mut impl common::Bus) {
+        let al = self.regs.byte(ByteReg::AL) as i8 as i16 as u16;
+        self.regs.set_word(WordReg::AX, al);
+        self.clk(bus, self.queue_resident_eu_cycles(2, 0));
+    }
+
+    fn cwd(&mut self, bus: &mut impl common::Bus) {
+        let aw = self.regs.word(WordReg::AX) as i16;
+        self.regs
+            .set_word(WordReg::DX, if aw < 0 { 0xFFFF } else { 0 });
+        self.clk(
+            bus,
+            self.queue_resident_eu_cycles(if aw < 0 { 6 } else { 5 }, 0),
+        );
+    }
+
+    fn call_far(&mut self, bus: &mut impl common::Bus) {
+        let offset = self.fetchword(bus);
+        let segment = self.fetchword(bus);
+        if self.far_immediate_call_uses_drained_queue_handoff() {
+            self.clk(bus, 1);
+            self.farcall_routine(bus, segment, offset, true, true);
+        } else if self.far_immediate_jump_uses_preloaded_finish() {
+            self.farcall_routine(bus, segment, offset, true, true);
+        } else {
+            self.farcall_routine(bus, segment, offset, true, false);
+        }
+    }
+
+    fn call_near(&mut self, bus: &mut impl common::Bus) {
+        let disp = self.fetchword(bus);
+        let new_ip = self.ip.wrapping_add(disp);
+
+        self.biu_fetch_suspend(bus);
+        self.clk(bus, 2);
+        self.corr(bus);
+        if !self.seg_prefix && self.instruction_entry_queue_full() {
+            self.nearcall_routine(bus, new_ip, false);
+        } else {
+            self.nearcall_routine(bus, new_ip, true);
+        }
+    }
+
+    fn jmp_near(&mut self, bus: &mut impl common::Bus) {
+        let disp = self.fetchword(bus);
+        self.set_ip_and_flush(bus, self.ip.wrapping_add(disp));
+        let total_cycles = 15 + self.opcode_start_penalty_2();
+        self.clk(bus, self.queue_resident_eu_cycles(total_cycles, 2));
+    }
+
+    fn jmp_far(&mut self, bus: &mut impl common::Bus) {
+        let offset = self.fetchword(bus);
+        let segment = self.fetchword(bus);
+        if self.far_immediate_jump_uses_preloaded_finish() {
+            self.sregs[SegReg16::CS as usize] = segment;
+            self.ip = offset;
+            self.flush_and_fetch(bus);
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        } else {
+            self.set_cs_ip_and_flush(bus, segment, offset);
+        }
+        let total_cycles = 15 + self.opcode_even_penalty_2();
+        self.clk(bus, self.queue_resident_eu_cycles(total_cycles, 4));
+    }
+
+    fn jmp_short(&mut self, bus: &mut impl common::Bus) {
+        let disp = self.fetch(bus) as i8 as u16;
+        self.set_ip_and_flush(bus, self.ip.wrapping_add(disp));
+        let total_cycles = 15 + self.opcode_start_penalty_2();
+        self.clk(bus, self.queue_resident_eu_cycles(total_cycles, 1));
+    }
+
+    fn ret_near(&mut self, bus: &mut impl common::Bus) {
+        let ip = self.pop(bus);
+        self.biu_fetch_suspend(bus);
+        self.clk(bus, 1);
+        self.ip = ip;
+        self.flush_and_fetch(bus);
+        self.clk(bus, 2);
+    }
+
+    fn ret_near_imm(&mut self, bus: &mut impl common::Bus) {
+        let imm = self.fetchword(bus);
+        self.farret_routine(bus, false);
+        self.clk(bus, 1);
+        let sp = self.regs.word(WordReg::SP).wrapping_add(imm);
+        self.regs.set_word(WordReg::SP, sp);
+        if self.instruction_entry_queue_full() {
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        }
+    }
+
+    fn ret_far(&mut self, bus: &mut impl common::Bus) {
+        self.farret_routine(bus, true);
+    }
+
+    fn ret_far_imm(&mut self, bus: &mut impl common::Bus) {
+        let imm = self.fetchword(bus);
+        self.farret_routine(bus, true);
+        self.clk(bus, 1);
+        let sp = self.regs.word(WordReg::SP).wrapping_add(imm);
+        self.regs.set_word(WordReg::SP, sp);
+        if self.instruction_entry_queue_full() {
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        }
+    }
+
+    fn pushf(&mut self, bus: &mut impl common::Bus) {
+        let flags_val = self.flags.compress();
+        self.push(bus, flags_val);
+        self.clk(bus, 3 + self.odd_queue_start_penalty());
+    }
+
+    fn popf(&mut self, bus: &mut impl common::Bus) {
+        let val = self.pop(bus);
+        self.flags.expand(val);
+    }
+
+    fn sahf(&mut self, bus: &mut impl common::Bus) {
+        let ah = self.regs.byte(ByteReg::AH);
+        self.flags.carry_val = (ah & 0x01) as u32;
+        self.flags.parity_val = if ah & 0x04 != 0 { 0 } else { 1 };
+        self.flags.aux_val = (ah & 0x10) as u32;
+        self.flags.zero_val = if ah & 0x40 != 0 { 0 } else { 1 };
+        self.flags.sign_val = if ah & 0x80 != 0 { -1 } else { 0 };
+        self.clk(bus, self.queue_resident_eu_cycles(4, 0));
+    }
+
+    fn lahf(&mut self, bus: &mut impl common::Bus) {
+        let flags_val = self.flags.compress() as u8;
+        self.regs.set_byte(ByteReg::AH, flags_val);
+        self.clk(bus, self.queue_resident_eu_cycles(2, 0));
+    }
+
+    fn mov_al_moffs(&mut self, bus: &mut impl common::Bus) {
+        let offset = self.fetchword(bus);
+        self.set_effective_address(SegReg16::DS, offset);
+        let val = self.read_memory_byte(bus, self.ea);
+        self.regs.set_byte(ByteReg::AL, val);
+        if !self.seg_prefix && self.instruction_entry_queue_full() {
+            self.clk(bus, 1);
+        }
+        self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+    }
+
+    fn mov_aw_moffs(&mut self, bus: &mut impl common::Bus) {
+        let offset = self.fetchword(bus);
+        self.set_effective_address(SegReg16::DS, offset);
+        let val = self.seg_read_word(bus);
+        self.regs.set_word(WordReg::AX, val);
+        if !self.seg_prefix && self.instruction_entry_queue_full() {
+            self.clk(bus, 1);
+        }
+        self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+    }
+
+    fn mov_moffs_al(&mut self, bus: &mut impl common::Bus) {
+        let offset = self.fetchword(bus);
+        self.set_effective_address(SegReg16::DS, offset);
+        self.clk(bus, 1);
+        self.write_memory_byte(bus, self.ea, self.regs.byte(ByteReg::AL));
+        if self.instruction_entry_queue_bytes >= 5 {
+            self.clk(bus, 1);
+            if !self.seg_prefix && self.instruction_entry_queue_full() {
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+            }
+        }
+    }
+
+    fn mov_moffs_aw(&mut self, bus: &mut impl common::Bus) {
+        let offset = self.fetchword(bus);
+        self.set_effective_address(SegReg16::DS, offset);
+        self.clk(bus, 1);
+        self.seg_write_word(bus, self.regs.word(WordReg::AX));
+        if self.instruction_entry_queue_bytes >= 5 {
+            self.clk(bus, 1);
+            if !self.seg_prefix && self.instruction_entry_queue_full() {
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+            }
+        }
+    }
+
+    fn mov_byte_reg_imm(&mut self, reg: ByteReg, bus: &mut impl common::Bus) {
+        let val = self.fetch(bus);
+        self.regs.set_byte(reg, val);
+        self.clk(bus, self.queue_resident_eu_cycles(4, 1));
+    }
+
+    fn mov_word_reg_imm(&mut self, reg: WordReg, bus: &mut impl common::Bus) {
+        let val = self.fetchword(bus);
+        self.regs.set_word(reg, val);
+        self.clk(bus, self.queue_resident_eu_cycles(4, 2));
+    }
+
+    fn mov_rm_imm8(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        if modrm >= 0xC0 {
+            let val = self.fetch(bus);
+            let reg = self.rm_byte(modrm);
+            self.regs.set_byte(reg, val);
+        } else {
+            self.resolve_rm_address(modrm);
+            self.charge_rm_eadone(modrm, bus);
+            let val = self.fetch(bus);
+            self.clk(bus, 1);
+            self.putback_rm_byte(modrm, val, bus);
+            if !self.seg_prefix
+                && self.instruction_entry_queue_full()
+                && !self.opcode_started_at_odd_address()
+                && self.has_simple_disp16_base(modrm)
+            {
+                self.finish_on_terminal_writeback_inline_commit(modrm);
+            } else if (self.fetch_state == FetchState::Normal
+                && !self.has_disp16_double_register_base(modrm))
+                || (self.fetch_state == FetchState::PausedFull
+                    && self.seg_prefix
+                    && modrm & 0xC7 == 0x06)
+            {
+                self.finish_on_terminal_writeback_with_fetch(modrm);
+            }
+        }
+    }
+
+    fn mov_rm_imm16(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        if modrm >= 0xC0 {
+            let val = self.fetchword(bus);
+            let reg = self.rm_word(modrm);
+            self.regs.set_word(reg, val);
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        } else {
+            self.resolve_rm_address(modrm);
+            self.charge_rm_eadone(modrm, bus);
+            let val = self.fetchword(bus);
+            self.putback_rm_word(modrm, val, bus);
+            if !self.seg_prefix
+                && self.instruction_entry_queue_full()
+                && !self.opcode_started_at_odd_address()
+                && self.has_simple_disp16_base(modrm)
+            {
+                self.finish_on_terminal_writeback_inline_commit(modrm);
+            } else if self.has_disp16_double_register_base(modrm) {
+                if self.ip & 1 == 1
+                    || (self.seg_prefix && self.has_disp16_cycle4_double_register_base(modrm))
+                {
+                    self.finish_on_terminal_writeback(modrm);
+                } else {
+                    self.finish_on_terminal_writeback_with_fetch(modrm);
+                }
+            } else if self.has_single_or_direct_base(modrm) {
+                if !(self.seg_prefix && self.ip & 1 == 0) && self.queue_len() >= 4 {
+                    self.finish_on_terminal_writeback(modrm);
+                } else {
+                    self.finish_on_terminal_writeback_with_fetch(modrm);
+                }
+            } else if self.queue_len() >= 4 {
+                self.finish_on_terminal_writeback(modrm);
+            } else {
+                self.finish_on_terminal_writeback_with_fetch(modrm);
+            }
+        }
+    }
+
+    fn les(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        self.calc_ea(modrm);
+        let offset = self.seg_read_word(bus);
+        self.clk_eaload(bus);
+        let segment = self.seg_read_word_at(bus, 2);
+        self.clk(bus, 1);
+        let reg = self.reg_word(modrm);
+        self.regs.set_word(reg, offset);
+        self.sregs[SegReg16::ES as usize] = segment;
+    }
+
+    fn lds(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        self.calc_ea(modrm);
+        let offset = self.seg_read_word(bus);
+        self.clk_eaload(bus);
+        let segment = self.seg_read_word_at(bus, 2);
+        self.clk(bus, 1);
+        let reg = self.reg_word(modrm);
+        self.regs.set_word(reg, offset);
+        self.sregs[SegReg16::DS as usize] = segment;
+    }
+
+    fn int3(&mut self, bus: &mut impl common::Bus) {
+        self.raise_software_interrupt(3, bus);
+    }
+
+    fn int_imm(&mut self, bus: &mut impl common::Bus) {
+        let vector = self.fetch_interrupt_vector(bus);
+        self.raise_software_interrupt_with_entry_cycles(vector, bus, 2);
+    }
+
+    fn into(&mut self, bus: &mut impl common::Bus) {
+        if self.flags.of() {
+            let preloaded_finish = !self.instruction_entry_queue_full();
+            self.clk(bus, 1);
+            self.raise_software_interrupt(4, bus);
+            if preloaded_finish {
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+            }
+        } else {
+            self.clk(bus, 2);
+        }
+    }
+
+    fn iret(&mut self, bus: &mut impl common::Bus) {
+        self.farret_routine(bus, true);
+        let flags_val = self.pop(bus);
+        self.flags.expand(flags_val);
+        self.clk(bus, 1);
+    }
+
+    fn loopne(&mut self, bus: &mut impl common::Bus) {
+        let disp = self.fetch(bus) as i8 as u16;
+        let cw = self.regs.word(WordReg::CX).wrapping_sub(1);
+        self.regs.set_word(WordReg::CX, cw);
+        if cw != 0 && !self.flags.zf() {
+            self.set_ip_and_flush(bus, self.ip.wrapping_add(disp));
+            let total_cycles = if self.seg_prefix || self.opcode_started_at_odd_address() {
+                18
+            } else {
+                21
+            };
+            self.clk(bus, self.queue_resident_eu_cycles(total_cycles, 1));
+        } else {
+            self.clk(bus, self.queue_resident_eu_cycles(6, 1));
+        }
+    }
+
+    fn loope(&mut self, bus: &mut impl common::Bus) {
+        let disp = self.fetch(bus) as i8 as u16;
+        let cw = self.regs.word(WordReg::CX).wrapping_sub(1);
+        self.regs.set_word(WordReg::CX, cw);
+        if cw != 0 && self.flags.zf() {
+            self.set_ip_and_flush(bus, self.ip.wrapping_add(disp));
+            let total_cycles = if self.seg_prefix || self.opcode_started_at_odd_address() {
+                18
+            } else {
+                21
+            };
+            self.clk(bus, self.queue_resident_eu_cycles(total_cycles, 1));
+        } else {
+            self.clk(bus, self.queue_resident_eu_cycles(6, 1));
+        }
+    }
+
+    fn loop_(&mut self, bus: &mut impl common::Bus) {
+        let disp = self.fetch(bus) as i8 as u16;
+        let cw = self.regs.word(WordReg::CX).wrapping_sub(1);
+        self.regs.set_word(WordReg::CX, cw);
+        if cw != 0 {
+            self.set_ip_and_flush(bus, self.ip.wrapping_add(disp));
+            self.clk(bus, self.queue_resident_eu_cycles(17, 1));
+        } else {
+            self.clk(bus, self.queue_resident_eu_cycles(5, 1));
+        }
+    }
+
+    fn jcxz(&mut self, bus: &mut impl common::Bus) {
+        let disp = self.fetch(bus) as i8 as u16;
+        if self.regs.word(WordReg::CX) == 0 {
+            self.set_ip_and_flush(bus, self.ip.wrapping_add(disp));
+            let total_cycles = if self.seg_prefix || self.opcode_started_at_odd_address() {
+                18
+            } else {
+                21
+            };
+            self.clk(bus, self.queue_resident_eu_cycles(total_cycles, 1));
+        } else {
+            self.clk(bus, self.queue_resident_eu_cycles(6, 1));
+        }
+    }
+
+    fn in_al_imm(&mut self, bus: &mut impl common::Bus) {
+        let port = self.fetch(bus) as u16;
+        let val = self.read_io_byte(bus, port);
+        self.clk(bus, 1);
+        self.regs.set_byte(ByteReg::AL, val);
+    }
+
+    fn in_aw_imm(&mut self, bus: &mut impl common::Bus) {
+        let port = self.fetch(bus) as u16;
+        let val = self.read_io_word(bus, port);
+        self.clk(bus, 1);
+        self.regs.set_word(WordReg::AX, val);
+    }
+
+    fn out_imm_al(&mut self, bus: &mut impl common::Bus) {
+        let port = self.fetch(bus) as u16;
+        let val = self.regs.byte(ByteReg::AL);
+        self.clk(bus, 2);
+        self.write_io_byte(bus, port, val);
+        self.clk(bus, self.odd_opcode_start_penalty());
+    }
+
+    fn out_imm_aw(&mut self, bus: &mut impl common::Bus) {
+        let port = self.fetch(bus) as u16;
+        let val = self.regs.word(WordReg::AX);
+        self.clk(bus, 2);
+        self.write_io_word(bus, port, val);
+        self.clk(bus, self.odd_opcode_start_penalty());
+    }
+
+    fn in_al_dw(&mut self, bus: &mut impl common::Bus) {
+        let port = self.regs.word(WordReg::DX);
+        let val = self.read_io_byte(bus, port);
+        self.regs.set_byte(ByteReg::AL, val);
+    }
+
+    fn in_aw_dw(&mut self, bus: &mut impl common::Bus) {
+        let port = self.regs.word(WordReg::DX);
+        let val = self.read_io_word(bus, port);
+        self.regs.set_word(WordReg::AX, val);
+    }
+
+    fn out_dw_al(&mut self, bus: &mut impl common::Bus) {
+        let port = self.regs.word(WordReg::DX);
+        let val = self.regs.byte(ByteReg::AL);
+        self.clk(bus, 1);
+        self.write_io_byte(bus, port, val);
+        self.clk(bus, self.odd_opcode_start_penalty());
+    }
+
+    fn out_dw_aw(&mut self, bus: &mut impl common::Bus) {
+        let port = self.regs.word(WordReg::DX);
+        let val = self.regs.word(WordReg::AX);
+        self.clk(bus, 1);
+        self.write_io_word(bus, port, val);
+        self.clk(bus, self.odd_opcode_start_penalty());
+    }
+
+    fn xlat(&mut self, bus: &mut impl common::Bus) {
+        let al = self.regs.byte(ByteReg::AL) as u16;
+        let bw = self.regs.word(WordReg::BX);
+        let addr = self
+            .default_base(SegReg16::DS)
+            .wrapping_add(bw.wrapping_add(al) as u32)
+            & ADDRESS_MASK;
+        self.clk(bus, 3);
+        let val = self.read_memory_byte(bus, addr);
+        self.regs.set_byte(ByteReg::AL, val);
+        self.clk(bus, self.odd_opcode_start_penalty());
+    }
+
+    fn salc(&mut self, bus: &mut impl common::Bus) {
+        let carry = self.flags.cf();
+        let value = if carry { 0xFF } else { 0x00 };
+        self.regs.set_byte(ByteReg::AL, value);
+        let total_cycles = if carry { 4 } else { 3 };
+        self.clk(bus, self.queue_resident_eu_cycles(total_cycles, 0));
+    }
+
+    fn daa(&mut self, bus: &mut impl common::Bus) {
+        let old_al = self.regs.byte(ByteReg::AL);
+        let old_cf = self.flags.cf();
+        let old_af = self.flags.af();
+        let mut al = old_al;
+        if (old_al & 0x0F) > 9 || old_af {
+            al = al.wrapping_add(6);
+            self.flags.aux_val = 1;
+        } else {
+            self.flags.aux_val = 0;
+        }
+        let threshold = if old_af { 0x9F } else { 0x99 };
+        if old_al > threshold || old_cf {
+            al = al.wrapping_add(0x60);
+            self.flags.carry_val = 1;
+        }
+        self.regs.set_byte(ByteReg::AL, al);
+        self.flags.set_szpf_byte(al as u32);
+        self.clk(bus, 2);
+    }
+
+    fn das(&mut self, bus: &mut impl common::Bus) {
+        let old_al = self.regs.byte(ByteReg::AL);
+        let old_cf = self.flags.cf();
+        let old_af = self.flags.af();
+        let mut al = old_al;
+        if (old_al & 0x0F) > 9 || old_af {
+            al = al.wrapping_sub(6);
+            self.flags.aux_val = 1;
+        } else {
+            self.flags.aux_val = 0;
+        }
+        let threshold = if old_af { 0x9F } else { 0x99 };
+        if old_al > threshold || old_cf {
+            al = al.wrapping_sub(0x60);
+            self.flags.carry_val = 1;
+        }
+        self.regs.set_byte(ByteReg::AL, al);
+        self.flags.set_szpf_byte(al as u32);
+        self.clk(bus, 2);
+    }
+
+    fn aaa(&mut self, bus: &mut impl common::Bus) {
+        let adjust = (self.regs.byte(ByteReg::AL) & 0x0F) > 9 || self.flags.af();
+        if adjust {
+            let al = self.regs.byte(ByteReg::AL).wrapping_add(6);
+            self.regs.set_byte(ByteReg::AL, al & 0x0F);
+            let ah = self.regs.byte(ByteReg::AH).wrapping_add(1);
+            self.regs.set_byte(ByteReg::AH, ah);
+            self.flags.aux_val = 1;
+            self.flags.carry_val = 1;
+        } else {
+            let al = self.regs.byte(ByteReg::AL) & 0x0F;
+            self.regs.set_byte(ByteReg::AL, al);
+            self.flags.aux_val = 0;
+            self.flags.carry_val = 0;
+        }
+        self.clk(bus, if adjust { 6 } else { 7 });
+    }
+
+    fn aas(&mut self, bus: &mut impl common::Bus) {
+        let adjust = (self.regs.byte(ByteReg::AL) & 0x0F) > 9 || self.flags.af();
+        if adjust {
+            let al = self.regs.byte(ByteReg::AL).wrapping_sub(6);
+            self.regs.set_byte(ByteReg::AL, al & 0x0F);
+            let ah = self.regs.byte(ByteReg::AH).wrapping_sub(1);
+            self.regs.set_byte(ByteReg::AH, ah);
+            self.flags.aux_val = 1;
+            self.flags.carry_val = 1;
+        } else {
+            let al = self.regs.byte(ByteReg::AL) & 0x0F;
+            self.regs.set_byte(ByteReg::AL, al);
+            self.flags.aux_val = 0;
+            self.flags.carry_val = 0;
+        }
+        self.clk(bus, if adjust { 6 } else { 7 });
+    }
+
+    fn aam(&mut self, bus: &mut impl common::Bus) {
+        let base = self.fetch(bus);
+        if base == 0 {
+            self.flags.set_szpf_byte(0);
+            self.clk(bus, 8);
+            self.raise_divide_error(bus);
+            return;
+        }
+        let al = self.regs.byte(ByteReg::AL);
+        let quotient = al / base;
+        let remainder = al % base;
+        self.regs.set_byte(ByteReg::AH, quotient);
+        self.regs.set_byte(ByteReg::AL, remainder);
+        let val = self.regs.byte(ByteReg::AL) as u32;
+        self.flags.set_szpf_byte(val);
+        let cycles = 77 + quotient.count_ones() as i32 + 2 * (quotient & 1) as i32;
+        self.clk(bus, self.queue_resident_eu_cycles(cycles, 1));
+    }
+
+    fn aad(&mut self, bus: &mut impl common::Bus) {
+        let base = self.fetch(bus);
+        let al = self.regs.byte(ByteReg::AL);
+        let ah = self.regs.byte(ByteReg::AH);
+        let result = al.wrapping_add(ah.wrapping_mul(base));
+        self.regs.set_byte(ByteReg::AL, result);
+        self.regs.set_byte(ByteReg::AH, 0);
+        self.flags.set_szpf_byte(result as u32);
+        let cycles = 59 + base.count_ones() as i32;
+        self.clk(bus, self.queue_resident_eu_cycles(cycles, 1));
+    }
+
+    fn fpu_escape(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        if modrm < 0xC0 {
+            self.calc_ea(modrm);
+            let _ = self.seg_read_word(bus);
+            self.clk_eaload(bus);
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        } else {
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        }
+    }
+
+    fn clc(&mut self, bus: &mut impl common::Bus) {
+        self.flags.carry_val = 0;
+        self.clk(bus, self.queue_resident_eu_cycles(2, 0));
+    }
+
+    fn stc(&mut self, bus: &mut impl common::Bus) {
+        self.flags.carry_val = 1;
+        self.clk(bus, self.queue_resident_eu_cycles(2, 0));
+    }
+
+    fn cli(&mut self, bus: &mut impl common::Bus) {
+        self.flags.if_flag = false;
+        self.clk(bus, self.queue_resident_eu_cycles(2, 0));
+    }
+
+    fn sti(&mut self, bus: &mut impl common::Bus) {
+        self.flags.if_flag = true;
+        self.no_interrupt = 1;
+        self.clk(bus, self.queue_resident_eu_cycles(2, 0));
+    }
+
+    fn cld(&mut self, bus: &mut impl common::Bus) {
+        self.flags.df = false;
+        self.clk(bus, self.queue_resident_eu_cycles(2, 0));
+    }
+
+    fn std(&mut self, bus: &mut impl common::Bus) {
+        self.flags.df = true;
+        self.clk(bus, self.queue_resident_eu_cycles(2, 0));
+    }
+
+    fn cmc(&mut self, bus: &mut impl common::Bus) {
+        self.flags.carry_val = if self.flags.cf() { 0 } else { 1 };
+        self.clk(bus, self.queue_resident_eu_cycles(2, 0));
+    }
+
+    fn hlt(&mut self, bus: &mut impl common::Bus) {
+        self.halted = true;
+        self.clk(bus, 2);
+    }
+
+    fn segment_prefix(&mut self, bus: &mut impl common::Bus, segment: SegReg16) {
+        self.seg_prefix = true;
+        self.prefix_seg = segment;
+        self.clk(bus, 1);
+        let opcode = self.fetch(bus);
+        self.dispatch(opcode, bus);
+    }
+
+    fn lock_prefix(&mut self, bus: &mut impl common::Bus) {
+        self.inhibit_all = 1;
+        self.clk(bus, 1);
+        let opcode = self.fetch(bus);
+        self.dispatch(opcode, bus);
+    }
+}

--- a/crates/cpu/src/i8086/execute_group.rs
+++ b/crates/cpu/src/i8086/execute_group.rs
@@ -1,0 +1,780 @@
+use super::{I8086, StepFinishCycle};
+use crate::{ByteReg, SegReg16, WordReg};
+
+impl I8086 {
+    fn rm_default_segment(&self, modrm: u8) -> SegReg16 {
+        let mode = modrm >> 6;
+        let rm = modrm & 7;
+        if mode == 0 && rm == 6 {
+            SegReg16::DS
+        } else if rm == 2 || rm == 3 || (rm == 6 && mode != 0) {
+            SegReg16::SS
+        } else {
+            SegReg16::DS
+        }
+    }
+
+    fn get_rm_widened_from_byte(&mut self, modrm: u8, bus: &mut impl common::Bus) -> u16 {
+        if modrm >= 0xC0 {
+            match self.rm_byte(modrm) {
+                ByteReg::AL => self.regs.word(WordReg::AX),
+                ByteReg::CL => self.regs.word(WordReg::CX),
+                ByteReg::DL => self.regs.word(WordReg::DX),
+                ByteReg::BL => self.regs.word(WordReg::BX),
+                ByteReg::AH => self.regs.word(WordReg::AX).swap_bytes(),
+                ByteReg::CH => self.regs.word(WordReg::CX).swap_bytes(),
+                ByteReg::DH => self.regs.word(WordReg::DX).swap_bytes(),
+                ByteReg::BH => self.regs.word(WordReg::BX).swap_bytes(),
+            }
+        } else {
+            self.calc_ea(modrm);
+            let value = self.read_memory_byte(bus, self.ea);
+            self.clk_eaload(bus);
+            u16::from(value) | 0xFF00
+        }
+    }
+
+    fn invalid_far_register_segment(&mut self, bus: &mut impl common::Bus) -> u16 {
+        self.read_word_seg(bus, self.default_segment(SegReg16::DS), 0x0004)
+    }
+
+    fn invalid_far_register_segment_from_byte(&mut self, bus: &mut impl common::Bus) -> u16 {
+        let address = self.seg_base(SegReg16::DS).wrapping_add(0x0004);
+        u16::from(self.read_memory_byte(bus, address)) | 0xFF00
+    }
+
+    fn get_rm_far_ptr_from_byte_pair(
+        &mut self,
+        modrm: u8,
+        bus: &mut impl common::Bus,
+    ) -> (u16, u16) {
+        debug_assert!(modrm < 0xC0);
+        self.calc_ea(modrm);
+        let offset = u16::from(self.read_memory_byte(bus, self.ea)) | 0xFF00;
+        self.clk_eaload(bus);
+        let segment_address = self
+            .seg_base(self.rm_default_segment(modrm))
+            .wrapping_add(self.eo as u32);
+        let segment = u16::from(self.read_memory_byte(bus, segment_address)) | 0xFF00;
+        (offset, segment)
+    }
+
+    fn invalid_far_register_ip_handoff(&self) -> u16 {
+        if self.instruction_entry_queue_bytes == 0 {
+            self.prev_ip
+        } else {
+            self.prev_ip.wrapping_sub(4)
+        }
+    }
+
+    fn push_byte_value(&mut self, bus: &mut impl common::Bus, value: u8) {
+        let sp = self.regs.word(WordReg::SP).wrapping_sub(2);
+        self.regs.set_word(WordReg::SP, sp);
+        let address = self.seg_base(SegReg16::SS).wrapping_add(sp as u32);
+        self.write_memory_byte(bus, address, value);
+    }
+
+    fn nearcall_byte_routine(
+        &mut self,
+        bus: &mut impl common::Bus,
+        new_ip: u16,
+        early_fetch: bool,
+    ) {
+        let return_ip = self.ip;
+        self.clk(bus, 1);
+        self.ip = new_ip;
+        if early_fetch {
+            self.flush_and_fetch_early(bus);
+        } else {
+            self.flush_and_fetch(bus);
+        }
+        self.clk(bus, 3);
+        self.push_byte_value(bus, return_ip as u8);
+    }
+
+    fn farcall_byte_routine(
+        &mut self,
+        bus: &mut impl common::Bus,
+        new_cs: u16,
+        new_ip: u16,
+        jump: bool,
+        early_fetch: bool,
+    ) {
+        if jump {
+            self.clk(bus, 1);
+        }
+        self.biu_fetch_suspend(bus);
+        self.clk(bus, 2);
+        self.corr(bus);
+        self.clk(bus, 1);
+        let return_cs = self.sregs[SegReg16::CS as usize];
+        self.push_byte_value(bus, return_cs as u8);
+        self.sregs[SegReg16::CS as usize] = new_cs;
+        self.clk(bus, 2);
+        self.nearcall_byte_routine(bus, new_ip, early_fetch);
+    }
+
+    /// Group 0x80: ALU r/m8, imm8
+    pub(super) fn group_80(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.get_rm_byte(modrm, bus);
+        let src = self.fetch(bus);
+        let op = (modrm >> 3) & 7;
+        let result = match op {
+            0 => self.alu_add_byte(dst, src),
+            1 => self.alu_or_byte(dst, src),
+            2 => {
+                let cf = self.flags.cf_val();
+                self.alu_adc_byte(dst, src, cf)
+            }
+            3 => {
+                let cf = self.flags.cf_val();
+                self.alu_sbb_byte(dst, src, cf)
+            }
+            4 => self.alu_and_byte(dst, src),
+            5 => self.alu_sub_byte(dst, src),
+            6 => self.alu_xor_byte(dst, src),
+            7 => {
+                self.alu_sub_byte(dst, src);
+                dst
+            }
+            _ => unreachable!(),
+        };
+        if op != 7 {
+            if modrm < 0xC0 {
+                self.clk(bus, 1);
+            }
+            self.putback_rm_byte(modrm, result, bus);
+        }
+        self.clk_modrm(bus, modrm, 0, 1);
+    }
+
+    /// Group 0x81: ALU r/m16, imm16
+    pub(super) fn group_81(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        if modrm >= 0xC0 {
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        }
+        let dst = self.get_rm_word(modrm, bus);
+        let src = self.fetchword(bus);
+        let op = (modrm >> 3) & 7;
+        let result = match op {
+            0 => self.alu_add_word(dst, src),
+            1 => self.alu_or_word(dst, src),
+            2 => {
+                let cf = self.flags.cf_val();
+                self.alu_adc_word(dst, src, cf)
+            }
+            3 => {
+                let cf = self.flags.cf_val();
+                self.alu_sbb_word(dst, src, cf)
+            }
+            4 => self.alu_and_word(dst, src),
+            5 => self.alu_sub_word(dst, src),
+            6 => self.alu_xor_word(dst, src),
+            7 => {
+                self.alu_sub_word(dst, src);
+                dst
+            }
+            _ => unreachable!(),
+        };
+        if op != 7 {
+            self.putback_rm_word(modrm, result, bus);
+            if modrm < 0xC0 && self.next_instruction_uses_prefetched_high_byte() {
+                self.finish_on_terminal_writeback_inline_commit(modrm);
+            }
+        }
+        if op == 7 {
+            self.clk_modrm_word(bus, modrm, 0, 0);
+        } else {
+            self.clk_modrm_word(bus, modrm, 0, 2);
+        }
+    }
+
+    /// Group 0x82: ALU r/m8, imm8 (same as 0x80)
+    pub(super) fn group_82(&mut self, bus: &mut impl common::Bus) {
+        self.group_80(bus);
+    }
+
+    /// Group 0x83: ALU r/m16, sign-extended imm8
+    pub(super) fn group_83(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.get_rm_word(modrm, bus);
+        let src = self.fetch(bus) as i8 as u16;
+        let op = (modrm >> 3) & 7;
+        let result = match op {
+            0 => self.alu_add_word(dst, src),
+            1 => self.alu_or_word(dst, src),
+            2 => {
+                let cf = self.flags.cf_val();
+                self.alu_adc_word(dst, src, cf)
+            }
+            3 => {
+                let cf = self.flags.cf_val();
+                self.alu_sbb_word(dst, src, cf)
+            }
+            4 => self.alu_and_word(dst, src),
+            5 => self.alu_sub_word(dst, src),
+            6 => self.alu_xor_word(dst, src),
+            7 => {
+                self.alu_sub_word(dst, src);
+                dst
+            }
+            _ => unreachable!(),
+        };
+        if op != 7 {
+            if modrm < 0xC0 {
+                self.clk(bus, 1);
+            }
+            self.putback_rm_word(modrm, result, bus);
+        }
+        self.clk_modrm_word(bus, modrm, 0, 1);
+    }
+
+    /// Group 0xD0: shift/rotate r/m8, 1
+    pub(super) fn group_d0(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.get_rm_byte(modrm, bus);
+        let result = match (modrm >> 3) & 7 {
+            0 => self.alu_rol_byte(dst, 1),
+            1 => self.alu_ror_byte(dst, 1),
+            2 => self.alu_rcl_byte(dst, 1),
+            3 => self.alu_rcr_byte(dst, 1),
+            4 => self.alu_shl_byte(dst, 1),
+            5 => self.alu_shr_byte(dst, 1),
+            6 => 0xFF,
+            7 => self.alu_sar_byte(dst, 1),
+            _ => unreachable!(),
+        };
+        self.putback_rm_byte(modrm, result, bus);
+        self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        self.clk_modrm(bus, modrm, 0, 2);
+    }
+
+    /// Group 0xD1: shift/rotate r/m16, 1
+    pub(super) fn group_d1(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.get_rm_word(modrm, bus);
+        let result = match (modrm >> 3) & 7 {
+            0 => self.alu_rol_word(dst, 1),
+            1 => self.alu_ror_word(dst, 1),
+            2 => self.alu_rcl_word(dst, 1),
+            3 => self.alu_rcr_word(dst, 1),
+            4 => self.alu_shl_word(dst, 1),
+            5 => self.alu_shr_word(dst, 1),
+            6 => 0xFFFF,
+            7 => self.alu_sar_word(dst, 1),
+            _ => unreachable!(),
+        };
+        self.putback_rm_word(modrm, result, bus);
+        self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        self.clk_modrm_word(bus, modrm, 0, 2);
+    }
+
+    /// Group 0xD2: shift/rotate r/m8, CL
+    pub(super) fn group_d2(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.get_rm_byte(modrm, bus);
+        let count = self.regs.byte(ByteReg::CL);
+        let result = match (modrm >> 3) & 7 {
+            0 => self.alu_rol_byte(dst, count),
+            1 => self.alu_ror_byte(dst, count),
+            2 => self.alu_rcl_byte(dst, count),
+            3 => self.alu_rcr_byte(dst, count),
+            4 => self.alu_shl_byte(dst, count),
+            5 => self.alu_shr_byte(dst, count),
+            6 => {
+                if count == 0 {
+                    dst
+                } else {
+                    0xFF
+                }
+            }
+            7 => self.alu_sar_byte(dst, count),
+            _ => unreachable!(),
+        };
+        self.putback_rm_byte(modrm, result, bus);
+        let n = count as i32;
+        self.clk_modrm(bus, modrm, 5 + 4 * n, 6 + 4 * n);
+    }
+
+    /// Group 0xD3: shift/rotate r/m16, CL
+    pub(super) fn group_d3(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let dst = self.get_rm_word(modrm, bus);
+        let count = self.regs.byte(ByteReg::CL);
+        let result = match (modrm >> 3) & 7 {
+            0 => self.alu_rol_word(dst, count),
+            1 => self.alu_ror_word(dst, count),
+            2 => self.alu_rcl_word(dst, count),
+            3 => self.alu_rcr_word(dst, count),
+            4 => self.alu_shl_word(dst, count),
+            5 => self.alu_shr_word(dst, count),
+            6 => {
+                if count == 0 {
+                    dst
+                } else {
+                    0xFFFF
+                }
+            }
+            7 => self.alu_sar_word(dst, count),
+            _ => unreachable!(),
+        };
+        self.putback_rm_word(modrm, result, bus);
+        let n = count as i32;
+        self.clk_modrm_word(bus, modrm, 5 + 4 * n, 6 + 4 * n);
+    }
+
+    /// Group 0xF6: various byte operations
+    pub(super) fn group_f6(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let op = (modrm >> 3) & 7;
+        match op {
+            0 | 1 => {
+                // TEST r/m8, imm8
+                let dst = self.get_rm_byte(modrm, bus);
+                let src = self.fetch(bus);
+                self.alu_and_byte(dst, src);
+                self.clk_modrm(bus, modrm, 1, 1);
+            }
+            2 => {
+                // NOT r/m8
+                let dst = self.get_rm_byte(modrm, bus);
+                self.putback_rm_byte(modrm, !dst, bus);
+                self.clk_modrm(bus, modrm, 0, 1);
+            }
+            3 => {
+                // NEG r/m8
+                let dst = self.get_rm_byte(modrm, bus);
+                let result = self.alu_neg_byte(dst);
+                self.putback_rm_byte(modrm, result, bus);
+                self.clk_modrm(bus, modrm, 0, 1);
+            }
+            4 => {
+                // MUL r/m8 (unsigned, NEC MULU)
+                let src = self.get_rm_byte(modrm, bus);
+                let al = self.regs.byte(ByteReg::AL);
+                let result = al as u16 * src as u16;
+                self.regs.set_word(WordReg::AX, result);
+                self.flags.carry_val = if result & 0xFF00 != 0 { 1 } else { 0 };
+                self.flags.overflow_val = self.flags.carry_val;
+                let cycles = self.mul8_timing(al, src, false, false);
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                self.clk_muldiv_modrm(bus, modrm, cycles);
+            }
+            5 => {
+                // IMUL r/m8 (signed, NEC MUL)
+                let src = self.get_rm_byte(modrm, bus) as i8 as i16;
+                let al = self.regs.byte(ByteReg::AL) as i8 as i16;
+                let result = al * src;
+                self.regs.set_word(WordReg::AX, result as u16);
+                let ah = (result >> 8) as i8;
+                let al_sign = result as i8;
+                self.flags.carry_val = if ah != (al_sign >> 7) { 1 } else { 0 };
+                self.flags.overflow_val = self.flags.carry_val;
+                let cycles = self.mul8_timing(al as u8, src as u8, true, self.rep_prefix);
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                self.clk_muldiv_modrm(bus, modrm, cycles);
+            }
+            6 => {
+                // DIV r/m8 (unsigned, NEC DIVU)
+                let src = self.get_rm_byte(modrm, bus) as u16;
+                let timing = self.div8_timing(self.regs.word(WordReg::AX), src as u8, false, false);
+                if src == 0 {
+                    let cycles = timing.cycles();
+                    self.clk_muldiv_modrm(bus, modrm, cycles);
+                    self.raise_divide_error(bus);
+                    return;
+                }
+                let aw = self.regs.word(WordReg::AX);
+                let quotient = aw / src;
+                if quotient > 0xFF {
+                    let cycles = timing.cycles();
+                    self.clk_muldiv_modrm(bus, modrm, cycles);
+                    self.raise_divide_error(bus);
+                    return;
+                }
+                let remainder = aw % src;
+                self.regs.set_byte(ByteReg::AL, quotient as u8);
+                self.regs.set_byte(ByteReg::AH, remainder as u8);
+                let cycles = timing.cycles();
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                self.clk_muldiv_modrm(bus, modrm, cycles);
+            }
+            7 => {
+                // IDIV r/m8 (signed, NEC DIV)
+                let src = self.get_rm_byte(modrm, bus) as i8 as i16;
+                let timing = self.div8_timing(
+                    self.regs.word(WordReg::AX),
+                    src as u8,
+                    true,
+                    self.rep_prefix,
+                );
+                if src == 0 {
+                    let cycles = timing.cycles();
+                    self.clk_muldiv_modrm(bus, modrm, cycles);
+                    self.raise_divide_error(bus);
+                    return;
+                }
+                let aw = self.regs.word(WordReg::AX) as i16;
+                let Some(quotient) = aw.checked_div(src) else {
+                    let cycles = timing.cycles();
+                    self.clk_muldiv_modrm(bus, modrm, cycles);
+                    self.raise_divide_error(bus);
+                    return;
+                };
+                let quotient = if self.rep_prefix {
+                    quotient.wrapping_neg()
+                } else {
+                    quotient
+                };
+                if !(-127..=127).contains(&quotient) {
+                    let cycles = timing.cycles();
+                    self.clk_muldiv_modrm(bus, modrm, cycles);
+                    self.raise_divide_error(bus);
+                    return;
+                }
+                let remainder = aw.checked_rem(src).unwrap_or(0);
+                self.regs.set_byte(ByteReg::AL, quotient as u8);
+                self.regs.set_byte(ByteReg::AH, remainder as u8);
+                let cycles = timing.cycles();
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                self.clk_muldiv_modrm(bus, modrm, cycles);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// Group 0xF7: various word operations
+    pub(super) fn group_f7(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        let op = (modrm >> 3) & 7;
+        match op {
+            0 | 1 => {
+                // TEST r/m16, imm16
+                let dst = self.get_rm_word(modrm, bus);
+                let src = self.fetchword(bus);
+                self.alu_and_word(dst, src);
+                if modrm >= 0xC0 {
+                    self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                }
+                self.clk_modrm_word(bus, modrm, 1, 0);
+            }
+            2 => {
+                // NOT r/m16
+                let dst = self.get_rm_word(modrm, bus);
+                self.putback_rm_word(modrm, !dst, bus);
+                self.clk_modrm_word(bus, modrm, 0, 1);
+            }
+            3 => {
+                // NEG r/m16
+                let dst = self.get_rm_word(modrm, bus);
+                let result = self.alu_neg_word(dst);
+                self.putback_rm_word(modrm, result, bus);
+                self.clk_modrm_word(bus, modrm, 0, 1);
+            }
+            4 => {
+                // MUL r/m16 (unsigned, NEC MULU)
+                let src = self.get_rm_word(modrm, bus);
+                let aw = self.regs.word(WordReg::AX);
+                let result = aw as u32 * src as u32;
+                self.regs.set_word(WordReg::AX, result as u16);
+                self.regs.set_word(WordReg::DX, (result >> 16) as u16);
+                self.flags.carry_val = if result & 0xFFFF0000 != 0 { 1 } else { 0 };
+                self.flags.overflow_val = self.flags.carry_val;
+                let cycles = self.mul16_timing(aw, src, false, false);
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                self.clk_muldiv_modrm(bus, modrm, cycles);
+            }
+            5 => {
+                // IMUL r/m16 (signed, NEC MUL)
+                let src = self.get_rm_word(modrm, bus) as i16 as i32;
+                let aw = self.regs.word(WordReg::AX) as i16 as i32;
+                let result = aw * src;
+                self.regs.set_word(WordReg::AX, result as u16);
+                self.regs.set_word(WordReg::DX, (result >> 16) as u16);
+                let upper = (result >> 16) as i16;
+                let lower_sign = result as i16;
+                self.flags.carry_val = if upper != (lower_sign >> 15) { 1 } else { 0 };
+                self.flags.overflow_val = self.flags.carry_val;
+                let cycles = self.mul16_timing(aw as u16, src as u16, true, self.rep_prefix);
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                self.clk_muldiv_modrm(bus, modrm, cycles);
+            }
+            6 => {
+                // DIV r/m16 (unsigned, NEC DIVU)
+                let src = self.get_rm_word(modrm, bus) as u32;
+                let dividend = ((self.regs.word(WordReg::DX) as u32) << 16)
+                    | self.regs.word(WordReg::AX) as u32;
+                let timing = self.div16_timing(dividend, src as u16, false, false);
+                if src == 0 {
+                    let cycles = timing.cycles();
+                    self.clk_muldiv_modrm(bus, modrm, cycles);
+                    self.raise_divide_error(bus);
+                    return;
+                }
+                let dw = self.regs.word(WordReg::DX) as u32;
+                let aw = self.regs.word(WordReg::AX) as u32;
+                let dividend = (dw << 16) | aw;
+                let quotient = dividend / src;
+                if quotient > 0xFFFF {
+                    let cycles = timing.cycles();
+                    self.clk_muldiv_modrm(bus, modrm, cycles);
+                    self.raise_divide_error(bus);
+                    return;
+                }
+                let remainder = dividend % src;
+                self.regs.set_word(WordReg::AX, quotient as u16);
+                self.regs.set_word(WordReg::DX, remainder as u16);
+                let cycles = timing.cycles();
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                self.clk_muldiv_modrm(bus, modrm, cycles);
+            }
+            7 => {
+                // IDIV r/m16 (signed, NEC DIV)
+                let src = self.get_rm_word(modrm, bus) as i16 as i32;
+                let dividend = ((self.regs.word(WordReg::DX) as u32) << 16)
+                    | self.regs.word(WordReg::AX) as u32;
+                let timing = self.div16_timing(dividend, src as u16, true, self.rep_prefix);
+                if src == 0 {
+                    let cycles = timing.cycles();
+                    self.clk_muldiv_modrm(bus, modrm, cycles);
+                    self.raise_divide_error(bus);
+                    return;
+                }
+                let dw = self.regs.word(WordReg::DX) as u32;
+                let aw = self.regs.word(WordReg::AX) as u32;
+                let dividend = ((dw << 16) | aw) as i32;
+                let Some(quotient) = dividend.checked_div(src) else {
+                    let cycles = timing.cycles();
+                    self.clk_muldiv_modrm(bus, modrm, cycles);
+                    self.raise_divide_error(bus);
+                    return;
+                };
+                let quotient = if self.rep_prefix {
+                    quotient.wrapping_neg()
+                } else {
+                    quotient
+                };
+                if !(-32768..=32767).contains(&quotient) {
+                    let cycles = timing.cycles();
+                    self.clk_muldiv_modrm(bus, modrm, cycles);
+                    self.raise_divide_error(bus);
+                    return;
+                }
+                let remainder = dividend.checked_rem(src).unwrap_or(0);
+                self.regs.set_word(WordReg::AX, quotient as u16);
+                self.regs.set_word(WordReg::DX, remainder as u16);
+                let cycles = timing.cycles();
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                self.clk_muldiv_modrm(bus, modrm, cycles);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// Group 0xFE: INC/DEC r/m8
+    pub(super) fn group_fe(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        match (modrm >> 3) & 7 {
+            0 => {
+                // INC r/m8
+                let dst = self.get_rm_byte(modrm, bus);
+                let result = self.alu_inc_byte(dst);
+                self.putback_rm_byte(modrm, result, bus);
+                self.clk_modrm(bus, modrm, 0, 1);
+            }
+            1 => {
+                // DEC r/m8
+                let dst = self.get_rm_byte(modrm, bus);
+                let result = self.alu_dec_byte(dst);
+                self.putback_rm_byte(modrm, result, bus);
+                self.clk_modrm(bus, modrm, 0, 1);
+            }
+            2 => {
+                // Undefined on paper, but executes as CALL with the 8-bit
+                // operand widened.
+                let dst = self.get_rm_widened_from_byte(modrm, bus);
+                if modrm >= 0xC0 {
+                    self.clk(bus, 1);
+                }
+                self.biu_fetch_suspend(bus);
+                self.clk(bus, 2);
+                self.corr(bus);
+                self.nearcall_byte_routine(bus, dst, true);
+            }
+            3 => {
+                // Undefined on paper, but executes as far CALL through an
+                // invalid 8-bit form.
+                let (offset, segment) = if modrm >= 0xC0 {
+                    self.clk(bus, 1);
+                    (
+                        self.invalid_far_register_ip_handoff(),
+                        self.invalid_far_register_segment_from_byte(bus),
+                    )
+                } else {
+                    self.get_rm_far_ptr_from_byte_pair(modrm, bus)
+                };
+                self.farcall_byte_routine(bus, segment, offset, true, false);
+            }
+            4 => {
+                // Undefined on paper, but executes as JMP with the 8-bit
+                // operand widened.
+                let dst = self.get_rm_widened_from_byte(modrm, bus);
+                if modrm >= 0xC0 {
+                    self.clk(bus, 1);
+                }
+                self.biu_fetch_suspend(bus);
+                self.clk(bus, 1);
+                self.ip = dst;
+                self.flush_and_fetch(bus);
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+            }
+            5 => {
+                // Undefined on paper, but executes as far JMP through an
+                // invalid 8-bit form.
+                let (offset, segment) = if modrm >= 0xC0 {
+                    self.clk(bus, 1);
+                    (
+                        self.invalid_far_register_ip_handoff(),
+                        self.invalid_far_register_segment_from_byte(bus),
+                    )
+                } else {
+                    self.get_rm_far_ptr_from_byte_pair(modrm, bus)
+                };
+                self.biu_fetch_suspend(bus);
+                self.clk(bus, 1);
+                self.sregs[SegReg16::CS as usize] = segment;
+                self.ip = offset;
+                self.flush_and_fetch(bus);
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+            }
+            6 | 7 => {
+                // Undefined on paper, but executes as PUSH byte.
+                let value = self.get_rm_byte(modrm, bus);
+                self.push_byte_value(bus, value);
+                if modrm >= 0xC0 {
+                    if self.seg_prefix || !self.instruction_entry_queue_full() {
+                        self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                    }
+                    self.clk(bus, 4);
+                } else {
+                    self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                    self.clk(bus, 3);
+                }
+            }
+            _ => {
+                self.clk(bus, 2);
+            }
+        }
+    }
+
+    /// Group 0xFF: various word operations
+    pub(super) fn group_ff(&mut self, bus: &mut impl common::Bus) {
+        let modrm = self.fetch_modrm(bus);
+        match (modrm >> 3) & 7 {
+            0 => {
+                // INC r/m16
+                let dst = self.get_rm_word(modrm, bus);
+                let result = self.alu_inc_word(dst);
+                self.putback_rm_word(modrm, result, bus);
+                self.clk_modrm_word(bus, modrm, 0, 1);
+            }
+            1 => {
+                // DEC r/m16
+                let dst = self.get_rm_word(modrm, bus);
+                let result = self.alu_dec_word(dst);
+                self.putback_rm_word(modrm, result, bus);
+                self.clk_modrm_word(bus, modrm, 0, 1);
+            }
+            2 => {
+                // CALL r/m16 (near indirect)
+                let dst = self.get_rm_word(modrm, bus);
+                if modrm >= 0xC0 {
+                    self.clk(bus, 1);
+                }
+                self.biu_fetch_suspend(bus);
+                self.clk(bus, 2);
+                self.corr(bus);
+                self.nearcall_routine(bus, dst, true);
+            }
+            3 => {
+                // CALL m16:16 (far indirect)
+                if modrm >= 0xC0 {
+                    self.clk(bus, 1);
+                    let segment = self.invalid_far_register_segment(bus);
+                    let offset = self.invalid_far_register_ip_handoff();
+                    self.farcall_routine(bus, segment, offset, true, false);
+                    return;
+                }
+                let offset = self.get_rm_word(modrm, bus);
+                let segment = self.seg_read_word_at(bus, 2);
+                if self.far_indirect_transfer_uses_preloaded_handoff(modrm) {
+                    self.clk(bus, 1);
+                }
+                self.farcall_routine(bus, segment, offset, true, false);
+            }
+            4 => {
+                // JMP r/m16 (near indirect)
+                let dst = self.get_rm_word(modrm, bus);
+                if modrm >= 0xC0 {
+                    self.clk(bus, 1);
+                }
+                self.biu_fetch_suspend(bus);
+                self.clk(bus, 1);
+                self.ip = dst;
+                self.flush_and_fetch(bus);
+                self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+            }
+            5 => {
+                // JMP m16:16 (far indirect)
+                if modrm >= 0xC0 {
+                    self.clk(bus, 1);
+                    let segment = self.invalid_far_register_segment(bus);
+                    self.biu_fetch_suspend(bus);
+                    self.clk(bus, 1);
+                    self.sregs[SegReg16::CS as usize] = segment;
+                    self.ip = self.invalid_far_register_ip_handoff();
+                    self.flush_and_fetch(bus);
+                    self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                    return;
+                }
+                let offset = self.get_rm_word(modrm, bus);
+                self.biu_fetch_suspend(bus);
+                self.clk(bus, 1);
+                let segment = self.seg_read_word_at(bus, 2);
+                let uses_preloaded_handoff =
+                    self.far_indirect_transfer_uses_preloaded_handoff(modrm);
+                self.sregs[SegReg16::CS as usize] = segment;
+                self.ip = offset;
+                self.flush_and_fetch(bus);
+                if uses_preloaded_handoff {
+                    self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                }
+            }
+            6 | 7 => {
+                // PUSH r/m16 (7 is undocumented alias)
+                if modrm >= 0xC0 && (modrm & 7) == 4 {
+                    let sp = self.regs.word(WordReg::SP).wrapping_sub(2);
+                    self.regs.set_word(WordReg::SP, sp);
+                    self.write_word_seg(bus, SegReg16::SS, sp, sp);
+                } else {
+                    let val = self.get_rm_word(modrm, bus);
+                    self.push(bus, val);
+                }
+                if modrm >= 0xC0 {
+                    if self.seg_prefix || !self.instruction_entry_queue_full() {
+                        self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                    }
+                    self.clk(bus, 4);
+                } else {
+                    self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+                    self.clk(bus, 3);
+                }
+            }
+            _ => {
+                self.clk(bus, 2);
+            }
+        }
+    }
+}

--- a/crates/cpu/src/i8086/flags.rs
+++ b/crates/cpu/src/i8086/flags.rs
@@ -1,0 +1,197 @@
+const PARITY_TABLE: [bool; 256] = {
+    let mut table = [false; 256];
+    let mut i = 0u16;
+    while i < 256 {
+        let mut bits = 0u32;
+        let mut v = i;
+        while v > 0 {
+            bits += (v & 1) as u32;
+            v >>= 1;
+        }
+        table[i as usize] = (bits & 1) == 0;
+        i += 1;
+    }
+    table
+};
+
+/// I8086 CPU flags register state.
+#[derive(Debug, Clone)]
+pub struct I8086Flags {
+    /// Lazily computed sign flag value (negative means SF=1).
+    pub sign_val: i32,
+    /// Lazily computed zero flag value (zero means ZF=1).
+    pub zero_val: u32,
+    /// Lazily computed carry flag value (non-zero means CF=1).
+    pub carry_val: u32,
+    /// Lazily computed overflow flag value (non-zero means OF=1).
+    pub overflow_val: u32,
+    /// Lazily computed auxiliary carry flag value (non-zero means AF=1).
+    pub aux_val: u32,
+    /// Lazily computed parity flag value (low byte used for lookup).
+    pub parity_val: u32,
+    /// Trap flag.
+    pub tf: bool,
+    /// Interrupt enable flag.
+    pub if_flag: bool,
+    /// Direction flag.
+    pub df: bool,
+}
+
+impl I8086Flags {
+    /// Creates flags with default power-on state.
+    pub const fn new() -> Self {
+        Self {
+            sign_val: 0,
+            zero_val: 1,
+            carry_val: 0,
+            overflow_val: 0,
+            aux_val: 0,
+            parity_val: 0,
+            tf: false,
+            if_flag: false,
+            df: false,
+        }
+    }
+
+    /// Returns the carry flag.
+    #[inline(always)]
+    pub fn cf(&self) -> bool {
+        self.carry_val != 0
+    }
+
+    /// Returns the sign flag.
+    #[inline(always)]
+    pub fn sf(&self) -> bool {
+        self.sign_val < 0
+    }
+
+    /// Returns the zero flag.
+    #[inline(always)]
+    pub fn zf(&self) -> bool {
+        self.zero_val == 0
+    }
+
+    /// Returns the parity flag.
+    #[inline(always)]
+    pub fn pf(&self) -> bool {
+        PARITY_TABLE[(self.parity_val & 0xFF) as usize]
+    }
+
+    /// Returns the auxiliary carry flag.
+    #[inline(always)]
+    pub fn af(&self) -> bool {
+        self.aux_val != 0
+    }
+
+    /// Returns the overflow flag.
+    #[inline(always)]
+    pub fn of(&self) -> bool {
+        self.overflow_val != 0
+    }
+
+    /// Returns the carry flag as a 0/1 integer.
+    #[inline(always)]
+    pub fn cf_val(&self) -> u32 {
+        u32::from(self.carry_val != 0)
+    }
+
+    /// Packs all flags into a 16-bit FLAGS register value.
+    pub fn compress(&self) -> u16 {
+        (self.cf() as u16)
+            | 0x0002
+            | ((self.pf() as u16) << 2)
+            | ((self.af() as u16) << 4)
+            | ((self.zf() as u16) << 6)
+            | ((self.sf() as u16) << 7)
+            | ((self.tf as u16) << 8)
+            | ((self.if_flag as u16) << 9)
+            | ((self.df as u16) << 10)
+            | ((self.of() as u16) << 11)
+            | 0xF000
+    }
+
+    /// Unpacks a 16-bit FLAGS register value into individual flags.
+    pub fn expand(&mut self, value: u16) {
+        self.carry_val = (value & 0x0001) as u32;
+        self.parity_val = if value & 0x0004 != 0 { 0 } else { 1 };
+        self.aux_val = (value & 0x0010) as u32;
+        self.zero_val = if value & 0x0040 != 0 { 0 } else { 1 };
+        self.sign_val = if value & 0x0080 != 0 { -1 } else { 0 };
+        self.tf = value & 0x0100 != 0;
+        self.if_flag = value & 0x0200 != 0;
+        self.df = value & 0x0400 != 0;
+        self.overflow_val = (value & 0x0800) as u32;
+    }
+
+    /// Sets carry flag from a byte-sized result (bit 8).
+    #[inline(always)]
+    pub fn set_cf_byte(&mut self, result: u32) {
+        self.carry_val = result & 0x100;
+    }
+
+    /// Sets carry flag from a word-sized result (bit 16).
+    #[inline(always)]
+    pub fn set_cf_word(&mut self, result: u32) {
+        self.carry_val = result & 0x10000;
+    }
+
+    /// Sets auxiliary carry flag from XOR of result, source, and destination.
+    #[inline(always)]
+    pub fn set_af(&mut self, result: u32, src: u32, dst: u32) {
+        self.aux_val = (result ^ (src ^ dst)) & 0x10;
+    }
+
+    /// Sets overflow flag for byte addition.
+    #[inline(always)]
+    pub fn set_of_add_byte(&mut self, result: u32, src: u32, dst: u32) {
+        self.overflow_val = (result ^ src) & (result ^ dst) & 0x80;
+    }
+
+    /// Sets overflow flag for word addition.
+    #[inline(always)]
+    pub fn set_of_add_word(&mut self, result: u32, src: u32, dst: u32) {
+        self.overflow_val = (result ^ src) & (result ^ dst) & 0x8000;
+    }
+
+    /// Sets overflow flag for byte subtraction.
+    #[inline(always)]
+    pub fn set_of_sub_byte(&mut self, result: u32, src: u32, dst: u32) {
+        self.overflow_val = (dst ^ src) & (dst ^ result) & 0x80;
+    }
+
+    /// Sets overflow flag for word subtraction.
+    #[inline(always)]
+    pub fn set_of_sub_word(&mut self, result: u32, src: u32, dst: u32) {
+        self.overflow_val = (dst ^ src) & (dst ^ result) & 0x8000;
+    }
+
+    /// Sets sign, zero, and parity flags from a byte result.
+    #[inline(always)]
+    pub fn set_szpf_byte(&mut self, result: u32) {
+        self.sign_val = result as u8 as i8 as i32;
+        self.zero_val = result & 0xFF;
+        self.parity_val = result;
+    }
+
+    /// Sets sign, zero, and parity flags from a word result.
+    #[inline(always)]
+    pub fn set_szpf_word(&mut self, result: u32) {
+        self.sign_val = result as u16 as i16 as i32;
+        self.zero_val = result & 0xFFFF;
+        self.parity_val = result;
+    }
+}
+
+impl Default for I8086Flags {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PartialEq for I8086Flags {
+    fn eq(&self, other: &Self) -> bool {
+        self.compress() == other.compress()
+    }
+}
+
+impl Eq for I8086Flags {}

--- a/crates/cpu/src/i8086/interrupt.rs
+++ b/crates/cpu/src/i8086/interrupt.rs
@@ -1,0 +1,122 @@
+use super::I8086;
+use crate::{PENDING_IRQ, PENDING_NMI, SegReg16};
+
+impl I8086 {
+    pub(super) fn raise_divide_error(&mut self, bus: &mut impl common::Bus) {
+        if self.rep_active {
+            self.ip = self.rep_restart_ip;
+        }
+        self.rep_active = false;
+
+        let flags_val = self.flags.compress();
+        let return_ip = self.ip;
+        let return_cs = self.sregs[SegReg16::CS as usize];
+
+        self.clk(bus, 4);
+
+        let dest_ip = self.read_memory_word(bus, 0);
+        self.clk(bus, 1);
+        let dest_cs = self.read_memory_word(bus, 2);
+
+        self.biu_fetch_suspend(bus);
+        self.clk(bus, 3);
+
+        self.push(bus, flags_val);
+        self.flags.tf = false;
+        self.flags.if_flag = false;
+
+        self.clk(bus, 3);
+        self.corr(bus);
+        self.clk(bus, 1);
+
+        self.push(bus, return_cs);
+        self.sregs[SegReg16::CS as usize] = dest_cs;
+
+        self.clk(bus, 3);
+        self.ip = dest_ip;
+        self.flush_and_fetch(bus);
+        self.clk(bus, 3);
+        self.push(bus, return_ip);
+    }
+
+    pub(super) fn check_interrupts(&mut self, bus: &mut impl common::Bus) {
+        if self.pending_irq & PENDING_NMI != 0 && self.inhibit_all == 0 {
+            self.pending_irq &= !PENDING_NMI;
+            bus.acknowledge_nmi();
+            self.raise_interrupt(2, bus);
+        } else if self.flags.if_flag
+            && self.pending_irq & PENDING_IRQ != 0
+            && self.no_interrupt == 0
+            && self.inhibit_all == 0
+        {
+            self.pending_irq &= !PENDING_IRQ;
+            let vector = bus.acknowledge_irq();
+            self.raise_interrupt(vector, bus);
+        }
+    }
+
+    pub(super) fn raise_software_interrupt_with_entry_cycles(
+        &mut self,
+        vector: u8,
+        bus: &mut impl common::Bus,
+        entry_cycles: i32,
+    ) {
+        if self.rep_active {
+            self.ip = self.rep_restart_ip;
+        }
+        self.rep_active = false;
+
+        let flags_val = self.flags.compress();
+        let return_ip = self.ip;
+        let return_cs = self.sregs[SegReg16::CS as usize];
+
+        self.clk(bus, entry_cycles);
+
+        let addr = (vector as u32) * 4;
+        let dest_ip = self.read_memory_word(bus, addr);
+        self.clk(bus, 1);
+        let dest_cs = self.read_memory_word(bus, addr + 2);
+
+        self.biu_fetch_suspend(bus);
+        self.clk(bus, 3);
+
+        self.push(bus, flags_val);
+        self.flags.tf = false;
+        self.flags.if_flag = false;
+
+        self.clk(bus, 6);
+
+        self.push(bus, return_cs);
+        self.sregs[SegReg16::CS as usize] = dest_cs;
+
+        self.clk(bus, 4);
+        self.ip = dest_ip;
+        self.flush_and_fetch(bus);
+        self.push(bus, return_ip);
+    }
+
+    pub(super) fn raise_software_interrupt(&mut self, vector: u8, bus: &mut impl common::Bus) {
+        self.raise_software_interrupt_with_entry_cycles(vector, bus, 3);
+    }
+
+    pub(super) fn raise_interrupt(&mut self, vector: u8, bus: &mut impl common::Bus) {
+        if self.rep_active {
+            self.ip = self.rep_restart_ip;
+        }
+        self.rep_active = false;
+        let flags_val = self.flags.compress();
+        self.push(bus, flags_val);
+        self.flags.tf = false;
+        self.flags.if_flag = false;
+
+        let addr = (vector as u32) * 4;
+        let dest_ip = self.read_memory_word(bus, addr);
+        let dest_cs = self.read_memory_word(bus, addr + 2);
+
+        let cs = self.sregs[SegReg16::CS as usize];
+        self.push(bus, cs);
+        self.push(bus, self.ip);
+
+        self.set_cs_ip_and_flush(bus, dest_cs, dest_ip);
+    }
+}

--- a/crates/cpu/src/i8086/modrm.rs
+++ b/crates/cpu/src/i8086/modrm.rs
@@ -1,0 +1,246 @@
+use super::I8086;
+use crate::{ByteReg, SegReg16, WordReg, build_x86_reg_word_table, build_x86_rm_table};
+
+static MODRM_REG: [u8; 256] = build_x86_reg_word_table();
+static MODRM_RM: [u8; 256] = build_x86_rm_table();
+
+impl I8086 {
+    #[inline(always)]
+    pub(super) fn reg_word(&self, modrm: u8) -> WordReg {
+        WordReg::from_index(MODRM_REG[modrm as usize])
+    }
+
+    #[inline(always)]
+    pub(super) fn reg_byte(&self, modrm: u8) -> ByteReg {
+        ByteReg::from_index(MODRM_REG[modrm as usize])
+    }
+
+    #[inline(always)]
+    pub(super) fn rm_word(&self, modrm: u8) -> WordReg {
+        WordReg::from_index(MODRM_RM[modrm as usize])
+    }
+
+    #[inline(always)]
+    pub(super) fn rm_byte(&self, modrm: u8) -> ByteReg {
+        ByteReg::from_index(MODRM_RM[modrm as usize])
+    }
+
+    #[inline(always)]
+    fn modrm_decode_costs(&self, modrm: u8) -> (i32, i32, u8) {
+        match modrm & 0xC7 {
+            0x00 => (4, 0, 0),
+            0x01 => (5, 0, 0),
+            0x02 => (5, 0, 0),
+            0x03 => (4, 0, 0),
+            0x04 => (2, 0, 0),
+            0x05 => (2, 0, 0),
+            0x06 => (0, 1, 2),
+            0x07 => (2, 0, 0),
+            0x40 => (4, 3, 1),
+            0x41 => (5, 3, 1),
+            0x42 => (5, 3, 1),
+            0x43 => (4, 3, 1),
+            0x44 => (2, 3, 1),
+            0x45 => (2, 3, 1),
+            0x46 => (2, 3, 1),
+            0x47 => (2, 3, 1),
+            0x80 => (4, 2, 2),
+            0x81 => (5, 2, 2),
+            0x82 => (5, 2, 2),
+            0x83 => (4, 2, 2),
+            0x84 => (2, 2, 2),
+            0x85 => (2, 2, 2),
+            0x86 => (2, 2, 2),
+            0x87 => (2, 2, 2),
+            _ => (0, 0, 0),
+        }
+    }
+
+    #[inline(always)]
+    pub(super) fn has_disp16_single_register_base(&self, modrm: u8) -> bool {
+        matches!(modrm & 0xC7, 0x84..=0x87)
+    }
+
+    #[inline(always)]
+    pub(super) fn has_disp8_single_register_base(&self, modrm: u8) -> bool {
+        matches!(modrm & 0xC7, 0x44..=0x47)
+    }
+
+    #[inline(always)]
+    pub(super) fn has_disp16_double_register_base(&self, modrm: u8) -> bool {
+        matches!(modrm & 0xC7, 0x80..=0x83)
+    }
+
+    #[inline(always)]
+    pub(super) fn has_disp16_cycle4_double_register_base(&self, modrm: u8) -> bool {
+        matches!(modrm & 0xC7, 0x80 | 0x83)
+    }
+
+    #[inline(always)]
+    pub(super) fn has_mod0_single_register_base(&self, modrm: u8) -> bool {
+        matches!(modrm & 0xC7, 0x04..=0x07)
+    }
+
+    #[inline(always)]
+    pub(super) fn has_single_or_direct_base(&self, modrm: u8) -> bool {
+        self.has_mod0_single_register_base(modrm) || self.has_disp16_single_register_base(modrm)
+    }
+
+    #[inline(always)]
+    pub(super) fn has_simple_disp16_base(&self, modrm: u8) -> bool {
+        matches!(modrm & 0xC7, 0x06 | 0x84..=0x87)
+    }
+
+    pub(super) fn fetch_modrm(&mut self, bus: &mut impl common::Bus) -> u8 {
+        let modrm = self.fetch(bus);
+        self.modrm_displacement = 0;
+        self.modrm_has_displacement = false;
+
+        if modrm < 0xC0 {
+            let (pre_disp_cost, post_disp_cost, displacement_size) = self.modrm_decode_costs(modrm);
+            self.clk(bus, 1 + pre_disp_cost);
+
+            match displacement_size {
+                1 => {
+                    self.modrm_displacement = self.fetch(bus) as i8 as u16;
+                    self.modrm_has_displacement = true;
+                }
+                2 => {
+                    self.modrm_displacement = self.fetchword(bus);
+                    self.modrm_has_displacement = true;
+                }
+                _ => {}
+            }
+
+            self.clk(bus, post_disp_cost);
+
+            if !self.seg_prefix
+                && !self.opcode_started_at_odd_address()
+                && self.has_disp16_single_register_base(modrm)
+            {
+                self.clk(bus, 1);
+            }
+        }
+
+        modrm
+    }
+
+    pub(super) fn calc_ea(&mut self, modrm: u8) {
+        debug_assert!(modrm < 0xC0);
+
+        let mode = modrm >> 6;
+        let rm = modrm & 7;
+
+        // Mode 0, rm 6 is the only "direct address" form: the displacement
+        // word holds the offset and the default segment is DS (not SS, even
+        // though rm 6 normally selects BP).
+        if mode == 0 && rm == 6 {
+            self.set_effective_address(SegReg16::DS, self.modrm_displacement);
+            return;
+        }
+
+        let base = self.ea_base(rm);
+        let displacement = if self.modrm_has_displacement {
+            self.modrm_displacement
+        } else {
+            0
+        };
+        // BP-based addressing modes (rm 2, 3, and rm 6 with a displacement)
+        // default to SS; every other base uses DS.
+        let seg = if rm == 2 || rm == 3 || (rm == 6 && mode != 0) {
+            SegReg16::SS
+        } else {
+            SegReg16::DS
+        };
+        self.set_effective_address(seg, base.wrapping_add(displacement));
+    }
+
+    #[inline(always)]
+    fn ea_base(&self, rm: u8) -> u16 {
+        match rm {
+            0 => self
+                .regs
+                .word(WordReg::BX)
+                .wrapping_add(self.regs.word(WordReg::SI)),
+            1 => self
+                .regs
+                .word(WordReg::BX)
+                .wrapping_add(self.regs.word(WordReg::DI)),
+            2 => self
+                .regs
+                .word(WordReg::BP)
+                .wrapping_add(self.regs.word(WordReg::SI)),
+            3 => self
+                .regs
+                .word(WordReg::BP)
+                .wrapping_add(self.regs.word(WordReg::DI)),
+            4 => self.regs.word(WordReg::SI),
+            5 => self.regs.word(WordReg::DI),
+            6 => self.regs.word(WordReg::BP),
+            7 => self.regs.word(WordReg::BX),
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline(always)]
+    pub(super) fn resolve_rm_address(&mut self, modrm: u8) {
+        if modrm < 0xC0 {
+            self.calc_ea(modrm);
+        }
+    }
+
+    #[inline(always)]
+    pub(super) fn charge_rm_eadone(&mut self, modrm: u8, bus: &mut impl common::Bus) {
+        if modrm < 0xC0 {
+            if !self.seg_prefix
+                && self.instruction_entry_queue_full()
+                && !self.opcode_started_at_odd_address()
+                && self.has_disp16_single_register_base(modrm)
+            {
+                self.clk(bus, 1);
+            } else {
+                self.clk_eadone(bus);
+            }
+        }
+    }
+
+    pub(super) fn get_rm_byte(&mut self, modrm: u8, bus: &mut impl common::Bus) -> u8 {
+        if modrm >= 0xC0 {
+            self.regs.byte(self.rm_byte(modrm))
+        } else {
+            self.calc_ea(modrm);
+            let value = self.read_memory_byte(bus, self.ea);
+            self.clk_eaload(bus);
+            value
+        }
+    }
+
+    pub(super) fn get_rm_word(&mut self, modrm: u8, bus: &mut impl common::Bus) -> u16 {
+        if modrm >= 0xC0 {
+            self.regs.word(self.rm_word(modrm))
+        } else {
+            self.calc_ea(modrm);
+            let value = self.seg_read_word(bus);
+            self.clk_eaload(bus);
+            value
+        }
+    }
+
+    pub(super) fn putback_rm_byte(&mut self, modrm: u8, value: u8, bus: &mut impl common::Bus) {
+        if modrm >= 0xC0 {
+            let reg = self.rm_byte(modrm);
+            self.regs.set_byte(reg, value);
+        } else {
+            self.write_memory_byte(bus, self.ea, value);
+        }
+    }
+
+    pub(super) fn putback_rm_word(&mut self, modrm: u8, value: u16, bus: &mut impl common::Bus) {
+        if modrm >= 0xC0 {
+            let reg = self.rm_word(modrm);
+            self.regs.set_word(reg, value);
+        } else {
+            self.seg_write_word(bus, value);
+        }
+    }
+}

--- a/crates/cpu/src/i8086/muldiv_timing.rs
+++ b/crates/cpu/src/i8086/muldiv_timing.rs
@@ -1,0 +1,545 @@
+//! Timing helpers for 8086 multiply and divide instructions.
+//!
+//! The microcode-derived timing model in this file was heavily influenced by
+//! the 8088 core implementation in MartyPC, which is licensed under the
+//! permissive MIT license.
+
+use super::I8086;
+
+pub(super) enum DivisionTiming {
+    Complete { cycles: i32, carry: bool },
+    Exception(i32),
+}
+
+impl DivisionTiming {
+    pub(super) fn cycles(&self) -> i32 {
+        match self {
+            Self::Complete { cycles, .. } | Self::Exception(cycles) => *cycles,
+        }
+    }
+}
+
+fn neg(value: u16, bits: u32) -> (u16, bool) {
+    let mask = if bits == 8 { 0x00FF } else { 0xFFFF };
+    let value = value & mask;
+    ((!value).wrapping_add(1) & mask, value != 0)
+}
+
+fn add(value: u16, other: u16, bits: u32) -> (u16, bool) {
+    let mask = if bits == 8 { 0x00FF } else { 0xFFFF };
+    let value = value & mask;
+    let other = other & mask;
+    let sum = value as u32 + other as u32;
+    ((sum as u16) & mask, sum > mask as u32)
+}
+
+fn sub(value: u16, other: u16, bits: u32) -> (u16, bool) {
+    let mask = if bits == 8 { 0x00FF } else { 0xFFFF };
+    let value = value & mask;
+    let other = other & mask;
+    let (result, borrow) = value.overflowing_sub(other);
+    (result & mask, borrow)
+}
+
+fn rcl(value: u16, carry: bool, bits: u32) -> (u16, bool) {
+    let mask = if bits == 8 { 0x00FF } else { 0xFFFF };
+    let carry_out = value & (1 << (bits - 1)) != 0;
+    let result = ((value << 1) | u16::from(carry)) & mask;
+    (result, carry_out)
+}
+
+fn rcr(value: u16, carry: bool, bits: u32) -> (u16, bool) {
+    let mask = if bits == 8 { 0x00FF } else { 0xFFFF };
+    let carry_out = value & 1 != 0;
+    let result = (((u16::from(carry)) << (bits - 1)) | (value >> 1)) & mask;
+    (result, carry_out)
+}
+
+fn sign_bit(value: u16, bits: u32) -> bool {
+    value & (1 << (bits - 1)) != 0
+}
+
+fn cor_negate_timing(
+    bits: u32,
+    mut tmpa: u16,
+    mut tmpb: u16,
+    mut tmpc: u16,
+    mut negate_flag: bool,
+    skip: bool,
+) -> (u16, u16, u16, bool, bool, i32) {
+    let mut cycles = 0;
+
+    if !skip {
+        // 0x1b6: SIGMA->tmpc | NEG tmpc
+        let (sigma, carry) = neg(tmpc, bits);
+        tmpc = sigma;
+
+        if carry {
+            // 0x1b6, 0x1b7, 0x1b8, MC_JUMP, 0x1ba
+            let mask = if bits == 8 { 0x00FF } else { 0xFFFF };
+            tmpa = (!tmpa) & mask;
+            cycles += 5;
+        } else {
+            // 0x1b6, 0x1b7, 0x1b8, 0x1b9, 0x1ba
+            tmpa = neg(tmpa, bits).0;
+            cycles += 5;
+        }
+        negate_flag = !negate_flag;
+    }
+
+    // 0x1bb: LRCY tmpb | 0x1bc: SIGMA->tmpb NEG tmpb | 0x1bd: NCY 11
+    let carry = sign_bit(tmpb, bits);
+    let (sigma, _) = neg(tmpb, bits);
+    cycles += 3;
+
+    if !carry {
+        // MC_JUMP, 0x1bf, MC_RTN
+        cycles += 3;
+    } else {
+        // 0x1be, MC_RTN
+        tmpb = sigma;
+        negate_flag = !negate_flag;
+        cycles += 2;
+    }
+
+    (tmpa, tmpb, tmpc, carry, negate_flag, cycles)
+}
+
+fn corx_timing(bits: u32, tmpb: u16, mut tmpc: u16, mut carry: bool) -> (u16, u16, i32) {
+    let mut cycles = 2;
+    let (sigma, next_carry) = rcr(tmpc, carry, bits);
+    let mut tmpa = 0;
+    tmpc = sigma;
+    carry = next_carry;
+
+    let mut internal_counter = bits - 1;
+    loop {
+        cycles += 1;
+        if carry {
+            let (sigma, next_carry) = add(tmpa, tmpb, bits);
+            tmpa = sigma;
+            carry = next_carry;
+            cycles += 2;
+        } else {
+            cycles += 1;
+        }
+
+        let (sigma, next_carry) = rcr(tmpa, carry, bits);
+        tmpa = sigma;
+        let (sigma, next_carry_2) = rcr(tmpc, next_carry, bits);
+        tmpc = sigma;
+        carry = next_carry_2;
+        cycles += 3;
+
+        if internal_counter == 0 {
+            break;
+        }
+
+        internal_counter -= 1;
+        cycles += 1;
+    }
+
+    cycles += 2;
+    (tmpa, tmpc, cycles)
+}
+
+fn pre_idiv_timing(
+    bits: u32,
+    tmpa: u16,
+    tmpb: u16,
+    tmpc: u16,
+    negate_flag: bool,
+) -> (u16, u16, u16, bool, i32) {
+    // 0x1b4: SIGMA->. (rcl dividend MSB) | 0x1b5: NCY 7
+    let mut cycles = 2;
+    let carry = sign_bit(tmpa, bits);
+    if !carry {
+        // Positive dividend: MC_JUMP into NEGATE @ line 7 (skip=true)
+        let (tmpa, tmpb, tmpc, _, negate_flag, extra) =
+            cor_negate_timing(bits, tmpa, tmpb, tmpc, negate_flag, true);
+        cycles += 1 + extra;
+        (tmpa, tmpb, tmpc, negate_flag, cycles)
+    } else {
+        // Negative dividend: fall into NEGATE (skip=false)
+        let (tmpa, tmpb, tmpc, _, negate_flag, extra) =
+            cor_negate_timing(bits, tmpa, tmpb, tmpc, negate_flag, false);
+        cycles += extra;
+        (tmpa, tmpb, tmpc, negate_flag, cycles)
+    }
+}
+
+fn post_idiv_timing(
+    bits: u32,
+    mut tmpa: u16,
+    tmpb: u16,
+    tmpc: u16,
+    carry: bool,
+    negate_flag: bool,
+) -> Result<((u16, u16), i32), i32> {
+    // 0x1c4: NCY INT0
+    let mut cycles = 1;
+    if !carry {
+        // Division exception (CORD flagged it via carry=false): MC_JUMP to INT0
+        return Err(cycles + 1);
+    }
+
+    // 0x1c5: LRCY tmpb | 0x1c6: SIGMA->. NEG tmpa | 0x1c7: NCY 5
+    let tmpb_sign = sign_bit(tmpb, bits);
+    let neg_tmpa = neg(tmpa, bits).0;
+    cycles += 3;
+    if !tmpb_sign {
+        // Divisor positive: MC_JUMP to 5
+        cycles += 1;
+    } else {
+        // Divisor negative: 0x1c8 SIGMA->tmpa (negate remainder)
+        tmpa = neg_tmpa;
+        cycles += 1;
+    }
+
+    // 0x1c9: INC tmpc | 0x1ca: F1 8
+    let mut sigma = tmpc.wrapping_add(1);
+    cycles += 2;
+    if !negate_flag {
+        // 0x1cb: COM tmpc (ones-complement)
+        sigma = !tmpc;
+        cycles += 1;
+    } else {
+        // MC_JUMP to 0x1cc
+        cycles += 1;
+    }
+
+    // 0x1cc: CCOF | MC_RTN
+    cycles += 2;
+    Ok(((tmpa, sigma), cycles))
+}
+
+fn cord_timing(bits: u32, mut tmpa: u16, tmpb: u16, mut tmpc: u16) -> DivisionTiming {
+    // 0x188: SUBT tmpa | 0x189: MAXC | 0x18a: NCY INT0
+    let mut cycles = 3;
+    let (_, mut carry) = sub(tmpa, tmpb, bits);
+    if !carry {
+        // Divide overflow on first compare: MC_JUMP to INT0
+        return DivisionTiming::Exception(cycles + 1);
+    }
+
+    let mut internal_counter = bits;
+    while internal_counter > 0 {
+        // 0x18b, 0x18c: RCLY tmpc, 0x18d: RCLY tmpa, 0x18e: NCY 8
+        let (sigma, next_carry) = rcl(tmpc, carry, bits);
+        tmpc = sigma;
+        let (sigma, next_carry_2) = rcl(tmpa, next_carry, bits);
+        tmpa = sigma;
+        carry = next_carry_2;
+        cycles += 4;
+
+        if carry {
+            // Path A (MSB of tmpa was set): divisor fits unconditionally.
+            // MC_JUMP, 0x195, 0x196: commit subtraction
+            cycles += 3;
+            carry = false;
+            tmpa = sub(tmpa, tmpb, bits).0;
+            internal_counter -= 1;
+            if internal_counter > 0 {
+                // MC_JUMP back to 0x18b
+                cycles += 1;
+                continue;
+            }
+            // Final iteration: 0x197, MC_JUMP to 0x192 trailer
+            cycles += 2;
+        } else {
+            // 0x18f: SUBT tmpa (trial subtract) | 0x190: NCY 14
+            let (sigma, next_carry) = sub(tmpa, tmpb, bits);
+            carry = next_carry;
+            cycles += 2;
+            if !carry {
+                // Path B1 (trial subtract succeeded): commit.
+                // MC_JUMP, 0x196
+                tmpa = sigma;
+                cycles += 2;
+                internal_counter -= 1;
+                if internal_counter > 0 {
+                    // MC_JUMP back to 0x18b
+                    cycles += 1;
+                    continue;
+                }
+                // Final iteration: 0x197, MC_JUMP to 0x192 trailer
+                cycles += 2;
+            } else {
+                // Path B2 (trial failed): do not commit.
+                // 0x191
+                cycles += 1;
+                internal_counter -= 1;
+                if internal_counter > 0 {
+                    // MC_JUMP back to 0x18b
+                    cycles += 1;
+                    continue;
+                }
+                // Final iteration: fall straight into 0x192 trailer (no extra)
+            }
+        }
+    }
+
+    // 0x192: RCLY tmpc | 0x193 | 0x194: CCOF | MC_RTN
+    let (sigma, next_carry) = rcl(tmpc, carry, bits);
+    tmpc = sigma;
+    let (_, carry) = rcl(tmpc, next_carry, bits);
+    DivisionTiming::Complete {
+        cycles: cycles + 4,
+        carry,
+    }
+}
+
+impl I8086 {
+    pub(super) fn mul8_timing(
+        &self,
+        al: u8,
+        operand: u8,
+        signed: bool,
+        mut negate_flag: bool,
+    ) -> i32 {
+        let mut cycles = 2;
+        let mut tmpc = al as u16;
+        let mut carry = sign_bit(tmpc, 8);
+        let mut tmpb = operand as u16;
+
+        if signed {
+            let (sigma, _) = neg(tmpc, 8);
+            cycles += 3;
+            if carry {
+                tmpc = sigma;
+                negate_flag = !negate_flag;
+                cycles += 3;
+            } else {
+                cycles += 1;
+            }
+
+            let (_, new_tmpb, new_tmpc, new_carry, new_negate_flag, extra) =
+                cor_negate_timing(8, 0, tmpb, tmpc, negate_flag, true);
+            tmpb = new_tmpb;
+            tmpc = new_tmpc;
+            carry = new_carry;
+            negate_flag = new_negate_flag;
+            cycles += extra;
+        }
+
+        cycles += 2;
+        let (mut tmpa, mut tmpc, extra) = corx_timing(8, tmpb, tmpc, carry);
+        cycles += extra;
+        cycles += 1;
+
+        if negate_flag {
+            let (new_tmpa, _, new_tmpc, _, _, extra) =
+                cor_negate_timing(8, tmpa, tmpb, tmpc, negate_flag, false);
+            tmpa = new_tmpa;
+            tmpc = new_tmpc;
+            cycles += 1 + extra;
+        }
+
+        cycles += 1;
+        if signed {
+            cycles += 1;
+            let carry = sign_bit(tmpc, 8);
+            let (sigma, _) = add(tmpa, 0, 8);
+            let sigma = sigma.wrapping_add(u16::from(carry)) & 0x00FF;
+            cycles += 3;
+            if sigma == 0 {
+                cycles += 4;
+            } else {
+                cycles += 3;
+            }
+            cycles += 2;
+        } else {
+            cycles += 6;
+            if tmpa == 0 {
+                cycles += 4;
+            } else {
+                cycles += 3;
+            }
+        }
+
+        cycles
+    }
+
+    pub(super) fn mul16_timing(
+        &self,
+        ax: u16,
+        operand: u16,
+        signed: bool,
+        mut negate_flag: bool,
+    ) -> i32 {
+        let mut cycles = 2;
+        let mut tmpc = ax;
+        let mut carry = sign_bit(tmpc, 16);
+        let mut tmpb = operand;
+
+        if signed {
+            let (sigma, _) = neg(tmpc, 16);
+            cycles += 3;
+            if carry {
+                tmpc = sigma;
+                negate_flag = !negate_flag;
+                cycles += 3;
+            } else {
+                cycles += 1;
+            }
+
+            let (_, new_tmpb, new_tmpc, new_carry, new_negate_flag, extra) =
+                cor_negate_timing(16, 0, tmpb, tmpc, negate_flag, true);
+            tmpb = new_tmpb;
+            tmpc = new_tmpc;
+            carry = new_carry;
+            negate_flag = new_negate_flag;
+            cycles += extra;
+        }
+
+        cycles += 2;
+        let (mut tmpa, mut tmpc, extra) = corx_timing(16, tmpb, tmpc, carry);
+        cycles += extra;
+        cycles += 1;
+
+        if negate_flag {
+            let (new_tmpa, _, new_tmpc, _, _, extra) =
+                cor_negate_timing(16, tmpa, tmpb, tmpc, negate_flag, false);
+            tmpa = new_tmpa;
+            tmpc = new_tmpc;
+            cycles += 1 + extra;
+        }
+
+        cycles += 1;
+        if signed {
+            cycles += 1;
+            let carry = sign_bit(tmpc, 16);
+            let (sigma, _) = add(tmpa, 0, 16);
+            let sigma = sigma.wrapping_add(u16::from(carry));
+            cycles += 3;
+            if sigma == 0 {
+                cycles += 4;
+            } else {
+                cycles += 3;
+            }
+            cycles += 2;
+        } else {
+            cycles += 6;
+            if tmpa == 0 {
+                cycles += 4;
+            } else {
+                cycles += 3;
+            }
+        }
+
+        cycles
+    }
+
+    pub(super) fn div8_timing(
+        &self,
+        dividend: u16,
+        divisor: u8,
+        signed: bool,
+        mut negate_flag: bool,
+    ) -> DivisionTiming {
+        // 0x160: A->tmpc | 0x161: M->tmpb | 0x162: X0 PREIDIV
+        let mut cycles = 3;
+        let mut tmpa = dividend >> 8;
+        let mut tmpc = dividend & 0x00FF;
+        let mut tmpb = divisor as u16;
+
+        if signed {
+            // MC_JUMP into PREIDIV
+            let (new_tmpa, new_tmpb, new_tmpc, new_negate_flag, extra) =
+                pre_idiv_timing(8, tmpa, tmpb, tmpc, negate_flag);
+            tmpa = new_tmpa;
+            tmpb = new_tmpb;
+            tmpc = new_tmpc;
+            negate_flag = new_negate_flag;
+            cycles += 1 + extra;
+        }
+
+        // 0x163: UNC CORD | MC_JUMP
+        cycles += 2;
+        match cord_timing(8, tmpa, tmpb, tmpc) {
+            // CORD signalled divide overflow already: no post-CORD cycles.
+            DivisionTiming::Exception(extra) => DivisionTiming::Exception(cycles + extra),
+            DivisionTiming::Complete {
+                cycles: extra,
+                carry,
+            } => {
+                cycles += extra;
+                // 0x164: COM1 tmpc | 0x165: X->tmpb X0 POSTDIV
+                cycles += 2;
+                if signed {
+                    // MC_JUMP into POSTIDIV
+                    cycles += 1;
+                    match post_idiv_timing(8, tmpa, dividend >> 8, tmpc, carry, negate_flag) {
+                        Ok((_, extra)) => DivisionTiming::Complete {
+                            cycles: cycles + extra,
+                            carry,
+                        },
+                        Err(extra) => DivisionTiming::Exception(cycles + extra),
+                    }
+                } else {
+                    DivisionTiming::Complete { cycles, carry }
+                }
+            }
+        }
+    }
+
+    pub(super) fn div16_timing(
+        &self,
+        dividend: u32,
+        divisor: u16,
+        signed: bool,
+        mut negate_flag: bool,
+    ) -> DivisionTiming {
+        // 0x168: DE->tmpa | 0x169: A->tmpc | 0x16a: M->tmpb X0 PREIDIV
+        let mut cycles = 3;
+        let mut tmpa = (dividend >> 16) as u16;
+        let mut tmpc = dividend as u16;
+        let mut tmpb = divisor;
+
+        if signed {
+            // MC_JUMP into PREIDIV
+            let (new_tmpa, new_tmpb, new_tmpc, new_negate_flag, extra) =
+                pre_idiv_timing(16, tmpa, tmpb, tmpc, negate_flag);
+            tmpa = new_tmpa;
+            tmpb = new_tmpb;
+            tmpc = new_tmpc;
+            negate_flag = new_negate_flag;
+            cycles += 1 + extra;
+        }
+
+        // 0x16b: UNC CORD | MC_JUMP
+        cycles += 2;
+        match cord_timing(16, tmpa, tmpb, tmpc) {
+            // CORD signalled divide overflow already: no post-CORD cycles.
+            DivisionTiming::Exception(extra) => DivisionTiming::Exception(cycles + extra),
+            DivisionTiming::Complete {
+                cycles: extra,
+                carry,
+            } => {
+                cycles += extra;
+                // 0x16c: COM1 tmpc | 0x16d: DE->tmpb X0 POSTDIV
+                cycles += 2;
+                if signed {
+                    // MC_JUMP into POSTIDIV
+                    cycles += 1;
+                    match post_idiv_timing(
+                        16,
+                        tmpa,
+                        (dividend >> 16) as u16,
+                        tmpc,
+                        carry,
+                        negate_flag,
+                    ) {
+                        Ok((_, extra)) => DivisionTiming::Complete {
+                            cycles: cycles + extra,
+                            carry,
+                        },
+                        Err(extra) => DivisionTiming::Exception(cycles + extra),
+                    }
+                } else {
+                    DivisionTiming::Complete { cycles, carry }
+                }
+            }
+        }
+    }
+}

--- a/crates/cpu/src/i8086/rep.rs
+++ b/crates/cpu/src/i8086/rep.rs
@@ -1,0 +1,240 @@
+use super::I8086;
+use crate::{SegReg16, WordReg};
+
+#[derive(Clone, Copy, PartialEq)]
+pub(super) enum RepType {
+    RepNe,
+    RepE,
+}
+
+impl I8086 {
+    fn start_rep(&mut self, rep_type: RepType, bus: &mut impl common::Bus) {
+        self.rep_restart_ip = self.prev_ip;
+        self.clk(bus, 1);
+        let next = self.fetch(bus);
+        self.start_rep_fetched(rep_type, next, bus);
+    }
+
+    pub(super) fn start_rep_with_opcode(
+        &mut self,
+        rep_type: RepType,
+        opcode: u8,
+        bus: &mut impl common::Bus,
+    ) {
+        self.rep_restart_ip = self.prev_ip;
+        self.start_rep_fetched(rep_type, opcode, bus);
+    }
+
+    fn start_rep_fetched(&mut self, rep_type: RepType, mut next: u8, bus: &mut impl common::Bus) {
+        let count = self.regs.word(WordReg::CX);
+
+        // Handle segment prefix after REP.
+        match next {
+            0x26 => {
+                self.seg_prefix = true;
+                self.prefix_seg = SegReg16::ES;
+                self.clk(bus, 1);
+                next = self.fetch(bus);
+            }
+            0x2E => {
+                self.seg_prefix = true;
+                self.prefix_seg = SegReg16::CS;
+                self.clk(bus, 1);
+                next = self.fetch(bus);
+            }
+            0x36 => {
+                self.seg_prefix = true;
+                self.prefix_seg = SegReg16::SS;
+                self.clk(bus, 1);
+                next = self.fetch(bus);
+            }
+            0x3E => {
+                self.seg_prefix = true;
+                self.prefix_seg = SegReg16::DS;
+                self.clk(bus, 1);
+                next = self.fetch(bus);
+            }
+            _ => {}
+        }
+
+        let startup = if matches!(next, 0xA4..=0xAF) {
+            if count == 0 { 5 } else { 8 }
+        } else {
+            0
+        };
+        self.clk(bus, startup);
+        self.do_rep(rep_type, next, bus);
+    }
+
+    fn do_rep(&mut self, rep_type: RepType, next: u8, bus: &mut impl common::Bus) {
+        // For non-string opcodes the REP/REPNE prefix does not iterate; it just
+        // sets the microcode F1 flag that MUL/IMUL/DIV/IDIV inspect to negate
+        // their operands. The instruction still executes exactly once regardless
+        // of CX, so dispatch it here before the string-loop bookkeeping.
+        if !matches!(next, 0xA4..=0xAF) {
+            self.rep_prefix = true;
+            self.dispatch(next, bus);
+            self.rep_prefix = false;
+            return;
+        }
+
+        let mut count = self.regs.word(WordReg::CX);
+
+        if count == 0 {
+            return;
+        }
+
+        let is_cmps_scas = matches!(next, 0xA6 | 0xA7 | 0xAE | 0xAF);
+
+        loop {
+            match next {
+                0xA4 => {
+                    self.movsb_body(bus);
+                    self.clk(bus, 2);
+                }
+                0xA5 => {
+                    self.movsw_body(bus);
+                    self.clk(bus, 2);
+                }
+                0xA6 => {
+                    self.cmpsb_body(bus);
+                }
+                0xA7 => {
+                    self.cmpsw_body(bus);
+                }
+                0xAA => {
+                    self.stosb_body(bus);
+                    self.clk(bus, 2);
+                }
+                0xAB => {
+                    self.stosw_body(bus);
+                    self.clk(bus, 2);
+                }
+                0xAC => {
+                    self.lodsb_body(bus);
+                    self.clk(bus, 3);
+                }
+                0xAD => {
+                    self.lodsw_body(bus);
+                    self.clk(bus, 3);
+                }
+                0xAE => {
+                    self.scasb_body(bus);
+                }
+                0xAF => {
+                    self.scasw_body(bus);
+                }
+                _ => {}
+            };
+
+            match next {
+                0xA4..=0xAF => {}
+                _ => {
+                    self.rep_prefix = true;
+                    self.dispatch(next, bus);
+                    self.rep_prefix = false;
+                    return;
+                }
+            }
+
+            match next {
+                0xA4 | 0xA5 => {
+                    count -= 1;
+                    self.clk(bus, 2);
+                    if count == 0 {
+                        break;
+                    }
+                    self.clk(bus, 1);
+                }
+                0xAA | 0xAB => {
+                    self.clk(bus, 1);
+                    count -= 1;
+                    self.clk(bus, 1);
+                    if count == 0 {
+                        break;
+                    }
+                    self.clk(bus, 1);
+                }
+                0xAC | 0xAD => {
+                    self.clk(bus, 2);
+                    count -= 1;
+                    self.clk(bus, 1);
+                    if count == 0 {
+                        break;
+                    }
+                    self.clk(bus, 1);
+                }
+                0xA6 | 0xA7 | 0xAE | 0xAF => {
+                    count -= 1;
+                    self.clk(bus, 1);
+                    let terminate = if is_cmps_scas {
+                        match rep_type {
+                            RepType::RepNe => self.flags.zf(),
+                            RepType::RepE => !self.flags.zf(),
+                        }
+                    } else {
+                        false
+                    };
+
+                    if terminate {
+                        self.clk(bus, 1);
+                        break;
+                    }
+
+                    self.clk(bus, 2);
+                    if count == 0 {
+                        break;
+                    }
+                    self.clk(bus, 1);
+                }
+                _ => unreachable!(),
+            }
+
+            self.cycles_remaining -= bus.drain_wait_cycles();
+
+            let consumed = (self.run_budget as i64 - self.cycles_remaining) as u64;
+            bus.set_current_cycle(self.run_start_cycle + consumed);
+
+            let interrupt_pending = bus.has_nmi() || (self.flags.if_flag && bus.has_irq());
+
+            if self.cycles_remaining <= 0 || interrupt_pending {
+                // Save state for resume.
+                self.rep_active = true;
+                self.rep_ip = self.ip;
+                self.rep_seg_prefix = self.seg_prefix;
+                self.rep_prefix_seg = self.prefix_seg;
+                self.rep_opcode = next;
+                self.rep_type = match rep_type {
+                    RepType::RepNe => 1,
+                    RepType::RepE => 0,
+                };
+                self.regs.set_word(WordReg::CX, count);
+                return;
+            }
+        }
+
+        self.regs.set_word(WordReg::CX, count);
+        self.seg_prefix = false;
+    }
+
+    pub(super) fn continue_rep(&mut self, bus: &mut impl common::Bus) {
+        self.ip = self.rep_ip;
+        self.seg_prefix = self.rep_seg_prefix;
+        self.prefix_seg = self.rep_prefix_seg;
+        let next = self.rep_opcode;
+        self.rep_active = false;
+        let rep_type = match self.rep_type {
+            1 => RepType::RepNe,
+            _ => RepType::RepE,
+        };
+        self.do_rep(rep_type, next, bus);
+    }
+
+    pub(super) fn repne(&mut self, bus: &mut impl common::Bus) {
+        self.start_rep(RepType::RepNe, bus);
+    }
+
+    pub(super) fn repe(&mut self, bus: &mut impl common::Bus) {
+        self.start_rep(RepType::RepE, bus);
+    }
+}

--- a/crates/cpu/src/i8086/state.rs
+++ b/crates/cpu/src/i8086/state.rs
@@ -1,0 +1,189 @@
+use super::{I8086, flags::I8086Flags};
+use crate::{ByteReg, RegisterFile16, SegReg16, WordReg};
+
+/// Snapshot of all I8086 CPU registers and flags.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct I8086State {
+    /// General-purpose register file.
+    pub regs: RegisterFile16,
+    /// Segment registers: ES, CS, SS, DS.
+    pub sregs: [u16; 4],
+    /// Instruction pointer.
+    pub ip: u16,
+    /// CPU flags.
+    pub flags: I8086Flags,
+}
+
+impl I8086State {
+    /// Returns the AX register.
+    pub fn ax(&self) -> u16 {
+        self.regs.word(WordReg::AX)
+    }
+
+    /// Sets the AX register.
+    pub fn set_ax(&mut self, v: u16) {
+        self.regs.set_word(WordReg::AX, v);
+    }
+
+    /// Returns the CX register.
+    pub fn cx(&self) -> u16 {
+        self.regs.word(WordReg::CX)
+    }
+
+    /// Sets the CX register.
+    pub fn set_cx(&mut self, v: u16) {
+        self.regs.set_word(WordReg::CX, v);
+    }
+
+    /// Returns the DX register.
+    pub fn dx(&self) -> u16 {
+        self.regs.word(WordReg::DX)
+    }
+
+    /// Sets the DX register.
+    pub fn set_dx(&mut self, v: u16) {
+        self.regs.set_word(WordReg::DX, v);
+    }
+
+    /// Returns the BX register.
+    pub fn bx(&self) -> u16 {
+        self.regs.word(WordReg::BX)
+    }
+
+    /// Sets the BX register.
+    pub fn set_bx(&mut self, v: u16) {
+        self.regs.set_word(WordReg::BX, v);
+    }
+
+    /// Returns the SP register.
+    pub fn sp(&self) -> u16 {
+        self.regs.word(WordReg::SP)
+    }
+
+    /// Sets the SP register.
+    pub fn set_sp(&mut self, v: u16) {
+        self.regs.set_word(WordReg::SP, v);
+    }
+
+    /// Returns the BP register.
+    pub fn bp(&self) -> u16 {
+        self.regs.word(WordReg::BP)
+    }
+
+    /// Sets the BP register.
+    pub fn set_bp(&mut self, v: u16) {
+        self.regs.set_word(WordReg::BP, v);
+    }
+
+    /// Returns the SI register.
+    pub fn si(&self) -> u16 {
+        self.regs.word(WordReg::SI)
+    }
+
+    /// Sets the SI register.
+    pub fn set_si(&mut self, v: u16) {
+        self.regs.set_word(WordReg::SI, v);
+    }
+
+    /// Returns the DI register.
+    pub fn di(&self) -> u16 {
+        self.regs.word(WordReg::DI)
+    }
+
+    /// Sets the DI register.
+    pub fn set_di(&mut self, v: u16) {
+        self.regs.set_word(WordReg::DI, v);
+    }
+
+    /// Returns the ES segment register.
+    pub fn es(&self) -> u16 {
+        self.sregs[SegReg16::ES as usize]
+    }
+
+    /// Sets the ES segment register.
+    pub fn set_es(&mut self, v: u16) {
+        self.sregs[SegReg16::ES as usize] = v;
+    }
+
+    /// Returns the CS segment register.
+    pub fn cs(&self) -> u16 {
+        self.sregs[SegReg16::CS as usize]
+    }
+
+    /// Sets the CS segment register.
+    pub fn set_cs(&mut self, v: u16) {
+        self.sregs[SegReg16::CS as usize] = v;
+    }
+
+    /// Returns the SS segment register.
+    pub fn ss(&self) -> u16 {
+        self.sregs[SegReg16::SS as usize]
+    }
+
+    /// Sets the SS segment register.
+    pub fn set_ss(&mut self, v: u16) {
+        self.sregs[SegReg16::SS as usize] = v;
+    }
+
+    /// Returns the DS segment register.
+    pub fn ds(&self) -> u16 {
+        self.sregs[SegReg16::DS as usize]
+    }
+
+    /// Sets the DS segment register.
+    pub fn set_ds(&mut self, v: u16) {
+        self.sregs[SegReg16::DS as usize] = v;
+    }
+
+    /// Returns the compressed flags register value.
+    pub fn compressed_flags(&self) -> u16 {
+        self.flags.compress()
+    }
+
+    /// Sets all flags from a compressed flags value.
+    pub fn set_compressed_flags(&mut self, v: u16) {
+        self.flags.expand(v);
+    }
+}
+
+impl I8086 {
+    /// Loads CPU state from a snapshot, resetting runtime flags.
+    pub fn load_state(&mut self, state: &I8086State) {
+        self.state = state.clone();
+        self.halted = false;
+        self.pending_irq = 0;
+        self.no_interrupt = 0;
+        self.inhibit_all = 0;
+        self.rep_active = false;
+        self.rep_restart_ip = 0;
+        self.rep_prefix = false;
+        self.seg_prefix = false;
+        self.flush_prefetch_queue();
+        self.reset_instruction_timing();
+    }
+
+    /// Returns the AL register value.
+    pub fn al(&self) -> u8 {
+        self.regs.byte(ByteReg::AL)
+    }
+
+    /// Returns the AH register value.
+    pub fn ah(&self) -> u8 {
+        self.regs.byte(ByteReg::AH)
+    }
+
+    /// Returns the CL register value.
+    pub fn cl(&self) -> u8 {
+        self.regs.byte(ByteReg::CL)
+    }
+
+    /// Returns the instruction pointer.
+    pub fn ip(&self) -> u16 {
+        self.ip
+    }
+
+    /// Returns the compressed flags register value.
+    pub fn flags_register(&self) -> u16 {
+        self.flags.compress()
+    }
+}

--- a/crates/cpu/src/i8086/string_ops.rs
+++ b/crates/cpu/src/i8086/string_ops.rs
@@ -1,0 +1,242 @@
+use super::{I8086, StepFinishCycle, biu::ADDRESS_MASK};
+use crate::{ByteReg, SegReg16, WordReg};
+
+impl I8086 {
+    fn direction_delta(&self) -> u16 {
+        if self.flags.df { 0xFFFF } else { 1 }
+    }
+
+    fn direction_delta_word(&self) -> u16 {
+        if self.flags.df { 0xFFFE } else { 2 }
+    }
+
+    pub(super) fn movsb_body(&mut self, bus: &mut impl common::Bus) {
+        let si = self.regs.word(WordReg::SI);
+        let di = self.regs.word(WordReg::DI);
+        let src_addr = self.default_base(SegReg16::DS).wrapping_add(si as u32) & ADDRESS_MASK;
+        let dst_addr = self.seg_base(SegReg16::ES).wrapping_add(di as u32) & ADDRESS_MASK;
+        let val = self.read_memory_byte(bus, src_addr);
+        self.clk(bus, 1);
+        self.write_memory_byte(bus, dst_addr, val);
+        let delta = self.direction_delta();
+        self.regs.set_word(WordReg::SI, si.wrapping_add(delta));
+        let delta = self.direction_delta();
+        self.regs.set_word(WordReg::DI, di.wrapping_add(delta));
+    }
+
+    pub(super) fn movsw_body(&mut self, bus: &mut impl common::Bus) {
+        let si = self.regs.word(WordReg::SI);
+        let di = self.regs.word(WordReg::DI);
+        let src_seg = if self.seg_prefix {
+            self.prefix_seg
+        } else {
+            SegReg16::DS
+        };
+        let val = self.read_word_seg(bus, src_seg, si);
+        self.clk(bus, 1);
+        self.write_word_seg(bus, SegReg16::ES, di, val);
+        let delta = self.direction_delta_word();
+        self.regs.set_word(WordReg::SI, si.wrapping_add(delta));
+        let delta = self.direction_delta_word();
+        self.regs.set_word(WordReg::DI, di.wrapping_add(delta));
+    }
+
+    pub(super) fn cmpsb_body(&mut self, bus: &mut impl common::Bus) {
+        let si = self.regs.word(WordReg::SI);
+        let di = self.regs.word(WordReg::DI);
+        let src_addr = self.default_base(SegReg16::DS).wrapping_add(si as u32) & ADDRESS_MASK;
+        let dst_addr = self.seg_base(SegReg16::ES).wrapping_add(di as u32) & ADDRESS_MASK;
+        self.clk(bus, 1);
+        let src = self.read_memory_byte(bus, src_addr);
+        self.clk(bus, 2);
+        let dst = self.read_memory_byte(bus, dst_addr);
+        self.clk(bus, 3);
+        self.alu_sub_byte(src, dst);
+        let delta = self.direction_delta();
+        self.regs.set_word(WordReg::SI, si.wrapping_add(delta));
+        let delta = self.direction_delta();
+        self.regs.set_word(WordReg::DI, di.wrapping_add(delta));
+    }
+
+    pub(super) fn cmpsw_body(&mut self, bus: &mut impl common::Bus) {
+        let si = self.regs.word(WordReg::SI);
+        let di = self.regs.word(WordReg::DI);
+        let src_seg = if self.seg_prefix {
+            self.prefix_seg
+        } else {
+            SegReg16::DS
+        };
+        self.clk(bus, 1);
+        let src = self.read_word_seg(bus, src_seg, si);
+        self.clk(bus, 2);
+        let dst = self.read_word_seg(bus, SegReg16::ES, di);
+        self.clk(bus, 3);
+        self.alu_sub_word(src, dst);
+        let delta = self.direction_delta_word();
+        self.regs.set_word(WordReg::SI, si.wrapping_add(delta));
+        let delta = self.direction_delta_word();
+        self.regs.set_word(WordReg::DI, di.wrapping_add(delta));
+    }
+
+    pub(super) fn stosb_body(&mut self, bus: &mut impl common::Bus) {
+        let di = self.regs.word(WordReg::DI);
+        let addr = self.seg_base(SegReg16::ES).wrapping_add(di as u32) & ADDRESS_MASK;
+        self.write_memory_byte(bus, addr, self.regs.byte(ByteReg::AL));
+        let delta = self.direction_delta();
+        self.regs.set_word(WordReg::DI, di.wrapping_add(delta));
+    }
+
+    pub(super) fn stosw_body(&mut self, bus: &mut impl common::Bus) {
+        let di = self.regs.word(WordReg::DI);
+        self.write_word_seg(bus, SegReg16::ES, di, self.regs.word(WordReg::AX));
+        let delta = self.direction_delta_word();
+        self.regs.set_word(WordReg::DI, di.wrapping_add(delta));
+    }
+
+    pub(super) fn lodsb_body(&mut self, bus: &mut impl common::Bus) {
+        let si = self.regs.word(WordReg::SI);
+        let addr = self.default_base(SegReg16::DS).wrapping_add(si as u32) & ADDRESS_MASK;
+        let val = self.read_memory_byte(bus, addr);
+        self.regs.set_byte(ByteReg::AL, val);
+        let delta = self.direction_delta();
+        self.regs.set_word(WordReg::SI, si.wrapping_add(delta));
+    }
+
+    pub(super) fn lodsw_body(&mut self, bus: &mut impl common::Bus) {
+        let si = self.regs.word(WordReg::SI);
+        let seg = if self.seg_prefix {
+            self.prefix_seg
+        } else {
+            SegReg16::DS
+        };
+        let val = self.read_word_seg(bus, seg, si);
+        self.regs.set_word(WordReg::AX, val);
+        let delta = self.direction_delta_word();
+        self.regs.set_word(WordReg::SI, si.wrapping_add(delta));
+    }
+
+    pub(super) fn scasb_body(&mut self, bus: &mut impl common::Bus) {
+        let di = self.regs.word(WordReg::DI);
+        let addr = self.seg_base(SegReg16::ES).wrapping_add(di as u32) & ADDRESS_MASK;
+        self.clk(bus, 1);
+        let dst = self.read_memory_byte(bus, addr);
+        self.clk(bus, 1);
+        self.clk(bus, 3);
+        let al = self.regs.byte(ByteReg::AL);
+        self.alu_sub_byte(al, dst);
+        let delta = self.direction_delta();
+        self.regs.set_word(WordReg::DI, di.wrapping_add(delta));
+    }
+
+    pub(super) fn scasw_body(&mut self, bus: &mut impl common::Bus) {
+        let di = self.regs.word(WordReg::DI);
+        self.clk(bus, 1);
+        let dst = self.read_word_seg(bus, SegReg16::ES, di);
+        self.clk(bus, 1);
+        self.clk(bus, 3);
+        let aw = self.regs.word(WordReg::AX);
+        self.alu_sub_word(aw, dst);
+        let delta = self.direction_delta_word();
+        self.regs.set_word(WordReg::DI, di.wrapping_add(delta));
+    }
+
+    pub(super) fn movsb(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 1);
+        self.movsb_body(bus);
+        self.clk(bus, 3);
+        if self.seg_prefix
+            && !self.instruction_entry_queue_full()
+            && self.next_instruction_uses_prefetched_high_byte()
+        {
+            self.clk(bus, 1);
+        }
+    }
+
+    pub(super) fn movsw(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 1);
+        self.movsw_body(bus);
+        self.clk(bus, 3);
+        if self.seg_prefix
+            && !self.instruction_entry_queue_full()
+            && self.next_instruction_uses_prefetched_high_byte()
+        {
+            self.clk(bus, 1);
+        }
+    }
+
+    pub(super) fn cmpsb(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 1);
+        self.cmpsb_body(bus);
+        if !self.seg_prefix
+            && self.instruction_entry_queue_full()
+            && self.next_instruction_uses_prefetched_high_byte()
+        {
+            self.clk(bus, 1);
+        }
+    }
+
+    pub(super) fn cmpsw(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 1);
+        self.cmpsw_body(bus);
+        if !self.seg_prefix
+            && self.instruction_entry_queue_full()
+            && self.next_instruction_uses_prefetched_high_byte()
+        {
+            self.clk(bus, 1);
+        }
+    }
+
+    pub(super) fn stosb(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 1);
+        self.stosb_body(bus);
+        self.clk(bus, 4);
+        if !self.seg_prefix && self.instruction_entry_queue_full() {
+            self.step_finish_cycle = StepFinishCycle::TerminalWritebackInlineCommit;
+        }
+    }
+
+    pub(super) fn stosw(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 1);
+        self.stosw_body(bus);
+        self.clk(bus, 4);
+        if !self.seg_prefix && self.instruction_entry_queue_full() {
+            self.step_finish_cycle = StepFinishCycle::TerminalWritebackInlineCommit;
+        }
+    }
+
+    pub(super) fn lodsb(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 1);
+        self.lodsb_body(bus);
+        self.clk(bus, 4);
+        if !self.seg_prefix && self.instruction_entry_queue_full() {
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        }
+    }
+
+    pub(super) fn lodsw(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 1);
+        self.lodsw_body(bus);
+        self.clk(bus, 4);
+        if !self.seg_prefix && self.instruction_entry_queue_full() {
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        }
+    }
+
+    pub(super) fn scasb(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 1);
+        self.scasb_body(bus);
+        self.clk(bus, 1);
+        if self.seg_prefix && self.next_instruction_uses_prefetched_high_byte() {
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        }
+    }
+
+    pub(super) fn scasw(&mut self, bus: &mut impl common::Bus) {
+        self.clk(bus, 1);
+        self.scasw_body(bus);
+        self.clk(bus, 1);
+        if self.seg_prefix && self.next_instruction_uses_prefetched_high_byte() {
+            self.step_finish_cycle = StepFinishCycle::PreloadedOnly;
+        }
+    }
+}

--- a/crates/cpu/src/lib.rs
+++ b/crates/cpu/src/lib.rs
@@ -1,15 +1,49 @@
-//! Implements the CPU emulation.
+//! # CPU emulation
+//!
+//! Each CPU core should be it's own unit with only limited core sharing.
+//! This is a deliberate decision, so that CPUs can evolve independently.
+//!
+//! All CPUs are verified with the help of [the SingleStepTests](https://github.com/SingleStepTests/),
+//! when available. The 386/486 also are verified against [test386.asm](https://github.com/barotto/test386.asm).
+//!
+//! ## Timing Scope
+//!
+//! The goal of these cores is to be cycle-count accuract (if possible) at the instruction and
+//! machine-model level so that software runs at the correct overall speed on the emulated PC-98
+//! configuration.
+//!
+//! We intentionally do not optimize for sub-cycle or bus-phase accurate wait state placement
+//! inside an instruction. PC-98 software could not reliably depend on such behavior because
+//! the platform existed across many machine generations, CPU models, clock speeds, and wait-state
+//! configurations (as oposed to console developers on the NES, Sega Master System and maybe the
+//! C64).
+//!
+//! Preserving correct total cycle cost is the priority; modeling exactly where a wait lands
+//! between internal clock counts is not.
+//!
+//! ## Supported CPUs
+//!
+//! | CPU   | Functionality verified | Cycle-count accurate | Uses datasheet timings |
+//! |-------|------------------------|----------------------|------------------------|
+//! | 8086  | Yes                    | Yes                  | No                     |
+//! | V30   | Yes                    | No                   | Yes                    |
+//! | 80286 | Yes                    | No                   | Yes                    |
+//! | 80386 | Yes                    | No                   | Yes                    |
+//! | 80486 | Yes                    | No                   | Yes                    |
+//! | Z80   | Yes                    | Yes                  | No                     |
 
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
 
 mod i286;
 mod i386;
+mod i8086;
 mod v30;
 mod z80;
 
 pub use i286::{I286, I286Flags, I286State};
 pub use i386::{CPU_MODEL_386, CPU_MODEL_486, I386, I386Flags, I386State};
+pub use i8086::{I8086, I8086Flags, I8086State, PC9801F_CPU_CLOCK_5MHZ, PC9801F_CPU_CLOCK_8MHZ};
 pub use v30::{V30, V30Flags, V30State};
 pub use z80::{Z80, Z80Flags, Z80State};
 

--- a/crates/cpu/src/z80.rs
+++ b/crates/cpu/src/z80.rs
@@ -239,7 +239,7 @@ impl Z80 {
     }
 }
 
-impl common::CpuZ80 for Z80 {
+impl CpuZ80 for Z80 {
     fn run_for(&mut self, cycles_to_run: u64, bus: &mut impl common::Bus) -> u64 {
         let start_cycle = bus.current_cycle();
         self.run_start_cycle = start_cycle;

--- a/crates/cpu/tests/common/verification_common.rs
+++ b/crates/cpu/tests/common/verification_common.rs
@@ -9,6 +9,7 @@ use zlib_rs::{InflateConfig, ReturnCode, decompress_slice};
 pub struct MooState {
     pub regs: HashMap<String, u32>,
     pub ram: Vec<(u32, u8)>,
+    pub queue: Vec<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -108,6 +109,12 @@ fn parse_ram(payload: &[u8]) -> Vec<(u32, u8)> {
     entries
 }
 
+fn parse_queue(payload: &[u8]) -> Vec<u8> {
+    let mut offset = 0;
+    let count = read_u32(payload, &mut offset) as usize;
+    payload[offset..offset + count].to_vec()
+}
+
 fn parse_cycles(payload: &[u8]) -> Vec<MooCycle> {
     let mut offset = 0;
     let count = read_u32(payload, &mut offset) as usize;
@@ -160,6 +167,7 @@ fn parse_cpu_state(payload: &[u8], reg_order16: &[&str], reg_order32: &[&str]) -
     let mut offset = 0;
     let mut regs = HashMap::new();
     let mut ram = Vec::new();
+    let mut queue = Vec::new();
 
     while offset < payload.len() {
         let tag = read_tag(payload, &mut offset);
@@ -171,14 +179,15 @@ fn parse_cpu_state(payload: &[u8], reg_order16: &[&str], reg_order32: &[&str]) -
             b"REGS" => regs = parse_regs16(sub_payload, reg_order16),
             b"RG32" => regs = parse_regs32(sub_payload, reg_order32),
             b"RAM " => ram = parse_ram(sub_payload),
-            b"QUEU" | b"EA32" => {}
+            b"QUEU" => queue = parse_queue(sub_payload),
+            b"EA32" => {}
             _ => {}
         }
 
         offset = end;
     }
 
-    MooState { regs, ram }
+    MooState { regs, ram, queue }
 }
 
 fn bytes_to_hex(bytes: &[u8]) -> String {
@@ -197,10 +206,12 @@ fn parse_test_chunk(payload: &[u8], reg_order16: &[&str], reg_order32: &[&str]) 
     let mut initial = MooState {
         regs: HashMap::new(),
         ram: Vec::new(),
+        queue: Vec::new(),
     };
     let mut final_state = MooState {
         regs: HashMap::new(),
         ram: Vec::new(),
+        queue: Vec::new(),
     };
     let mut cycles = Vec::new();
     let mut ports = Vec::new();

--- a/crates/cpu/tests/undefined_i8086.rs
+++ b/crates/cpu/tests/undefined_i8086.rs
@@ -1,0 +1,238 @@
+use common::{Bus as _, Cpu as _};
+use cpu::{I8086, I8086State};
+
+const RAM_SIZE: usize = 1024 * 1024;
+const ADDRESS_MASK: u32 = 0x000F_FFFF;
+
+struct TestBus {
+    ram: Vec<u8>,
+}
+
+impl TestBus {
+    fn new() -> Self {
+        Self {
+            ram: vec![0u8; RAM_SIZE],
+        }
+    }
+}
+
+impl common::Bus for TestBus {
+    fn read_byte(&mut self, address: u32) -> u8 {
+        self.ram[(address & ADDRESS_MASK) as usize]
+    }
+
+    fn write_byte(&mut self, address: u32, value: u8) {
+        self.ram[(address & ADDRESS_MASK) as usize] = value;
+    }
+
+    fn io_read_byte(&mut self, _port: u16) -> u8 {
+        0xFF
+    }
+
+    fn io_write_byte(&mut self, _port: u16, _value: u8) {}
+
+    fn has_irq(&self) -> bool {
+        false
+    }
+
+    fn acknowledge_irq(&mut self) -> u8 {
+        0
+    }
+
+    fn has_nmi(&self) -> bool {
+        false
+    }
+
+    fn acknowledge_nmi(&mut self) {}
+
+    fn current_cycle(&self) -> u64 {
+        0
+    }
+
+    fn set_current_cycle(&mut self, _cycle: u64) {}
+}
+
+fn place_code(bus: &mut TestBus, cs: u16, ip: u16, code: &[u8]) {
+    let base = (cs as u32) << 4;
+    for (index, &byte) in code.iter().enumerate() {
+        bus.write_byte(base + ip as u32 + index as u32, byte);
+    }
+}
+
+fn setup_state(cs: u16, ip: u16) -> I8086State {
+    let mut state = I8086State::default();
+    state.set_cs(cs);
+    state.set_ss(0x2000);
+    state.set_ds(0x3000);
+    state.set_es(0x4000);
+    state.set_sp(0x0100);
+    state.ip = ip;
+    state
+}
+
+#[test]
+fn i8086_f1_is_a_lock_prefix_alias() {
+    let mut cpu = I8086::new();
+    let mut bus = TestBus::new();
+
+    place_code(&mut bus, 0x1000, 0x0000, &[0xF1, 0x90, 0xF4]);
+
+    let state = setup_state(0x1000, 0x0000);
+    cpu.load_state(&state);
+
+    cpu.step(&mut bus);
+
+    assert_eq!(cpu.ip(), 0x0002, "F1 should prefix the following opcode");
+    assert!(!cpu.halted(), "F1 NOP should not halt the CPU");
+}
+
+#[test]
+fn i8086_rep_handles_multiple_segment_prefixes() {
+    let mut cpu = I8086::new();
+    let mut bus = TestBus::new();
+
+    place_code(&mut bus, 0x1000, 0x0000, &[0xF3, 0x26, 0x2E, 0xA4]);
+    bus.write_byte((0x1000u32 << 4) + 0x0010, 0xAA);
+    bus.write_byte((0x4000u32 << 4) + 0x0010, 0x55);
+
+    let mut state = setup_state(0x1000, 0x0000);
+    state.set_cx(1);
+    state.set_si(0x0010);
+    state.set_di(0x0020);
+    cpu.load_state(&state);
+
+    cpu.step(&mut bus);
+
+    assert_eq!(
+        bus.ram[((0x4000u32 << 4) + 0x0020) as usize],
+        0xAA,
+        "the last segment override must win after REP"
+    );
+    assert_eq!(cpu.cx(), 0, "REP MOVSB should consume CX");
+}
+
+#[test]
+fn i8086_fe_call_register_uses_widened_byte_operand() {
+    let mut cpu = I8086::new();
+    let mut bus = TestBus::new();
+
+    place_code(&mut bus, 0x1000, 0x0000, &[0xFE, 0xD7]);
+    bus.write_byte((0x2000u32 << 4) + 0x00FF, 0x7A);
+
+    let mut state = setup_state(0x1000, 0x0000);
+    state.set_bx(0xE2D8);
+    cpu.load_state(&state);
+
+    cpu.step(&mut bus);
+
+    assert_eq!(cpu.ip(), 0xD8E2, "CALL BH should use BX with swapped bytes");
+    assert_eq!(cpu.sp(), 0x00FE, "CALL should push a return address");
+    let stack_address = ((0x2000u32 << 4) + 0x00FE) as usize;
+    assert_eq!(bus.ram[stack_address], 0x02);
+    assert_eq!(bus.ram[stack_address + 1], 0x7A);
+}
+
+#[test]
+fn i8086_fe_push_byte_writes_one_stack_byte() {
+    let mut cpu = I8086::new();
+    let mut bus = TestBus::new();
+
+    place_code(&mut bus, 0x1000, 0x0000, &[0xFE, 0x36, 0x00, 0x10]);
+    bus.write_byte((0x3000u32 << 4) + 0x1000, 0x23);
+    bus.write_byte((0x2000u32 << 4) + 0x00FF, 0x7A);
+
+    let state = setup_state(0x1000, 0x0000);
+    cpu.load_state(&state);
+
+    cpu.step(&mut bus);
+
+    assert_eq!(cpu.sp(), 0x00FE, "PUSH byte should still decrement SP by 2");
+    let stack_address = ((0x2000u32 << 4) + 0x00FE) as usize;
+    assert_eq!(bus.ram[stack_address], 0x23, "low byte should be written");
+    assert_eq!(
+        bus.ram[stack_address + 1],
+        0x7A,
+        "high byte should remain untouched"
+    );
+}
+
+#[test]
+fn i8086_fe_callf_register_uses_prefetch_dependent_ip_handoff() {
+    let mut cpu = I8086::new();
+    let mut bus = TestBus::new();
+
+    place_code(&mut bus, 0x4177, 0x1234, &[0xFE, 0xD9]);
+    bus.write_byte((0x3000u32 << 4) + 0x0004, 0xB5);
+    bus.write_byte((0x2000u32 << 4) + 0x00FD, 0x7A);
+    bus.write_byte((0x2000u32 << 4) + 0x00FF, 0x6C);
+
+    let state = setup_state(0x4177, 0x1234);
+    cpu.load_state(&state);
+
+    cpu.step(&mut bus);
+
+    assert_eq!(cpu.cs(), 0xFFB5);
+    assert_eq!(cpu.ip(), 0x1234);
+    assert_eq!(cpu.sp(), 0x00FC);
+    let stack_address = ((0x2000u32 << 4) + 0x00FC) as usize;
+    assert_eq!(bus.ram[stack_address], 0x36);
+    assert_eq!(bus.ram[stack_address + 1], 0x7A);
+    assert_eq!(bus.ram[stack_address + 2], 0x77);
+    assert_eq!(bus.ram[stack_address + 3], 0x6C);
+}
+
+#[test]
+fn i8086_ff_jmpf_register_uses_prefetch_dependent_ip_handoff() {
+    let mut cpu = I8086::new();
+    let mut bus = TestBus::new();
+
+    place_code(&mut bus, 0x1000, 0x1234, &[0xFF, 0xE8]);
+    bus.write_byte((0x3000u32 << 4) + 0x0004, 0x34);
+    bus.write_byte((0x3000u32 << 4) + 0x0005, 0x12);
+
+    let state = setup_state(0x1000, 0x1234);
+    cpu.load_state(&state);
+    cpu.install_prefetch_queue(&[0xFF, 0xE8, 0x90, 0x90]);
+
+    cpu.step(&mut bus);
+
+    assert_eq!(cpu.cs(), 0x1234);
+    assert_eq!(cpu.ip(), 0x1230);
+    assert_eq!(cpu.sp(), 0x0100);
+}
+
+#[test]
+fn i8086_pop_rm_overlap_matches_undefined_corpus_final_state() {
+    let mut cpu = I8086::new();
+    let mut bus = TestBus::new();
+
+    place_code(&mut bus, 0x09FC, 0xF8C0, &[0x36, 0x8F, 0x79, 0xB2]);
+
+    let mut state = I8086State::default();
+    state.set_ax(0xF382);
+    state.set_bx(0x0A25);
+    state.set_cx(0x3DB2);
+    state.set_dx(0x76CB);
+    state.set_cs(0x09FC);
+    state.set_ss(0x300B);
+    state.set_ds(0x62EF);
+    state.set_es(0x432E);
+    state.set_sp(0x59DF);
+    state.set_bp(0x6C9F);
+    state.set_si(0xF282);
+    state.set_di(0x5009);
+    state.ip = 0xF8C0;
+    state.set_compressed_flags(0xF082);
+
+    bus.write_byte(0x35A8F, 0x56);
+    bus.write_byte(0x35A90, 0x56);
+
+    cpu.load_state(&state);
+
+    cpu.step(&mut bus);
+
+    assert_eq!(cpu.sp(), 0x59E1);
+    assert_eq!(cpu.ip(), 0xF8C4);
+    assert_eq!(bus.ram[0x35A90], 0x56);
+    assert_eq!(bus.ram[0x35A91], 0x56);
+}

--- a/crates/cpu/tests/verification_i8086.rs
+++ b/crates/cpu/tests/verification_i8086.rs
@@ -1,0 +1,1215 @@
+#![cfg(feature = "verification")]
+
+#[path = "common/metadata_json.rs"]
+mod metadata_json;
+#[path = "common/verification_common.rs"]
+mod verification_common;
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::LazyLock,
+};
+
+use common::Cpu as _;
+use cpu::{I8086, I8086State};
+use metadata_json::{Metadata, load_metadata};
+use verification_common::{MooState, load_moo_tests};
+
+const RAM_SIZE: usize = 1_048_576;
+const ADDRESS_MASK: u32 = 0x000F_FFFF;
+const REG_ORDER_I8086: [&str; 14] = [
+    "ax", "bx", "cx", "dx", "cs", "ss", "ds", "es", "sp", "bp", "si", "di", "ip", "flags",
+];
+
+struct TestBus {
+    ram: Box<[u8]>,
+    dirty: Vec<u32>,
+    dirty_marker: Box<[u8]>,
+    current_cycle: u64,
+    wait_cycles: i64,
+}
+
+impl TestBus {
+    fn new() -> Self {
+        Self {
+            ram: vec![0u8; RAM_SIZE].into_boxed_slice(),
+            dirty: Vec::new(),
+            dirty_marker: vec![0u8; RAM_SIZE].into_boxed_slice(),
+            current_cycle: 0,
+            wait_cycles: 0,
+        }
+    }
+
+    fn clear(&mut self) {
+        for &address in &self.dirty {
+            let index = (address & ADDRESS_MASK) as usize;
+            self.ram[index] = 0;
+            self.dirty_marker[index] = 0;
+        }
+        self.dirty.clear();
+        self.current_cycle = 0;
+        self.wait_cycles = 0;
+    }
+
+    fn set_memory(&mut self, address: u32, value: u8) {
+        let masked_address = address & ADDRESS_MASK;
+        let index = masked_address as usize;
+        if self.dirty_marker[index] == 0 {
+            self.dirty_marker[index] = 1;
+            self.dirty.push(masked_address);
+        }
+        self.ram[index] = value;
+    }
+}
+
+impl common::Bus for TestBus {
+    fn read_byte(&mut self, address: u32) -> u8 {
+        self.ram[(address & ADDRESS_MASK) as usize]
+    }
+
+    fn write_byte(&mut self, address: u32, value: u8) {
+        self.set_memory(address, value);
+    }
+
+    fn io_read_byte(&mut self, port: u16) -> u8 {
+        let _ = port;
+        0xFF
+    }
+
+    fn io_write_byte(&mut self, port: u16, value: u8) {
+        let _ = (port, value);
+    }
+
+    fn has_irq(&self) -> bool {
+        false
+    }
+
+    fn acknowledge_irq(&mut self) -> u8 {
+        0
+    }
+
+    fn has_nmi(&self) -> bool {
+        false
+    }
+
+    fn acknowledge_nmi(&mut self) {}
+
+    fn current_cycle(&self) -> u64 {
+        self.current_cycle
+    }
+
+    fn set_current_cycle(&mut self, cycle: u64) {
+        self.current_cycle = cycle;
+    }
+
+    fn drain_wait_cycles(&mut self) -> i64 {
+        let wait_cycles = self.wait_cycles;
+        self.wait_cycles = 0;
+        wait_cycles
+    }
+}
+
+fn functionality_dir() -> &'static Path {
+    static DIR: LazyLock<PathBuf> = LazyLock::new(|| {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/SingleStepTests/8088/v2_binary")
+    });
+    &DIR
+}
+
+fn functionality_metadata() -> &'static Metadata {
+    static META: LazyLock<Metadata> = LazyLock::new(|| {
+        load_metadata(
+            &Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/SingleStepTests/8088/v2/metadata.json"),
+        )
+    });
+    &META
+}
+
+fn timing_dir() -> &'static Path {
+    static DIR: LazyLock<PathBuf> = LazyLock::new(|| {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/SingleStepTests/8086/v1_binary")
+    });
+    &DIR
+}
+
+fn timing_metadata() -> &'static Metadata {
+    static META: LazyLock<Metadata> = LazyLock::new(|| {
+        load_metadata(
+            &Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/SingleStepTests/8086/v1/metadata.json"),
+        )
+    });
+    &META
+}
+
+fn should_test(status: &str) -> bool {
+    matches!(
+        status,
+        "normal" | "alias" | "undocumented" | "fpu" | "undefined"
+    )
+}
+
+fn format_flags_diff(expected: u16, actual: u16, mask: u16) -> String {
+    const FLAG_BITS: &[(u16, &str)] = &[
+        (0x0001, "CF"),
+        (0x0004, "PF"),
+        (0x0010, "AF"),
+        (0x0040, "ZF"),
+        (0x0080, "SF"),
+        (0x0100, "TF"),
+        (0x0200, "IF"),
+        (0x0400, "DF"),
+        (0x0800, "OF"),
+    ];
+
+    let expected_masked = expected & mask;
+    let actual_masked = actual & mask;
+    let diff_bits = expected_masked ^ actual_masked;
+
+    let mut changed: Vec<String> = Vec::new();
+    for &(bit, name) in FLAG_BITS {
+        if diff_bits & bit != 0 {
+            let expected_bit = u16::from(expected_masked & bit != 0);
+            let actual_bit = u16::from(actual_masked & bit != 0);
+            changed.push(format!("{name}:{expected_bit}->{actual_bit}"));
+        }
+    }
+
+    format!(
+        "  flags: expected 0x{expected_masked:04X}, got 0x{actual_masked:04X} [{}] (mask 0x{mask:04X})",
+        changed.join(", ")
+    )
+}
+
+fn initial_reg_value(regs: &HashMap<String, u32>, name: &str) -> u16 {
+    regs.get(name)
+        .copied()
+        .unwrap_or_else(|| panic!("missing register in initial state: {name}")) as u16
+}
+
+fn build_state(regs: &HashMap<String, u16>) -> I8086State {
+    let get = |name: &str| -> u16 {
+        regs.get(name)
+            .copied()
+            .unwrap_or_else(|| panic!("missing register: {name}"))
+    };
+
+    let mut state = I8086State::default();
+    state.set_ax(get("ax"));
+    state.set_cx(get("cx"));
+    state.set_dx(get("dx"));
+    state.set_bx(get("bx"));
+    state.set_sp(get("sp"));
+    state.set_bp(get("bp"));
+    state.set_si(get("si"));
+    state.set_di(get("di"));
+    state.set_es(get("es"));
+    state.set_cs(get("cs"));
+    state.set_ss(get("ss"));
+    state.set_ds(get("ds"));
+    state.ip = get("ip");
+    state.set_compressed_flags(get("flags"));
+    state
+}
+
+fn resolve_final_regs(
+    initial: &HashMap<String, u32>,
+    final_state: &HashMap<String, u32>,
+) -> HashMap<String, u16> {
+    REG_ORDER_I8086
+        .iter()
+        .map(|name| {
+            let value = final_state
+                .get(*name)
+                .copied()
+                .unwrap_or_else(|| u32::from(initial_reg_value(initial, name)));
+            ((*name).to_string(), value as u16)
+        })
+        .collect()
+}
+
+fn resolve_initial_regs(initial: &HashMap<String, u32>) -> HashMap<String, u16> {
+    REG_ORDER_I8086
+        .iter()
+        .map(|name| ((*name).to_string(), initial_reg_value(initial, name)))
+        .collect()
+}
+
+fn is_division_exception(
+    opcode: &str,
+    reg_ext: Option<&str>,
+    bytes: &[u8],
+    initial: &MooState,
+    expected: &I8086State,
+) -> bool {
+    let is_div = matches!(
+        (opcode, reg_ext),
+        ("F6", Some("6")) | ("F6", Some("7")) | ("F7", Some("6")) | ("F7", Some("7"))
+    ) || (opcode == "D4" && bytes.last() == Some(&0));
+    if !is_div {
+        return false;
+    }
+
+    let byte_at = |address: u32| -> u16 {
+        initial
+            .ram
+            .iter()
+            .find(|(candidate, _)| *candidate == address)
+            .map(|(_, value)| u16::from(*value))
+            .unwrap_or(0)
+    };
+    let handler_ip = byte_at(0) | (byte_at(1) << 8);
+    let handler_cs = byte_at(2) | (byte_at(3) << 8);
+
+    expected.cs() == handler_cs && expected.ip == handler_ip
+}
+
+fn parse_stem(stem: &str) -> (&str, Option<&str>) {
+    if let Some(dot_pos) = stem.find('.') {
+        (&stem[..dot_pos], Some(&stem[dot_pos + 1..]))
+    } else {
+        (stem, None)
+    }
+}
+
+fn status_and_mask<'a>(metadata: &'a Metadata, stem: &str) -> Option<(&'a str, u16)> {
+    let (opcode, reg_ext) = parse_stem(stem);
+    let entry = metadata.opcodes.get(opcode)?;
+    match (reg_ext, &entry.reg) {
+        (Some(reg_ext), Some(reg_map)) => {
+            let info = reg_map.get(reg_ext)?;
+            Some((info.status.as_str(), info.flags_mask.unwrap_or(0xFFFF)))
+        }
+        (Some(_), None) => None,
+        (None, _) => {
+            if let Some(status) = &entry.status {
+                Some((status.as_str(), entry.flags_mask.unwrap_or(0xFFFF)))
+            } else if let Some(reg_map) = &entry.reg {
+                let any_testable = reg_map.values().any(|info| should_test(&info.status));
+                if !any_testable {
+                    return None;
+                }
+                let mask = reg_map
+                    .values()
+                    .map(|info| info.flags_mask.unwrap_or(0xFFFF))
+                    .fold(0xFFFFu16, |combined_mask, flags_mask| {
+                        combined_mask & flags_mask
+                    });
+                Some(("normal", mask))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+fn run_test_file(stem: &str, test_dir: &Path, metadata: &Metadata, check_cycles: bool) {
+    let Some((status, flags_mask)) = status_and_mask(metadata, stem) else {
+        return;
+    };
+    if !should_test(status) {
+        return;
+    }
+
+    let filename = format!("{stem}.MOO.gz");
+    let path = test_dir.join(&filename);
+    let test_cases = load_moo_tests(&path, &REG_ORDER_I8086, &[]);
+    let (opcode, reg_ext) = parse_stem(stem);
+
+    let mut bus = TestBus::new();
+    let mut failures: Vec<String> = Vec::new();
+
+    for (index, test) in test_cases.iter().enumerate() {
+        bus.clear();
+        for &(address, value) in &test.initial.ram {
+            bus.set_memory(address, value);
+        }
+
+        let initial_regs16 = resolve_initial_regs(&test.initial.regs);
+        let final_regs16 = resolve_final_regs(&test.initial.regs, &test.final_state.regs);
+        let initial_state = build_state(&initial_regs16);
+        let expected = build_state(&final_regs16);
+
+        let mut cpu = I8086::new();
+        cpu.load_state(&initial_state);
+        cpu.install_prefetch_queue(&test.initial.queue);
+        cpu.step(&mut bus);
+
+        let mut diffs: Vec<String> = Vec::new();
+        let check_reg = |name: &str,
+                         initial_value: u16,
+                         actual_value: u16,
+                         expected_value: u16,
+                         diffs: &mut Vec<String>| {
+            if actual_value != expected_value {
+                diffs.push(format!(
+                    "  {name}: expected 0x{expected_value:04X}, got 0x{actual_value:04X} (was 0x{initial_value:04X})"
+                ));
+            }
+        };
+
+        check_reg(
+            "ax",
+            initial_state.ax(),
+            cpu.ax(),
+            expected.ax(),
+            &mut diffs,
+        );
+        check_reg(
+            "bx",
+            initial_state.bx(),
+            cpu.bx(),
+            expected.bx(),
+            &mut diffs,
+        );
+        check_reg(
+            "cx",
+            initial_state.cx(),
+            cpu.cx(),
+            expected.cx(),
+            &mut diffs,
+        );
+        check_reg(
+            "dx",
+            initial_state.dx(),
+            cpu.dx(),
+            expected.dx(),
+            &mut diffs,
+        );
+        check_reg(
+            "sp",
+            initial_state.sp(),
+            cpu.sp(),
+            expected.sp(),
+            &mut diffs,
+        );
+        check_reg(
+            "bp",
+            initial_state.bp(),
+            cpu.bp(),
+            expected.bp(),
+            &mut diffs,
+        );
+        check_reg(
+            "si",
+            initial_state.si(),
+            cpu.si(),
+            expected.si(),
+            &mut diffs,
+        );
+        check_reg(
+            "di",
+            initial_state.di(),
+            cpu.di(),
+            expected.di(),
+            &mut diffs,
+        );
+        check_reg(
+            "cs",
+            initial_state.cs(),
+            cpu.cs(),
+            expected.cs(),
+            &mut diffs,
+        );
+        check_reg(
+            "ss",
+            initial_state.ss(),
+            cpu.ss(),
+            expected.ss(),
+            &mut diffs,
+        );
+        check_reg(
+            "ds",
+            initial_state.ds(),
+            cpu.ds(),
+            expected.ds(),
+            &mut diffs,
+        );
+        check_reg(
+            "es",
+            initial_state.es(),
+            cpu.es(),
+            expected.es(),
+            &mut diffs,
+        );
+        check_reg("ip", initial_state.ip, cpu.ip, expected.ip, &mut diffs);
+
+        let actual_flags_masked = cpu.compressed_flags() & flags_mask;
+        let expected_flags_masked = expected.compressed_flags() & flags_mask;
+        if actual_flags_masked != expected_flags_masked {
+            diffs.push(format!(
+                "{} (was 0x{:04X})",
+                format_flags_diff(
+                    expected.compressed_flags(),
+                    cpu.compressed_flags(),
+                    flags_mask
+                ),
+                initial_state.compressed_flags()
+            ));
+        }
+
+        if check_cycles {
+            let actual_cycles = cpu.cycles_consumed();
+            let expected_cycles = test.cycles.len() as u64;
+            if actual_cycles != expected_cycles {
+                diffs.push(format!(
+                    "  cycles: expected {expected_cycles}, got {actual_cycles}"
+                ));
+            }
+        }
+
+        let division_exception =
+            is_division_exception(opcode, reg_ext, &test.bytes, &test.initial, &expected);
+        if !division_exception {
+            for &(address, expected_value) in &test.final_state.ram {
+                let actual_value = bus.ram[(address & ADDRESS_MASK) as usize];
+                if actual_value != expected_value {
+                    let initial_value = test
+                        .initial
+                        .ram
+                        .iter()
+                        .find(|(candidate, _)| *candidate == address)
+                        .map(|(_, value)| *value);
+                    match initial_value {
+                        Some(before) => diffs.push(format!(
+                            "  ram[0x{address:05X}]: expected 0x{expected_value:02X}, got 0x{actual_value:02X} (was 0x{before:02X})"
+                        )),
+                        None => diffs.push(format!(
+                            "  ram[0x{address:05X}]: expected 0x{expected_value:02X}, got 0x{actual_value:02X} (not in initial RAM)"
+                        )),
+                    }
+                }
+            }
+        }
+
+        if !diffs.is_empty() {
+            let bytes_hex: Vec<String> = test
+                .bytes
+                .iter()
+                .map(|byte| format!("{byte:02X}"))
+                .collect();
+            if let Ok(path) = std::env::var("VERIFICATION_FAILURE_DUMP") {
+                use std::io::Write;
+                if let Ok(mut file) = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&path)
+                {
+                    let _ = writeln!(
+                        file,
+                        "{filename}\t{index}\t{}\t{}\t{}\t{}\t{}",
+                        test.name,
+                        bytes_hex.join(" "),
+                        test.initial.queue.len(),
+                        test.initial
+                            .queue
+                            .iter()
+                            .map(|byte| format!("{byte:02X}"))
+                            .collect::<Vec<_>>()
+                            .join(" "),
+                        diffs.join(" | ")
+                    );
+                }
+            }
+            failures.push(format!(
+                "[{filename} #{index}] {} ({})\n{}",
+                test.name,
+                bytes_hex.join(" "),
+                diffs.join("\n")
+            ));
+        }
+    }
+
+    if !failures.is_empty() {
+        let fail_count = failures.len();
+        let test_count = test_cases.len();
+        let mut message = format!("{filename}: {fail_count}/{test_count} tests failed\n");
+        let display_count = failures.len().min(5);
+        for failure in &failures[..display_count] {
+            message.push_str(failure);
+            message.push('\n');
+        }
+        if failures.len() > 5 {
+            message.push_str(&format!("  ... and {} more failures\n", failures.len() - 5));
+        }
+        panic!("{message}");
+    }
+}
+
+fn run_8088_functionality_file(stem: &str) {
+    run_test_file(stem, functionality_dir(), functionality_metadata(), false);
+}
+
+fn run_8086_timing_file(stem: &str) {
+    run_test_file(stem, timing_dir(), timing_metadata(), true);
+}
+
+macro_rules! test_functionality_opcode {
+    ($name:ident, $file:expr) => {
+        #[test]
+        #[allow(non_snake_case)]
+        fn $name() {
+            run_8088_functionality_file($file);
+        }
+    };
+}
+
+macro_rules! test_timing_opcode {
+    ($name:ident, $file:expr) => {
+        #[test]
+        #[allow(non_snake_case)]
+        fn $name() {
+            run_8086_timing_file($file);
+        }
+    };
+}
+
+test_functionality_opcode!(functionality_op_00, "00");
+test_functionality_opcode!(functionality_op_01, "01");
+test_functionality_opcode!(functionality_op_02, "02");
+test_functionality_opcode!(functionality_op_03, "03");
+test_functionality_opcode!(functionality_op_04, "04");
+test_functionality_opcode!(functionality_op_05, "05");
+test_functionality_opcode!(functionality_op_06, "06");
+test_functionality_opcode!(functionality_op_07, "07");
+test_functionality_opcode!(functionality_op_08, "08");
+test_functionality_opcode!(functionality_op_09, "09");
+test_functionality_opcode!(functionality_op_0a, "0A");
+test_functionality_opcode!(functionality_op_0b, "0B");
+test_functionality_opcode!(functionality_op_0c, "0C");
+test_functionality_opcode!(functionality_op_0d, "0D");
+test_functionality_opcode!(functionality_op_0e, "0E");
+test_functionality_opcode!(functionality_op_10, "10");
+test_functionality_opcode!(functionality_op_11, "11");
+test_functionality_opcode!(functionality_op_12, "12");
+test_functionality_opcode!(functionality_op_13, "13");
+test_functionality_opcode!(functionality_op_14, "14");
+test_functionality_opcode!(functionality_op_15, "15");
+test_functionality_opcode!(functionality_op_16, "16");
+test_functionality_opcode!(functionality_op_17, "17");
+test_functionality_opcode!(functionality_op_18, "18");
+test_functionality_opcode!(functionality_op_19, "19");
+test_functionality_opcode!(functionality_op_1a, "1A");
+test_functionality_opcode!(functionality_op_1b, "1B");
+test_functionality_opcode!(functionality_op_1c, "1C");
+test_functionality_opcode!(functionality_op_1d, "1D");
+test_functionality_opcode!(functionality_op_1e, "1E");
+test_functionality_opcode!(functionality_op_1f, "1F");
+test_functionality_opcode!(functionality_op_20, "20");
+test_functionality_opcode!(functionality_op_21, "21");
+test_functionality_opcode!(functionality_op_22, "22");
+test_functionality_opcode!(functionality_op_23, "23");
+test_functionality_opcode!(functionality_op_24, "24");
+test_functionality_opcode!(functionality_op_25, "25");
+test_functionality_opcode!(functionality_op_27, "27");
+test_functionality_opcode!(functionality_op_28, "28");
+test_functionality_opcode!(functionality_op_29, "29");
+test_functionality_opcode!(functionality_op_2a, "2A");
+test_functionality_opcode!(functionality_op_2b, "2B");
+test_functionality_opcode!(functionality_op_2c, "2C");
+test_functionality_opcode!(functionality_op_2d, "2D");
+test_functionality_opcode!(functionality_op_2f, "2F");
+test_functionality_opcode!(functionality_op_30, "30");
+test_functionality_opcode!(functionality_op_31, "31");
+test_functionality_opcode!(functionality_op_32, "32");
+test_functionality_opcode!(functionality_op_33, "33");
+test_functionality_opcode!(functionality_op_34, "34");
+test_functionality_opcode!(functionality_op_35, "35");
+test_functionality_opcode!(functionality_op_37, "37");
+test_functionality_opcode!(functionality_op_38, "38");
+test_functionality_opcode!(functionality_op_39, "39");
+test_functionality_opcode!(functionality_op_3a, "3A");
+test_functionality_opcode!(functionality_op_3b, "3B");
+test_functionality_opcode!(functionality_op_3c, "3C");
+test_functionality_opcode!(functionality_op_3d, "3D");
+test_functionality_opcode!(functionality_op_3f, "3F");
+test_functionality_opcode!(functionality_op_40, "40");
+test_functionality_opcode!(functionality_op_41, "41");
+test_functionality_opcode!(functionality_op_42, "42");
+test_functionality_opcode!(functionality_op_43, "43");
+test_functionality_opcode!(functionality_op_44, "44");
+test_functionality_opcode!(functionality_op_45, "45");
+test_functionality_opcode!(functionality_op_46, "46");
+test_functionality_opcode!(functionality_op_47, "47");
+test_functionality_opcode!(functionality_op_48, "48");
+test_functionality_opcode!(functionality_op_49, "49");
+test_functionality_opcode!(functionality_op_4a, "4A");
+test_functionality_opcode!(functionality_op_4b, "4B");
+test_functionality_opcode!(functionality_op_4c, "4C");
+test_functionality_opcode!(functionality_op_4d, "4D");
+test_functionality_opcode!(functionality_op_4e, "4E");
+test_functionality_opcode!(functionality_op_4f, "4F");
+test_functionality_opcode!(functionality_op_50, "50");
+test_functionality_opcode!(functionality_op_51, "51");
+test_functionality_opcode!(functionality_op_52, "52");
+test_functionality_opcode!(functionality_op_53, "53");
+test_functionality_opcode!(functionality_op_54, "54");
+test_functionality_opcode!(functionality_op_55, "55");
+test_functionality_opcode!(functionality_op_56, "56");
+test_functionality_opcode!(functionality_op_57, "57");
+test_functionality_opcode!(functionality_op_58, "58");
+test_functionality_opcode!(functionality_op_59, "59");
+test_functionality_opcode!(functionality_op_5a, "5A");
+test_functionality_opcode!(functionality_op_5b, "5B");
+test_functionality_opcode!(functionality_op_5c, "5C");
+test_functionality_opcode!(functionality_op_5d, "5D");
+test_functionality_opcode!(functionality_op_5e, "5E");
+test_functionality_opcode!(functionality_op_5f, "5F");
+test_functionality_opcode!(functionality_op_60, "60");
+test_functionality_opcode!(functionality_op_61, "61");
+test_functionality_opcode!(functionality_op_62, "62");
+test_functionality_opcode!(functionality_op_63, "63");
+test_functionality_opcode!(functionality_op_64, "64");
+test_functionality_opcode!(functionality_op_65, "65");
+test_functionality_opcode!(functionality_op_66, "66");
+test_functionality_opcode!(functionality_op_67, "67");
+test_functionality_opcode!(functionality_op_68, "68");
+test_functionality_opcode!(functionality_op_69, "69");
+test_functionality_opcode!(functionality_op_6a, "6A");
+test_functionality_opcode!(functionality_op_6b, "6B");
+test_functionality_opcode!(functionality_op_6c, "6C");
+test_functionality_opcode!(functionality_op_6d, "6D");
+test_functionality_opcode!(functionality_op_6e, "6E");
+test_functionality_opcode!(functionality_op_6f, "6F");
+test_functionality_opcode!(functionality_op_70, "70");
+test_functionality_opcode!(functionality_op_71, "71");
+test_functionality_opcode!(functionality_op_72, "72");
+test_functionality_opcode!(functionality_op_73, "73");
+test_functionality_opcode!(functionality_op_74, "74");
+test_functionality_opcode!(functionality_op_75, "75");
+test_functionality_opcode!(functionality_op_76, "76");
+test_functionality_opcode!(functionality_op_77, "77");
+test_functionality_opcode!(functionality_op_78, "78");
+test_functionality_opcode!(functionality_op_79, "79");
+test_functionality_opcode!(functionality_op_7a, "7A");
+test_functionality_opcode!(functionality_op_7b, "7B");
+test_functionality_opcode!(functionality_op_7c, "7C");
+test_functionality_opcode!(functionality_op_7d, "7D");
+test_functionality_opcode!(functionality_op_7e, "7E");
+test_functionality_opcode!(functionality_op_7f, "7F");
+test_functionality_opcode!(functionality_op_80_0, "80.0");
+test_functionality_opcode!(functionality_op_80_1, "80.1");
+test_functionality_opcode!(functionality_op_80_2, "80.2");
+test_functionality_opcode!(functionality_op_80_3, "80.3");
+test_functionality_opcode!(functionality_op_80_4, "80.4");
+test_functionality_opcode!(functionality_op_80_5, "80.5");
+test_functionality_opcode!(functionality_op_80_6, "80.6");
+test_functionality_opcode!(functionality_op_80_7, "80.7");
+test_functionality_opcode!(functionality_op_81_0, "81.0");
+test_functionality_opcode!(functionality_op_81_1, "81.1");
+test_functionality_opcode!(functionality_op_81_2, "81.2");
+test_functionality_opcode!(functionality_op_81_3, "81.3");
+test_functionality_opcode!(functionality_op_81_4, "81.4");
+test_functionality_opcode!(functionality_op_81_5, "81.5");
+test_functionality_opcode!(functionality_op_81_6, "81.6");
+test_functionality_opcode!(functionality_op_81_7, "81.7");
+test_functionality_opcode!(functionality_op_82_0, "82.0");
+test_functionality_opcode!(functionality_op_82_1, "82.1");
+test_functionality_opcode!(functionality_op_82_2, "82.2");
+test_functionality_opcode!(functionality_op_82_3, "82.3");
+test_functionality_opcode!(functionality_op_82_4, "82.4");
+test_functionality_opcode!(functionality_op_82_5, "82.5");
+test_functionality_opcode!(functionality_op_82_6, "82.6");
+test_functionality_opcode!(functionality_op_82_7, "82.7");
+test_functionality_opcode!(functionality_op_83_0, "83.0");
+test_functionality_opcode!(functionality_op_83_1, "83.1");
+test_functionality_opcode!(functionality_op_83_2, "83.2");
+test_functionality_opcode!(functionality_op_83_3, "83.3");
+test_functionality_opcode!(functionality_op_83_4, "83.4");
+test_functionality_opcode!(functionality_op_83_5, "83.5");
+test_functionality_opcode!(functionality_op_83_6, "83.6");
+test_functionality_opcode!(functionality_op_83_7, "83.7");
+test_functionality_opcode!(functionality_op_84, "84");
+test_functionality_opcode!(functionality_op_85, "85");
+test_functionality_opcode!(functionality_op_86, "86");
+test_functionality_opcode!(functionality_op_87, "87");
+test_functionality_opcode!(functionality_op_88, "88");
+test_functionality_opcode!(functionality_op_89, "89");
+test_functionality_opcode!(functionality_op_8a, "8A");
+test_functionality_opcode!(functionality_op_8b, "8B");
+test_functionality_opcode!(functionality_op_8c, "8C");
+test_functionality_opcode!(functionality_op_8d, "8D");
+test_functionality_opcode!(functionality_op_8e, "8E");
+test_functionality_opcode!(functionality_op_8f, "8F");
+test_functionality_opcode!(functionality_op_90, "90");
+test_functionality_opcode!(functionality_op_91, "91");
+test_functionality_opcode!(functionality_op_92, "92");
+test_functionality_opcode!(functionality_op_93, "93");
+test_functionality_opcode!(functionality_op_94, "94");
+test_functionality_opcode!(functionality_op_95, "95");
+test_functionality_opcode!(functionality_op_96, "96");
+test_functionality_opcode!(functionality_op_97, "97");
+test_functionality_opcode!(functionality_op_98, "98");
+test_functionality_opcode!(functionality_op_99, "99");
+test_functionality_opcode!(functionality_op_9a, "9A");
+test_functionality_opcode!(functionality_op_9c, "9C");
+test_functionality_opcode!(functionality_op_9d, "9D");
+test_functionality_opcode!(functionality_op_9e, "9E");
+test_functionality_opcode!(functionality_op_9f, "9F");
+test_functionality_opcode!(functionality_op_a0, "A0");
+test_functionality_opcode!(functionality_op_a1, "A1");
+test_functionality_opcode!(functionality_op_a2, "A2");
+test_functionality_opcode!(functionality_op_a3, "A3");
+test_functionality_opcode!(functionality_op_a4, "A4");
+test_functionality_opcode!(functionality_op_a5, "A5");
+test_functionality_opcode!(functionality_op_a6, "A6");
+test_functionality_opcode!(functionality_op_a7, "A7");
+test_functionality_opcode!(functionality_op_a8, "A8");
+test_functionality_opcode!(functionality_op_a9, "A9");
+test_functionality_opcode!(functionality_op_aa, "AA");
+test_functionality_opcode!(functionality_op_ab, "AB");
+test_functionality_opcode!(functionality_op_ac, "AC");
+test_functionality_opcode!(functionality_op_ad, "AD");
+test_functionality_opcode!(functionality_op_ae, "AE");
+test_functionality_opcode!(functionality_op_af, "AF");
+test_functionality_opcode!(functionality_op_b0, "B0");
+test_functionality_opcode!(functionality_op_b1, "B1");
+test_functionality_opcode!(functionality_op_b2, "B2");
+test_functionality_opcode!(functionality_op_b3, "B3");
+test_functionality_opcode!(functionality_op_b4, "B4");
+test_functionality_opcode!(functionality_op_b5, "B5");
+test_functionality_opcode!(functionality_op_b6, "B6");
+test_functionality_opcode!(functionality_op_b7, "B7");
+test_functionality_opcode!(functionality_op_b8, "B8");
+test_functionality_opcode!(functionality_op_b9, "B9");
+test_functionality_opcode!(functionality_op_ba, "BA");
+test_functionality_opcode!(functionality_op_bb, "BB");
+test_functionality_opcode!(functionality_op_bc, "BC");
+test_functionality_opcode!(functionality_op_bd, "BD");
+test_functionality_opcode!(functionality_op_be, "BE");
+test_functionality_opcode!(functionality_op_bf, "BF");
+test_functionality_opcode!(functionality_op_c0, "C0");
+test_functionality_opcode!(functionality_op_c1, "C1");
+test_functionality_opcode!(functionality_op_c2, "C2");
+test_functionality_opcode!(functionality_op_c3, "C3");
+test_functionality_opcode!(functionality_op_c4, "C4");
+test_functionality_opcode!(functionality_op_c5, "C5");
+test_functionality_opcode!(functionality_op_c6, "C6");
+test_functionality_opcode!(functionality_op_c7, "C7");
+test_functionality_opcode!(functionality_op_c8, "C8");
+test_functionality_opcode!(functionality_op_c9, "C9");
+test_functionality_opcode!(functionality_op_ca, "CA");
+test_functionality_opcode!(functionality_op_cb, "CB");
+test_functionality_opcode!(functionality_op_cc, "CC");
+test_functionality_opcode!(functionality_op_cd, "CD");
+test_functionality_opcode!(functionality_op_ce, "CE");
+test_functionality_opcode!(functionality_op_cf, "CF");
+test_functionality_opcode!(functionality_op_d0_0, "D0.0");
+test_functionality_opcode!(functionality_op_d0_1, "D0.1");
+test_functionality_opcode!(functionality_op_d0_2, "D0.2");
+test_functionality_opcode!(functionality_op_d0_3, "D0.3");
+test_functionality_opcode!(functionality_op_d0_4, "D0.4");
+test_functionality_opcode!(functionality_op_d0_5, "D0.5");
+test_functionality_opcode!(functionality_op_d0_6, "D0.6");
+test_functionality_opcode!(functionality_op_d0_7, "D0.7");
+test_functionality_opcode!(functionality_op_d1_0, "D1.0");
+test_functionality_opcode!(functionality_op_d1_1, "D1.1");
+test_functionality_opcode!(functionality_op_d1_2, "D1.2");
+test_functionality_opcode!(functionality_op_d1_3, "D1.3");
+test_functionality_opcode!(functionality_op_d1_4, "D1.4");
+test_functionality_opcode!(functionality_op_d1_5, "D1.5");
+test_functionality_opcode!(functionality_op_d1_6, "D1.6");
+test_functionality_opcode!(functionality_op_d1_7, "D1.7");
+test_functionality_opcode!(functionality_op_d2_0, "D2.0");
+test_functionality_opcode!(functionality_op_d2_1, "D2.1");
+test_functionality_opcode!(functionality_op_d2_2, "D2.2");
+test_functionality_opcode!(functionality_op_d2_3, "D2.3");
+test_functionality_opcode!(functionality_op_d2_4, "D2.4");
+test_functionality_opcode!(functionality_op_d2_5, "D2.5");
+test_functionality_opcode!(functionality_op_d2_6, "D2.6");
+test_functionality_opcode!(functionality_op_d2_7, "D2.7");
+test_functionality_opcode!(functionality_op_d3_0, "D3.0");
+test_functionality_opcode!(functionality_op_d3_1, "D3.1");
+test_functionality_opcode!(functionality_op_d3_2, "D3.2");
+test_functionality_opcode!(functionality_op_d3_3, "D3.3");
+test_functionality_opcode!(functionality_op_d3_4, "D3.4");
+test_functionality_opcode!(functionality_op_d3_5, "D3.5");
+test_functionality_opcode!(functionality_op_d3_6, "D3.6");
+test_functionality_opcode!(functionality_op_d3_7, "D3.7");
+test_functionality_opcode!(functionality_op_d4, "D4");
+test_functionality_opcode!(functionality_op_d5, "D5");
+test_functionality_opcode!(functionality_op_d6, "D6");
+test_functionality_opcode!(functionality_op_d7, "D7");
+test_functionality_opcode!(functionality_op_d8, "D8");
+test_functionality_opcode!(functionality_op_d9, "D9");
+test_functionality_opcode!(functionality_op_da, "DA");
+test_functionality_opcode!(functionality_op_db, "DB");
+test_functionality_opcode!(functionality_op_dc, "DC");
+test_functionality_opcode!(functionality_op_dd, "DD");
+test_functionality_opcode!(functionality_op_de, "DE");
+test_functionality_opcode!(functionality_op_df, "DF");
+test_functionality_opcode!(functionality_op_e0, "E0");
+test_functionality_opcode!(functionality_op_e1, "E1");
+test_functionality_opcode!(functionality_op_e2, "E2");
+test_functionality_opcode!(functionality_op_e3, "E3");
+test_functionality_opcode!(functionality_op_e4, "E4");
+test_functionality_opcode!(functionality_op_e5, "E5");
+test_functionality_opcode!(functionality_op_e6, "E6");
+test_functionality_opcode!(functionality_op_e7, "E7");
+test_functionality_opcode!(functionality_op_e8, "E8");
+test_functionality_opcode!(functionality_op_e9, "E9");
+test_functionality_opcode!(functionality_op_ea, "EA");
+test_functionality_opcode!(functionality_op_eb, "EB");
+test_functionality_opcode!(functionality_op_ec, "EC");
+test_functionality_opcode!(functionality_op_ed, "ED");
+test_functionality_opcode!(functionality_op_ee, "EE");
+test_functionality_opcode!(functionality_op_ef, "EF");
+test_functionality_opcode!(functionality_op_f5, "F5");
+test_functionality_opcode!(functionality_op_f6_0, "F6.0");
+test_functionality_opcode!(functionality_op_f6_1, "F6.1");
+test_functionality_opcode!(functionality_op_f6_2, "F6.2");
+test_functionality_opcode!(functionality_op_f6_3, "F6.3");
+test_functionality_opcode!(functionality_op_f6_4, "F6.4");
+test_functionality_opcode!(functionality_op_f6_5, "F6.5");
+test_functionality_opcode!(functionality_op_f6_6, "F6.6");
+test_functionality_opcode!(functionality_op_f6_7, "F6.7");
+test_functionality_opcode!(functionality_op_f7_0, "F7.0");
+test_functionality_opcode!(functionality_op_f7_1, "F7.1");
+test_functionality_opcode!(functionality_op_f7_2, "F7.2");
+test_functionality_opcode!(functionality_op_f7_3, "F7.3");
+test_functionality_opcode!(functionality_op_f7_4, "F7.4");
+test_functionality_opcode!(functionality_op_f7_5, "F7.5");
+test_functionality_opcode!(functionality_op_f7_6, "F7.6");
+test_functionality_opcode!(functionality_op_f7_7, "F7.7");
+test_functionality_opcode!(functionality_op_f8, "F8");
+test_functionality_opcode!(functionality_op_f9, "F9");
+test_functionality_opcode!(functionality_op_fa, "FA");
+test_functionality_opcode!(functionality_op_fb, "FB");
+test_functionality_opcode!(functionality_op_fc, "FC");
+test_functionality_opcode!(functionality_op_fd, "FD");
+test_functionality_opcode!(functionality_op_fe_0, "FE.0");
+test_functionality_opcode!(functionality_op_fe_1, "FE.1");
+test_functionality_opcode!(functionality_op_ff_0, "FF.0");
+test_functionality_opcode!(functionality_op_ff_1, "FF.1");
+test_functionality_opcode!(functionality_op_ff_2, "FF.2");
+test_functionality_opcode!(functionality_op_ff_3, "FF.3");
+test_functionality_opcode!(functionality_op_ff_4, "FF.4");
+test_functionality_opcode!(functionality_op_ff_5, "FF.5");
+test_functionality_opcode!(functionality_op_ff_6, "FF.6");
+test_functionality_opcode!(functionality_op_ff_7, "FF.7");
+
+test_timing_opcode!(timing_op_00, "00");
+test_timing_opcode!(timing_op_01, "01");
+test_timing_opcode!(timing_op_02, "02");
+test_timing_opcode!(timing_op_03, "03");
+test_timing_opcode!(timing_op_04, "04");
+test_timing_opcode!(timing_op_05, "05");
+test_timing_opcode!(timing_op_06, "06");
+test_timing_opcode!(timing_op_07, "07");
+test_timing_opcode!(timing_op_08, "08");
+test_timing_opcode!(timing_op_09, "09");
+test_timing_opcode!(timing_op_0a, "0A");
+test_timing_opcode!(timing_op_0b, "0B");
+test_timing_opcode!(timing_op_0c, "0C");
+test_timing_opcode!(timing_op_0d, "0D");
+test_timing_opcode!(timing_op_0e, "0E");
+test_timing_opcode!(timing_op_10, "10");
+test_timing_opcode!(timing_op_11, "11");
+test_timing_opcode!(timing_op_12, "12");
+test_timing_opcode!(timing_op_13, "13");
+test_timing_opcode!(timing_op_14, "14");
+test_timing_opcode!(timing_op_15, "15");
+test_timing_opcode!(timing_op_16, "16");
+test_timing_opcode!(timing_op_17, "17");
+test_timing_opcode!(timing_op_18, "18");
+test_timing_opcode!(timing_op_19, "19");
+test_timing_opcode!(timing_op_1a, "1A");
+test_timing_opcode!(timing_op_1b, "1B");
+test_timing_opcode!(timing_op_1c, "1C");
+test_timing_opcode!(timing_op_1d, "1D");
+test_timing_opcode!(timing_op_1e, "1E");
+test_timing_opcode!(timing_op_1f, "1F");
+test_timing_opcode!(timing_op_20, "20");
+test_timing_opcode!(timing_op_21, "21");
+test_timing_opcode!(timing_op_22, "22");
+test_timing_opcode!(timing_op_23, "23");
+test_timing_opcode!(timing_op_24, "24");
+test_timing_opcode!(timing_op_25, "25");
+test_timing_opcode!(timing_op_27, "27");
+test_timing_opcode!(timing_op_28, "28");
+test_timing_opcode!(timing_op_29, "29");
+test_timing_opcode!(timing_op_2a, "2A");
+test_timing_opcode!(timing_op_2b, "2B");
+test_timing_opcode!(timing_op_2c, "2C");
+test_timing_opcode!(timing_op_2d, "2D");
+test_timing_opcode!(timing_op_2f, "2F");
+test_timing_opcode!(timing_op_30, "30");
+test_timing_opcode!(timing_op_31, "31");
+test_timing_opcode!(timing_op_32, "32");
+test_timing_opcode!(timing_op_33, "33");
+test_timing_opcode!(timing_op_34, "34");
+test_timing_opcode!(timing_op_35, "35");
+test_timing_opcode!(timing_op_37, "37");
+test_timing_opcode!(timing_op_38, "38");
+test_timing_opcode!(timing_op_39, "39");
+test_timing_opcode!(timing_op_3a, "3A");
+test_timing_opcode!(timing_op_3b, "3B");
+test_timing_opcode!(timing_op_3c, "3C");
+test_timing_opcode!(timing_op_3d, "3D");
+test_timing_opcode!(timing_op_3f, "3F");
+test_timing_opcode!(timing_op_40, "40");
+test_timing_opcode!(timing_op_41, "41");
+test_timing_opcode!(timing_op_42, "42");
+test_timing_opcode!(timing_op_43, "43");
+test_timing_opcode!(timing_op_44, "44");
+test_timing_opcode!(timing_op_45, "45");
+test_timing_opcode!(timing_op_46, "46");
+test_timing_opcode!(timing_op_47, "47");
+test_timing_opcode!(timing_op_48, "48");
+test_timing_opcode!(timing_op_49, "49");
+test_timing_opcode!(timing_op_4a, "4A");
+test_timing_opcode!(timing_op_4b, "4B");
+test_timing_opcode!(timing_op_4c, "4C");
+test_timing_opcode!(timing_op_4d, "4D");
+test_timing_opcode!(timing_op_4e, "4E");
+test_timing_opcode!(timing_op_4f, "4F");
+test_timing_opcode!(timing_op_50, "50");
+test_timing_opcode!(timing_op_51, "51");
+test_timing_opcode!(timing_op_52, "52");
+test_timing_opcode!(timing_op_53, "53");
+test_timing_opcode!(timing_op_54, "54");
+test_timing_opcode!(timing_op_55, "55");
+test_timing_opcode!(timing_op_56, "56");
+test_timing_opcode!(timing_op_57, "57");
+test_timing_opcode!(timing_op_58, "58");
+test_timing_opcode!(timing_op_59, "59");
+test_timing_opcode!(timing_op_5a, "5A");
+test_timing_opcode!(timing_op_5b, "5B");
+test_timing_opcode!(timing_op_5c, "5C");
+test_timing_opcode!(timing_op_5d, "5D");
+test_timing_opcode!(timing_op_5e, "5E");
+test_timing_opcode!(timing_op_5f, "5F");
+test_timing_opcode!(timing_op_60, "60");
+test_timing_opcode!(timing_op_61, "61");
+test_timing_opcode!(timing_op_62, "62");
+test_timing_opcode!(timing_op_63, "63");
+test_timing_opcode!(timing_op_64, "64");
+test_timing_opcode!(timing_op_65, "65");
+test_timing_opcode!(timing_op_66, "66");
+test_timing_opcode!(timing_op_67, "67");
+test_timing_opcode!(timing_op_68, "68");
+test_timing_opcode!(timing_op_69, "69");
+test_timing_opcode!(timing_op_6a, "6A");
+test_timing_opcode!(timing_op_6b, "6B");
+test_timing_opcode!(timing_op_6c, "6C");
+test_timing_opcode!(timing_op_6d, "6D");
+test_timing_opcode!(timing_op_6e, "6E");
+test_timing_opcode!(timing_op_6f, "6F");
+test_timing_opcode!(timing_op_70, "70");
+test_timing_opcode!(timing_op_71, "71");
+test_timing_opcode!(timing_op_72, "72");
+test_timing_opcode!(timing_op_73, "73");
+test_timing_opcode!(timing_op_74, "74");
+test_timing_opcode!(timing_op_75, "75");
+test_timing_opcode!(timing_op_76, "76");
+test_timing_opcode!(timing_op_77, "77");
+test_timing_opcode!(timing_op_78, "78");
+test_timing_opcode!(timing_op_79, "79");
+test_timing_opcode!(timing_op_7a, "7A");
+test_timing_opcode!(timing_op_7b, "7B");
+test_timing_opcode!(timing_op_7c, "7C");
+test_timing_opcode!(timing_op_7d, "7D");
+test_timing_opcode!(timing_op_7e, "7E");
+test_timing_opcode!(timing_op_7f, "7F");
+test_timing_opcode!(timing_op_80_0, "80.0");
+test_timing_opcode!(timing_op_80_1, "80.1");
+test_timing_opcode!(timing_op_80_2, "80.2");
+test_timing_opcode!(timing_op_80_3, "80.3");
+test_timing_opcode!(timing_op_80_4, "80.4");
+test_timing_opcode!(timing_op_80_5, "80.5");
+test_timing_opcode!(timing_op_80_6, "80.6");
+test_timing_opcode!(timing_op_80_7, "80.7");
+test_timing_opcode!(timing_op_81_0, "81.0");
+test_timing_opcode!(timing_op_81_1, "81.1");
+test_timing_opcode!(timing_op_81_2, "81.2");
+test_timing_opcode!(timing_op_81_3, "81.3");
+test_timing_opcode!(timing_op_81_4, "81.4");
+test_timing_opcode!(timing_op_81_5, "81.5");
+test_timing_opcode!(timing_op_81_6, "81.6");
+test_timing_opcode!(timing_op_81_7, "81.7");
+test_timing_opcode!(timing_op_82_0, "82.0");
+test_timing_opcode!(timing_op_82_1, "82.1");
+test_timing_opcode!(timing_op_82_2, "82.2");
+test_timing_opcode!(timing_op_82_3, "82.3");
+test_timing_opcode!(timing_op_82_4, "82.4");
+test_timing_opcode!(timing_op_82_5, "82.5");
+test_timing_opcode!(timing_op_82_6, "82.6");
+test_timing_opcode!(timing_op_82_7, "82.7");
+test_timing_opcode!(timing_op_83_0, "83.0");
+test_timing_opcode!(timing_op_83_1, "83.1");
+test_timing_opcode!(timing_op_83_2, "83.2");
+test_timing_opcode!(timing_op_83_3, "83.3");
+test_timing_opcode!(timing_op_83_4, "83.4");
+test_timing_opcode!(timing_op_83_5, "83.5");
+test_timing_opcode!(timing_op_83_6, "83.6");
+test_timing_opcode!(timing_op_83_7, "83.7");
+test_timing_opcode!(timing_op_84, "84");
+test_timing_opcode!(timing_op_85, "85");
+test_timing_opcode!(timing_op_86, "86");
+test_timing_opcode!(timing_op_87, "87");
+test_timing_opcode!(timing_op_88, "88");
+test_timing_opcode!(timing_op_89, "89");
+test_timing_opcode!(timing_op_8a, "8A");
+test_timing_opcode!(timing_op_8b, "8B");
+test_timing_opcode!(timing_op_8c, "8C");
+test_timing_opcode!(timing_op_8d, "8D");
+test_timing_opcode!(timing_op_8e, "8E");
+test_timing_opcode!(timing_op_8f, "8F");
+test_timing_opcode!(timing_op_90, "90");
+test_timing_opcode!(timing_op_91, "91");
+test_timing_opcode!(timing_op_92, "92");
+test_timing_opcode!(timing_op_93, "93");
+test_timing_opcode!(timing_op_94, "94");
+test_timing_opcode!(timing_op_95, "95");
+test_timing_opcode!(timing_op_96, "96");
+test_timing_opcode!(timing_op_97, "97");
+test_timing_opcode!(timing_op_98, "98");
+test_timing_opcode!(timing_op_99, "99");
+test_timing_opcode!(timing_op_9a, "9A");
+test_timing_opcode!(timing_op_9c, "9C");
+test_timing_opcode!(timing_op_9d, "9D");
+test_timing_opcode!(timing_op_9e, "9E");
+test_timing_opcode!(timing_op_9f, "9F");
+test_timing_opcode!(timing_op_a0, "A0");
+test_timing_opcode!(timing_op_a1, "A1");
+test_timing_opcode!(timing_op_a2, "A2");
+test_timing_opcode!(timing_op_a3, "A3");
+test_timing_opcode!(timing_op_a4, "A4");
+test_timing_opcode!(timing_op_a5, "A5");
+test_timing_opcode!(timing_op_a6, "A6");
+test_timing_opcode!(timing_op_a7, "A7");
+test_timing_opcode!(timing_op_a8, "A8");
+test_timing_opcode!(timing_op_a9, "A9");
+test_timing_opcode!(timing_op_aa, "AA");
+test_timing_opcode!(timing_op_ab, "AB");
+test_timing_opcode!(timing_op_ac, "AC");
+test_timing_opcode!(timing_op_ad, "AD");
+test_timing_opcode!(timing_op_ae, "AE");
+test_timing_opcode!(timing_op_af, "AF");
+test_timing_opcode!(timing_op_b0, "B0");
+test_timing_opcode!(timing_op_b1, "B1");
+test_timing_opcode!(timing_op_b2, "B2");
+test_timing_opcode!(timing_op_b3, "B3");
+test_timing_opcode!(timing_op_b4, "B4");
+test_timing_opcode!(timing_op_b5, "B5");
+test_timing_opcode!(timing_op_b6, "B6");
+test_timing_opcode!(timing_op_b7, "B7");
+test_timing_opcode!(timing_op_b8, "B8");
+test_timing_opcode!(timing_op_b9, "B9");
+test_timing_opcode!(timing_op_ba, "BA");
+test_timing_opcode!(timing_op_bb, "BB");
+test_timing_opcode!(timing_op_bc, "BC");
+test_timing_opcode!(timing_op_bd, "BD");
+test_timing_opcode!(timing_op_be, "BE");
+test_timing_opcode!(timing_op_bf, "BF");
+test_timing_opcode!(timing_op_c0, "C0");
+test_timing_opcode!(timing_op_c1, "C1");
+test_timing_opcode!(timing_op_c2, "C2");
+test_timing_opcode!(timing_op_c3, "C3");
+test_timing_opcode!(timing_op_c4, "C4");
+test_timing_opcode!(timing_op_c5, "C5");
+test_timing_opcode!(timing_op_c6, "C6");
+test_timing_opcode!(timing_op_c7, "C7");
+test_timing_opcode!(timing_op_c8, "C8");
+test_timing_opcode!(timing_op_c9, "C9");
+test_timing_opcode!(timing_op_ca, "CA");
+test_timing_opcode!(timing_op_cb, "CB");
+test_timing_opcode!(timing_op_cc, "CC");
+test_timing_opcode!(timing_op_cd, "CD");
+test_timing_opcode!(timing_op_ce, "CE");
+test_timing_opcode!(timing_op_cf, "CF");
+test_timing_opcode!(timing_op_d0_0, "D0.0");
+test_timing_opcode!(timing_op_d0_1, "D0.1");
+test_timing_opcode!(timing_op_d0_2, "D0.2");
+test_timing_opcode!(timing_op_d0_3, "D0.3");
+test_timing_opcode!(timing_op_d0_4, "D0.4");
+test_timing_opcode!(timing_op_d0_5, "D0.5");
+test_timing_opcode!(timing_op_d0_6, "D0.6");
+test_timing_opcode!(timing_op_d0_7, "D0.7");
+test_timing_opcode!(timing_op_d1_0, "D1.0");
+test_timing_opcode!(timing_op_d1_1, "D1.1");
+test_timing_opcode!(timing_op_d1_2, "D1.2");
+test_timing_opcode!(timing_op_d1_3, "D1.3");
+test_timing_opcode!(timing_op_d1_4, "D1.4");
+test_timing_opcode!(timing_op_d1_5, "D1.5");
+test_timing_opcode!(timing_op_d1_6, "D1.6");
+test_timing_opcode!(timing_op_d1_7, "D1.7");
+test_timing_opcode!(timing_op_d2_0, "D2.0");
+test_timing_opcode!(timing_op_d2_1, "D2.1");
+test_timing_opcode!(timing_op_d2_2, "D2.2");
+test_timing_opcode!(timing_op_d2_3, "D2.3");
+test_timing_opcode!(timing_op_d2_4, "D2.4");
+test_timing_opcode!(timing_op_d2_5, "D2.5");
+test_timing_opcode!(timing_op_d2_6, "D2.6");
+test_timing_opcode!(timing_op_d2_7, "D2.7");
+test_timing_opcode!(timing_op_d3_0, "D3.0");
+test_timing_opcode!(timing_op_d3_1, "D3.1");
+test_timing_opcode!(timing_op_d3_2, "D3.2");
+test_timing_opcode!(timing_op_d3_3, "D3.3");
+test_timing_opcode!(timing_op_d3_4, "D3.4");
+test_timing_opcode!(timing_op_d3_5, "D3.5");
+test_timing_opcode!(timing_op_d3_6, "D3.6");
+test_timing_opcode!(timing_op_d3_7, "D3.7");
+test_timing_opcode!(timing_op_d4, "D4");
+test_timing_opcode!(timing_op_d5, "D5");
+test_timing_opcode!(timing_op_d6, "D6");
+test_timing_opcode!(timing_op_d7, "D7");
+test_timing_opcode!(timing_op_d8, "D8");
+test_timing_opcode!(timing_op_d9, "D9");
+test_timing_opcode!(timing_op_da, "DA");
+test_timing_opcode!(timing_op_db, "DB");
+test_timing_opcode!(timing_op_dc, "DC");
+test_timing_opcode!(timing_op_dd, "DD");
+test_timing_opcode!(timing_op_de, "DE");
+test_timing_opcode!(timing_op_df, "DF");
+test_timing_opcode!(timing_op_e0, "E0");
+test_timing_opcode!(timing_op_e1, "E1");
+test_timing_opcode!(timing_op_e2, "E2");
+test_timing_opcode!(timing_op_e3, "E3");
+test_timing_opcode!(timing_op_e4, "E4");
+test_timing_opcode!(timing_op_e5, "E5");
+test_timing_opcode!(timing_op_e6, "E6");
+test_timing_opcode!(timing_op_e7, "E7");
+test_timing_opcode!(timing_op_e8, "E8");
+test_timing_opcode!(timing_op_e9, "E9");
+test_timing_opcode!(timing_op_ea, "EA");
+test_timing_opcode!(timing_op_eb, "EB");
+test_timing_opcode!(timing_op_ec, "EC");
+test_timing_opcode!(timing_op_ed, "ED");
+test_timing_opcode!(timing_op_ee, "EE");
+test_timing_opcode!(timing_op_ef, "EF");
+test_timing_opcode!(timing_op_f5, "F5");
+test_timing_opcode!(timing_op_f6_0, "F6.0");
+test_timing_opcode!(timing_op_f6_1, "F6.1");
+test_timing_opcode!(timing_op_f6_2, "F6.2");
+test_timing_opcode!(timing_op_f6_3, "F6.3");
+test_timing_opcode!(timing_op_f6_4, "F6.4");
+test_timing_opcode!(timing_op_f6_5, "F6.5");
+test_timing_opcode!(timing_op_f6_6, "F6.6");
+test_timing_opcode!(timing_op_f6_7, "F6.7");
+test_timing_opcode!(timing_op_f7_0, "F7.0");
+test_timing_opcode!(timing_op_f7_1, "F7.1");
+test_timing_opcode!(timing_op_f7_2, "F7.2");
+test_timing_opcode!(timing_op_f7_3, "F7.3");
+test_timing_opcode!(timing_op_f7_4, "F7.4");
+test_timing_opcode!(timing_op_f7_5, "F7.5");
+test_timing_opcode!(timing_op_f7_6, "F7.6");
+test_timing_opcode!(timing_op_f7_7, "F7.7");
+test_timing_opcode!(timing_op_f8, "F8");
+test_timing_opcode!(timing_op_f9, "F9");
+test_timing_opcode!(timing_op_fa, "FA");
+test_timing_opcode!(timing_op_fb, "FB");
+test_timing_opcode!(timing_op_fc, "FC");
+test_timing_opcode!(timing_op_fd, "FD");
+test_timing_opcode!(timing_op_fe_0, "FE.0");
+test_timing_opcode!(timing_op_fe_1, "FE.1");
+test_timing_opcode!(timing_op_ff_0, "FF.0");
+test_timing_opcode!(timing_op_ff_1, "FF.1");
+test_timing_opcode!(timing_op_ff_2, "FF.2");
+test_timing_opcode!(timing_op_ff_3, "FF.3");
+test_timing_opcode!(timing_op_ff_4, "FF.4");
+test_timing_opcode!(timing_op_ff_5, "FF.5");
+test_timing_opcode!(timing_op_ff_6, "FF.6");
+test_timing_opcode!(timing_op_ff_7, "FF.7");

--- a/crates/machine/src/bus/init.rs
+++ b/crates/machine/src/bus/init.rs
@@ -327,7 +327,8 @@ impl<T: Tracing> Pc9801Bus<T> {
     /// Populates BDA fields based on machine model and clock lineage.
     fn populate_bda(&mut self) {
         let cpu_type = self.machine_model.cpu_type();
-        let is_v30 = cpu_type == CpuType::V30;
+        // TODO: Most likely wrong for the 8086.
+        let is_v30 = matches!(cpu_type, CpuType::I8086 | CpuType::V30);
 
         // MSW3 from text VRAM memory switch area (stride 4, at offset 0x3FEA).
         let msw3 = self.memory.state.text_vram[0x3FEA];
@@ -365,7 +366,8 @@ impl<T: Tracing> Pc9801Bus<T> {
         //   bit 6: EGC / protected mode test passed
         //   bit 7: IDE hard disk controller present
         let sys_type = match cpu_type {
-            CpuType::V30 => 0x00,
+            // TODO: Most likely wrong for the 8086.
+            CpuType::I8086 | CpuType::V30 => 0x00,
             CpuType::I286 => 0x01,
             CpuType::I386 | CpuType::I486DX => 0x4B,
         };
@@ -392,7 +394,7 @@ impl<T: Tracing> Pc9801Bus<T> {
 
         // BIOS_FLAG3 (0x0481): 386 machines have bit 5 set.
         self.memory.state.ram[0x0481] = match cpu_type {
-            CpuType::I286 | CpuType::V30 => 0x00,
+            CpuType::I8086 | CpuType::I286 | CpuType::V30 => 0x00,
             CpuType::I386 | CpuType::I486DX => 0x20,
         };
 

--- a/crates/machine/src/bus/io_read.rs
+++ b/crates/machine/src/bus/io_read.rs
@@ -311,8 +311,9 @@ impl<T: Tracing> Pc9801Bus<T> {
                 self.pending_wait_cycles += self.cbus_wait_cycles();
                 if let Some(ref sb14) = self.soundboard_14 {
                     sb14.read_port_b()
-                } else if self.soundboard_26k.is_some() && self.soundboard_86.is_some() {
-                    let sb26k = self.soundboard_26k.as_mut().unwrap();
+                } else if let Some(sb26k) = self.soundboard_26k.as_mut()
+                    && self.soundboard_86.is_some()
+                {
                     if sb26k.address() == 0x0E {
                         let irq_bits = match sb26k.irq_line() {
                             3 => 0x00,

--- a/crates/machine/src/bus/io_write.rs
+++ b/crates/machine/src/bus/io_write.rs
@@ -344,11 +344,10 @@ impl<T: Tracing> Pc9801Bus<T> {
                 self.pending_wait_cycles += self.cbus_wait_cycles();
                 if let Some(ref mut sb14) = self.soundboard_14 {
                     sb14.write_port_a(value);
-                } else if self.soundboard_26k.is_some() && self.soundboard_86.is_some() {
-                    self.soundboard_26k
-                        .as_mut()
-                        .unwrap()
-                        .write_address(value, self.current_cycle);
+                } else if let Some(sb26k) = self.soundboard_26k.as_mut()
+                    && self.soundboard_86.is_some()
+                {
+                    sb26k.write_address(value, self.current_cycle);
                     self.process_soundboard_actions();
                 }
             }
@@ -357,11 +356,10 @@ impl<T: Tracing> Pc9801Bus<T> {
                 self.pending_wait_cycles += self.cbus_wait_cycles();
                 if let Some(ref mut sb14) = self.soundboard_14 {
                     sb14.write_port_b(value);
-                } else if self.soundboard_26k.is_some() && self.soundboard_86.is_some() {
-                    self.soundboard_26k
-                        .as_mut()
-                        .unwrap()
-                        .write_data(value, self.current_cycle);
+                } else if let Some(sb26k) = self.soundboard_26k.as_mut()
+                    && self.soundboard_86.is_some()
+                {
+                    sb26k.write_data(value, self.current_cycle);
                     self.process_soundboard_actions();
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1103,6 +1103,7 @@ fn initialize_machine(config: &EmulatorConfig, sample_rate: u32) -> Result<Box<d
     }
 
     let machine: Box<dyn Machine> = match model.cpu_type() {
+        common::CpuType::I8086 => unreachable!("PC-9801F is not wired as a machine model yet"),
         common::CpuType::V30 => Box::new(machine::Machine::new(cpu::V30::new(), bus)),
         common::CpuType::I286 => Box::new(machine::Machine::new(cpu::I286::new(), bus)),
         common::CpuType::I386 => Box::new(machine::Machine::new(


### PR DESCRIPTION
Cycle-count accurate 8086 CPU emulation based on the research of [MartyPC](https://github.com/dbalsom/martypc) on the 8088 and their [test data](https://github.com/SingleStepTests/8088).

Branch is  100% cycle accurate and passes the test data of SingleStepTests without any deviation in the testset.

This CPU will be used for the PC-9801F target, which will be our lowest target for the pre-GRCG machines, for the games that were cycle timing sensitive like "Flappy" or "Xanadu". We will most likely offer an option to run them in 5 and 8 Mhz mode. The next goal would be to have a VM30 cycle accurate emulation, but we currently don't have traces from a real V30. Maybe we will use the timings of the V20 and add a "16-bit bus" correction factor to it as a first narrowing. Not sure yet.