### PR TITLE
refactor: move PC-98 text attribute normalization from GPU to CPU

### DIFF
--- a/crates/common/src/display_snapshot.rs
+++ b/crates/common/src/display_snapshot.rs
@@ -1,6 +1,13 @@
 #[cfg(not(target_endian = "little"))]
 compile_error!("DisplaySnapshotUpload requires a little-endian target");
 
+/// Total byte size of the PC-98 text VRAM image (16 KiB).
+///
+/// Bytes 0x0000-0x1FFF hold character codes (low and high byte interleaved
+/// per cell); bytes 0x2000-0x3FFF hold attribute bytes with the same cell
+/// layout.
+pub const TEXT_VRAM_BYTES: usize = 0x4000;
+
 /// Typed display snapshot uploaded from CPU emulation to the GPU compose pass.
 ///
 /// The binary layout of this struct is stable and shared with shader code.
@@ -43,10 +50,24 @@ pub struct DisplaySnapshotUpload {
     pub text_cursor: u32,
     /// Graphics GDC active display lines (AL from SYNC command, 0-1023).
     pub gdc_graphics_al: u32,
-    /// Reserved header words so text VRAM starts at byte offset 0x100.
+    /// Reserved header words so the text plane starts at byte offset 0x100.
     pub reserved_header_words: [u32; 26],
-    /// Text VRAM bytes as 32-bit little-endian words.
-    pub text_vram_words: [u32; 0x4000 / 4],
+    /// Normalized text plane: one packed `u32` per cell, indexed by TVRAM
+    /// character word address (`memory_addr / 2`).
+    ///
+    /// Layout (LSB-first):
+    /// - bits  0..19: font ROM byte offset for raster line 0 (kanji right
+    ///   half is encoded as left-half offset + 0x800).
+    /// - bits 20..22: foreground color (BRG, attr bits 7..5).
+    /// - bit  23: blank cell (secret bit clear, or blink phase suppresses).
+    /// - bit  24: reverse (XOR final pixel color).
+    /// - bit  25: underline_this (this cell has the underline attribute).
+    /// - bit  26: underline_left (previous cell on this row had underline).
+    /// - bit  27: vertical line at glyph_x == 4.
+    /// - bit  28: cursor cell (EAD address matches; inherited to right half
+    ///   of a kanji pair).
+    /// - bits 29..31: reserved.
+    pub text_cells: [u32; 4096],
     /// Graphics VRAM B-plane (32 KB) as 32-bit little-endian words.
     pub graphics_b_plane: [u32; 0x8000 / 4],
     /// Graphics VRAM R-plane (32 KB) as 32-bit little-endian words.
@@ -213,7 +234,7 @@ mod tests {
             offset_of!(DisplaySnapshotUpload, reserved_header_words),
             0x098
         );
-        assert_eq!(offset_of!(DisplaySnapshotUpload, text_vram_words), 0x100);
+        assert_eq!(offset_of!(DisplaySnapshotUpload, text_cells), 0x100);
         assert_eq!(offset_of!(DisplaySnapshotUpload, graphics_b_plane), 0x4100);
         assert_eq!(offset_of!(DisplaySnapshotUpload, graphics_r_plane), 0xC100);
         assert_eq!(offset_of!(DisplaySnapshotUpload, graphics_g_plane), 0x14100);

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -14,10 +14,11 @@ mod jis;
 pub mod log;
 mod os;
 mod stack_vec;
+mod text_normalizer;
 mod trace;
 
 pub use display_snapshot::{
-    DISPLAY_FLAG_PEGC_256_COLOR, DisplaySnapshotUpload, PegcSnapshotUpload,
+    DISPLAY_FLAG_PEGC_256_COLOR, DisplaySnapshotUpload, PegcSnapshotUpload, TEXT_VRAM_BYTES,
     cast_u32_slice_as_bytes_mut,
 };
 pub use error::{Context, ContextError, OptionContext, StringError};
@@ -30,6 +31,7 @@ pub use os::{
     ConsoleIo, CpuAccess, CursorAccess, DiskIo, DriveIo, HardwareCursorState, MemoryAccess,
 };
 pub use stack_vec::StackVec;
+pub use text_normalizer::{TEXT_CELL_COUNT, TextNormalizerInputs, normalize_text_plane};
 pub use trace::{NoTracing, OsBootStage, Tracing};
 
 /// CPU generation.

--- a/crates/common/src/text_normalizer.rs
+++ b/crates/common/src/text_normalizer.rs
@@ -1,0 +1,617 @@
+//! CPU-side normalization of the PC-98 text plane.
+//!
+//! Text rendering on the PC-98 is partly stateful: kanji characters span two
+//! cells with a leading + trailing JIS byte, gaiji codes alternate between two
+//! ROM banks, and the underline attribute "bleeds" into the right edge of the
+//! next cell on the same row. Doing this on the GPU forces per-pixel neighbor
+//! lookbacks. We instead walk the 80x25 text plane on the CPU once per VSYNC
+//! and produce a self-contained packed `u32` per cell that the compose shader
+//! can read without any neighbor lookups.
+//!
+//! The packed cell layout matches [`crate::DisplaySnapshotUpload::text_cells`].
+
+use crate::display_snapshot::TEXT_VRAM_BYTES;
+
+/// Width in bits of the font ROM offset field within a packed cell.
+const FONT_OFFSET_BITS: u32 = 20;
+/// Mask covering the font ROM offset field.
+const FONT_OFFSET_MASK: u32 = (1 << FONT_OFFSET_BITS) - 1;
+/// Bit position of the foreground color field.
+const COLOR_SHIFT: u32 = 20;
+/// Bit position of the `blank` flag.
+const FLAG_BLANK: u32 = 1 << 23;
+/// Bit position of the `reverse` flag.
+const FLAG_REVERSE: u32 = 1 << 24;
+/// Bit position of the `underline_this` flag.
+const FLAG_UNDERLINE_THIS: u32 = 1 << 25;
+/// Bit position of the `underline_left` flag.
+const FLAG_UNDERLINE_LEFT: u32 = 1 << 26;
+/// Bit position of the `vertical_line` flag.
+const FLAG_VLINE: u32 = 1 << 27;
+/// Bit position of the `cursor_cell` flag.
+const FLAG_CURSOR_CELL: u32 = 1 << 28;
+
+/// Number of cells in the normalized text plane.
+pub const TEXT_CELL_COUNT: usize = 4096;
+
+/// Address mask for the cursor EAD field (matches the shader-side mask).
+const CURSOR_ADDRESS_MASK: u32 = 0x3FFFF;
+
+/// Half of the kanji ROM (left half size in bytes). Adding this to a left-half
+/// font offset selects the right half of the same glyph.
+const KANJI_RIGHT_HALF_OFFSET: u32 = 0x800;
+
+/// Offset added to the kanji lead font offset when the cell carries the
+/// semigraphics attribute (attr bit 4 with ATTRSEL on).
+const KANJI_SEMIGRAPHICS_OFFSET: u32 = 8;
+
+/// Base offset of the 8x16 ANK font in the font ROM.
+const ANK_8X16_BASE: u32 = 0x80000;
+/// Base offset of the 6x8 ANK font in the font ROM.
+const ANK_6X8_BASE: u32 = 0x82000;
+/// Bytes per ANK glyph in the font ROM.
+const ANK_GLYPH_STRIDE: u32 = 16;
+/// Offset added for the semigraphics variant in 8x16 mode.
+const ANK_8X16_SEMIGFX_OFFSET: u32 = 0x1000;
+/// Offset added for the semigraphics variant in 6x8 mode.
+const ANK_6X8_SEMIGFX_OFFSET: u32 = 8;
+
+/// Inputs that vary per VSYNC and drive the normalization pass.
+pub struct TextNormalizerInputs<'a> {
+    /// Full TVRAM image: 0x0000-0x1FFF character bytes, 0x2000-0x3FFF attribute bytes.
+    pub text_vram: &'a [u8; TEXT_VRAM_BYTES],
+    /// GDC text pitch in cells per row (typically 80).
+    pub pitch: u32,
+    /// Mask applied to `char_high` to detect kanji. 0xFF for code-access mode,
+    /// 0x00 when KAC dot-access mode is selected (which disables kanji decoding).
+    pub kanji_high_mask: u8,
+    /// True when port 0x68 bit 0 selects semigraphics for attr bit 4 (false = vertical line).
+    pub attr_semigraphics_mode: bool,
+    /// True when port 0x68 bit 3 selects 7x13/8x16 mode (false = 6x8 mode).
+    pub fontsel_8x16: bool,
+    /// True when the current frame's blink phase makes blink-attributed cells visible.
+    pub blink_visible: bool,
+    /// True when the cursor is currently visible.
+    pub cursor_visible: bool,
+    /// EAD address of the cursor cell.
+    pub cursor_addr: u32,
+}
+
+/// Normalizes the text plane into self-contained packed cells.
+///
+/// Walks each TVRAM row left-to-right, carrying forward the per-row state
+/// needed to flatten kanji lead/trail pairs, gaiji bank pairing, underline
+/// bleed, and cursor inheritance. Cells beyond `pitch * rows` for the active
+/// pitch are zeroed.
+pub fn normalize_text_plane(
+    inputs: &TextNormalizerInputs<'_>,
+    out_cells: &mut [u32; TEXT_CELL_COUNT],
+) {
+    out_cells.fill(0);
+
+    let pitch = inputs.pitch as usize;
+    if pitch == 0 {
+        return;
+    }
+
+    let max_rows = TEXT_CELL_COUNT / pitch;
+    let cursor_addr = inputs.cursor_addr & CURSOR_ADDRESS_MASK;
+
+    for row in 0..max_rows {
+        let row_base = row * pitch;
+        normalize_row(inputs, row_base, pitch, cursor_addr, out_cells);
+    }
+}
+
+fn normalize_row(
+    inputs: &TextNormalizerInputs<'_>,
+    row_base: usize,
+    pitch: usize,
+    cursor_addr: u32,
+    out_cells: &mut [u32; TEXT_CELL_COUNT],
+) {
+    let mut kanji_pending = false;
+    let mut kanji_pending_offset: u32 = 0;
+    let mut kanji_pending_was_cursor = false;
+    let mut prev_was_gaiji_lead = false;
+    let mut prev_gaiji_jis: u16 = 0;
+    let mut prev_gaiji_was_cursor = false;
+    let mut prev_underline = false;
+
+    for col in 0..pitch {
+        let cell_idx = row_base + col;
+        if cell_idx >= TEXT_CELL_COUNT {
+            return;
+        }
+
+        let char_offset = cell_idx * 2;
+        let char_low = inputs.text_vram[char_offset];
+        let char_high = inputs.text_vram[char_offset + 1];
+        let attr = inputs.text_vram[char_offset + 0x2000];
+
+        let is_secret = (attr & 0x01) == 0;
+        let is_blink = (attr & 0x02) != 0;
+        let is_reverse = (attr & 0x04) != 0;
+        let is_underline = (attr & 0x08) != 0;
+        let attr_bit4 = (attr & 0x10) != 0;
+        let is_vline = !inputs.attr_semigraphics_mode && attr_bit4;
+        let is_semigfx = inputs.attr_semigraphics_mode && attr_bit4;
+        let color = u32::from((attr >> 5) & 0x07);
+
+        let cell_addr_matches_cursor = inputs.cursor_visible && cursor_addr == cell_idx as u32;
+
+        let is_kanji = (char_high & inputs.kanji_high_mask) != 0;
+        let row_code = char_low & 0x7F;
+        let is_gaiji = is_kanji && (row_code == 0x56 || row_code == 0x57);
+        let kanji_jis: u16 = ((u16::from(char_high) << 8) | u16::from(char_low)) & 0x7F7F;
+        let lead_offset = u32::from(kanji_jis) << 4;
+        let kanji_lead_offset = if is_semigfx {
+            lead_offset + KANJI_SEMIGRAPHICS_OFFSET
+        } else {
+            lead_offset
+        };
+
+        let mut cursor_cell = cell_addr_matches_cursor;
+
+        let mut next_kanji_pending = false;
+        let mut next_kanji_pending_offset: u32 = 0;
+        let mut next_kanji_pending_was_cursor = false;
+        let mut next_prev_was_gaiji_lead = false;
+        let mut next_prev_gaiji_jis: u16 = 0;
+        let mut next_prev_gaiji_was_cursor = false;
+
+        let font_offset = if kanji_pending {
+            cursor_cell = cursor_cell || kanji_pending_was_cursor;
+            kanji_pending_offset + KANJI_RIGHT_HALF_OFFSET
+        } else if is_gaiji {
+            if prev_was_gaiji_lead {
+                if prev_gaiji_jis == kanji_jis {
+                    cursor_cell = cursor_cell || prev_gaiji_was_cursor;
+                }
+                kanji_lead_offset + KANJI_RIGHT_HALF_OFFSET
+            } else {
+                next_prev_was_gaiji_lead = true;
+                next_prev_gaiji_jis = kanji_jis;
+                next_prev_gaiji_was_cursor = cell_addr_matches_cursor;
+                kanji_lead_offset
+            }
+        } else if is_kanji {
+            if !(0x09..0x0C).contains(&row_code) {
+                next_kanji_pending = true;
+                next_kanji_pending_offset = kanji_lead_offset;
+                next_kanji_pending_was_cursor = cell_addr_matches_cursor;
+            }
+            kanji_lead_offset
+        } else if inputs.fontsel_8x16 {
+            ANK_8X16_BASE
+                + u32::from(char_low) * ANK_GLYPH_STRIDE
+                + if is_semigfx {
+                    ANK_8X16_SEMIGFX_OFFSET
+                } else {
+                    0
+                }
+        } else {
+            ANK_6X8_BASE
+                + u32::from(char_low) * ANK_GLYPH_STRIDE
+                + if is_semigfx {
+                    ANK_6X8_SEMIGFX_OFFSET
+                } else {
+                    0
+                }
+        };
+
+        let blank = is_secret || (is_blink && !inputs.blink_visible);
+        let underline_left = prev_underline;
+
+        let mut packed = font_offset & FONT_OFFSET_MASK;
+        packed |= color << COLOR_SHIFT;
+        if blank {
+            packed |= FLAG_BLANK;
+        }
+        if is_reverse {
+            packed |= FLAG_REVERSE;
+        }
+        if is_underline {
+            packed |= FLAG_UNDERLINE_THIS;
+        }
+        if underline_left {
+            packed |= FLAG_UNDERLINE_LEFT;
+        }
+        if is_vline {
+            packed |= FLAG_VLINE;
+        }
+        if cursor_cell {
+            packed |= FLAG_CURSOR_CELL;
+        }
+
+        out_cells[cell_idx] = packed;
+
+        kanji_pending = next_kanji_pending;
+        kanji_pending_offset = next_kanji_pending_offset;
+        kanji_pending_was_cursor = next_kanji_pending_was_cursor;
+        prev_was_gaiji_lead = next_prev_was_gaiji_lead;
+        prev_gaiji_jis = next_prev_gaiji_jis;
+        prev_gaiji_was_cursor = next_prev_gaiji_was_cursor;
+        prev_underline = is_underline;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_vram() -> Box<[u8; TEXT_VRAM_BYTES]> {
+        vec![0u8; TEXT_VRAM_BYTES]
+            .into_boxed_slice()
+            .try_into()
+            .unwrap()
+    }
+
+    fn default_inputs<'a>(text_vram: &'a [u8; TEXT_VRAM_BYTES]) -> TextNormalizerInputs<'a> {
+        TextNormalizerInputs {
+            text_vram,
+            pitch: 80,
+            kanji_high_mask: 0xFF,
+            attr_semigraphics_mode: false,
+            fontsel_8x16: true,
+            blink_visible: true,
+            cursor_visible: false,
+            cursor_addr: 0,
+        }
+    }
+
+    fn write_cell(vram: &mut [u8; TEXT_VRAM_BYTES], cell_idx: usize, low: u8, high: u8, attr: u8) {
+        vram[cell_idx * 2] = low;
+        vram[cell_idx * 2 + 1] = high;
+        vram[cell_idx * 2 + 0x2000] = attr;
+    }
+
+    fn cell_font_offset(packed: u32) -> u32 {
+        packed & FONT_OFFSET_MASK
+    }
+
+    fn cell_color(packed: u32) -> u32 {
+        (packed >> COLOR_SHIFT) & 0x07
+    }
+
+    fn cell_has(packed: u32, flag: u32) -> bool {
+        (packed & flag) != 0
+    }
+
+    #[test]
+    fn ank_8x16_encodes_base_and_color() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 0, b'A', 0x00, 0xE1);
+
+        let inputs = default_inputs(&vram);
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        let cell = out[0];
+        assert_eq!(cell_font_offset(cell), ANK_8X16_BASE + (b'A' as u32) * 16);
+        assert_eq!(cell_color(cell), 0x07);
+        assert!(!cell_has(cell, FLAG_BLANK));
+    }
+
+    #[test]
+    fn ank_6x8_encodes_base() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 5, b'Z', 0x00, 0x21);
+
+        let mut inputs = default_inputs(&vram);
+        inputs.fontsel_8x16 = false;
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert_eq!(cell_font_offset(out[5]), ANK_6X8_BASE + (b'Z' as u32) * 16);
+        assert_eq!(cell_color(out[5]), 0x01);
+    }
+
+    #[test]
+    fn semigraphics_offset_added() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 1, 0x80, 0x00, 0x11);
+
+        let mut inputs = default_inputs(&vram);
+        inputs.attr_semigraphics_mode = true;
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert_eq!(
+            cell_font_offset(out[1]),
+            ANK_8X16_BASE + 0x80 * 16 + ANK_8X16_SEMIGFX_OFFSET
+        );
+        assert!(!cell_has(out[1], FLAG_VLINE));
+    }
+
+    #[test]
+    fn vline_set_when_attr_semigraphics_disabled() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 2, b'B', 0x00, 0x11);
+
+        let inputs = default_inputs(&vram);
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert!(cell_has(out[2], FLAG_VLINE));
+    }
+
+    #[test]
+    fn secret_bit_blanks_cell() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 0, b'X', 0x00, 0x00);
+
+        let inputs = default_inputs(&vram);
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert!(cell_has(out[0], FLAG_BLANK));
+    }
+
+    #[test]
+    fn blink_invisible_blanks_cell() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 0, b'X', 0x00, 0x03);
+
+        let mut inputs = default_inputs(&vram);
+        inputs.blink_visible = false;
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert!(cell_has(out[0], FLAG_BLANK));
+
+        inputs.blink_visible = true;
+        normalize_text_plane(&inputs, &mut out);
+        assert!(!cell_has(out[0], FLAG_BLANK));
+    }
+
+    #[test]
+    fn reverse_attribute_encoded() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 0, b'X', 0x00, 0x05);
+
+        let inputs = default_inputs(&vram);
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert!(cell_has(out[0], FLAG_REVERSE));
+    }
+
+    #[test]
+    fn underline_left_propagates_within_row() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 0, b'A', 0x00, 0x09);
+        write_cell(&mut vram, 1, b'B', 0x00, 0x01);
+        write_cell(&mut vram, 2, b'C', 0x00, 0x01);
+
+        let inputs = default_inputs(&vram);
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert!(cell_has(out[0], FLAG_UNDERLINE_THIS));
+        assert!(!cell_has(out[0], FLAG_UNDERLINE_LEFT));
+        assert!(!cell_has(out[1], FLAG_UNDERLINE_THIS));
+        assert!(cell_has(out[1], FLAG_UNDERLINE_LEFT));
+        assert!(!cell_has(out[2], FLAG_UNDERLINE_LEFT));
+    }
+
+    #[test]
+    fn underline_left_resets_at_row_boundary() {
+        let mut vram = empty_vram();
+        let last_col = 79;
+        write_cell(&mut vram, last_col, b'A', 0x00, 0x09);
+        write_cell(&mut vram, 80, b'B', 0x00, 0x01);
+
+        let inputs = default_inputs(&vram);
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert!(cell_has(out[last_col], FLAG_UNDERLINE_THIS));
+        assert!(!cell_has(out[80], FLAG_UNDERLINE_LEFT));
+    }
+
+    #[test]
+    fn kanji_lead_marks_trail_with_right_half_offset() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 10, 0x21, 0x21, 0x01);
+        write_cell(&mut vram, 11, 0x00, 0x00, 0x01);
+
+        let inputs = default_inputs(&vram);
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        let lead_offset = (0x2121u32 & 0x7F7F) << 4;
+        assert_eq!(cell_font_offset(out[10]), lead_offset);
+        assert_eq!(
+            cell_font_offset(out[11]),
+            lead_offset + KANJI_RIGHT_HALF_OFFSET
+        );
+    }
+
+    #[test]
+    fn half_width_kana_lead_codes_do_not_pair() {
+        let mut vram = empty_vram();
+        for (i, row_code) in [0x09u8, 0x0A, 0x0B].iter().enumerate() {
+            let cell = 20 + i * 2;
+            write_cell(&mut vram, cell, *row_code, 0xA1, 0x01);
+            write_cell(&mut vram, cell + 1, b'X', 0x00, 0x01);
+        }
+
+        let inputs = default_inputs(&vram);
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        for (i, _) in [0x09u8, 0x0A, 0x0B].iter().enumerate() {
+            let following_cell = 20 + i * 2 + 1;
+            assert_eq!(
+                cell_font_offset(out[following_cell]),
+                ANK_8X16_BASE + (b'X' as u32) * 16,
+                "cell after half-width kana lead {i} should be ANK, not kanji trail"
+            );
+        }
+    }
+
+    #[test]
+    fn gaiji_pair_uses_left_then_right_half() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 30, 0x56, 0xA1, 0x01);
+        write_cell(&mut vram, 31, 0x56, 0xA1, 0x01);
+
+        let inputs = default_inputs(&vram);
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        let lead_offset = (0xA156u32 & 0x7F7F) << 4;
+        assert_eq!(cell_font_offset(out[30]), lead_offset);
+        assert_eq!(
+            cell_font_offset(out[31]),
+            lead_offset + KANJI_RIGHT_HALF_OFFSET
+        );
+    }
+
+    #[test]
+    fn cursor_flag_set_on_matching_cell() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 7, b'A', 0x00, 0x01);
+
+        let mut inputs = default_inputs(&vram);
+        inputs.cursor_visible = true;
+        inputs.cursor_addr = 7;
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert!(cell_has(out[7], FLAG_CURSOR_CELL));
+        assert!(!cell_has(out[6], FLAG_CURSOR_CELL));
+        assert!(!cell_has(out[8], FLAG_CURSOR_CELL));
+    }
+
+    #[test]
+    fn cursor_inherits_to_kanji_right_half() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 12, 0x21, 0x21, 0x01);
+        write_cell(&mut vram, 13, 0x00, 0x00, 0x01);
+
+        let mut inputs = default_inputs(&vram);
+        inputs.cursor_visible = true;
+        inputs.cursor_addr = 12;
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert!(cell_has(out[12], FLAG_CURSOR_CELL));
+        assert!(cell_has(out[13], FLAG_CURSOR_CELL));
+    }
+
+    #[test]
+    fn cursor_invisible_clears_flag() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 7, b'A', 0x00, 0x01);
+
+        let mut inputs = default_inputs(&vram);
+        inputs.cursor_visible = false;
+        inputs.cursor_addr = 7;
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert!(!cell_has(out[7], FLAG_CURSOR_CELL));
+    }
+
+    #[test]
+    fn kac_dot_access_disables_kanji_decoding() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 0, 0x21, 0x21, 0x01);
+        write_cell(&mut vram, 1, 0x00, 0x00, 0x01);
+
+        let mut inputs = default_inputs(&vram);
+        inputs.kanji_high_mask = 0x00;
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert_eq!(cell_font_offset(out[0]), ANK_8X16_BASE + 0x21 * 16);
+        assert_eq!(cell_font_offset(out[1]), ANK_8X16_BASE);
+    }
+
+    #[test]
+    fn gaiji_mismatched_pair_emits_right_half() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 40, 0x56, 0xA1, 0x01);
+        write_cell(&mut vram, 41, 0x56, 0xA2, 0x01);
+
+        let inputs = default_inputs(&vram);
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        let lead_offset_a = (0xA156u32 & 0x7F7F) << 4;
+        let lead_offset_b = (0xA256u32 & 0x7F7F) << 4;
+        assert_eq!(cell_font_offset(out[40]), lead_offset_a);
+        assert_eq!(
+            cell_font_offset(out[41]),
+            lead_offset_b + KANJI_RIGHT_HALF_OFFSET,
+            "second gaiji uses its OWN right half regardless of JIS match"
+        );
+    }
+
+    #[test]
+    fn gaiji_mismatched_pair_does_not_inherit_cursor() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 50, 0x56, 0xA1, 0x01);
+        write_cell(&mut vram, 51, 0x56, 0xA2, 0x01);
+
+        let mut inputs = default_inputs(&vram);
+        inputs.cursor_visible = true;
+        inputs.cursor_addr = 50;
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert!(cell_has(out[50], FLAG_CURSOR_CELL));
+        assert!(
+            !cell_has(out[51], FLAG_CURSOR_CELL),
+            "cursor must not inherit when JIS codes differ"
+        );
+    }
+
+    #[test]
+    fn kanji_lead_with_semigraphics_adds_eight() {
+        let mut vram = empty_vram();
+        // Kanji at JIS 0x2121 with attr bit 4 set.
+        write_cell(&mut vram, 60, 0x21, 0x21, 0x11);
+        write_cell(&mut vram, 61, 0x00, 0x00, 0x01);
+
+        let mut inputs = default_inputs(&vram);
+        inputs.attr_semigraphics_mode = true;
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        let lead_offset = (0x2121u32 & 0x7F7F) << 4;
+        assert_eq!(cell_font_offset(out[60]), lead_offset + 8);
+    }
+
+    #[test]
+    fn kanji_trail_inherits_semigraphics_offset() {
+        let mut vram = empty_vram();
+        write_cell(&mut vram, 70, 0x21, 0x21, 0x11);
+        write_cell(&mut vram, 71, 0x00, 0x00, 0x01);
+
+        let mut inputs = default_inputs(&vram);
+        inputs.attr_semigraphics_mode = true;
+        let mut out = [0u32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        let lead_offset = (0x2121u32 & 0x7F7F) << 4;
+        assert_eq!(
+            cell_font_offset(out[71]),
+            lead_offset + 8 + KANJI_RIGHT_HALF_OFFSET,
+            "trail must inherit the lead's +8 semigraphics offset"
+        );
+    }
+
+    #[test]
+    fn pitch_zero_produces_zero_cells() {
+        let vram = empty_vram();
+        let mut inputs = default_inputs(&vram);
+        inputs.pitch = 0;
+        let mut out = [0xDEAD_BEEFu32; TEXT_CELL_COUNT];
+        normalize_text_plane(&inputs, &mut out);
+
+        assert!(out.iter().all(|&c| c == 0));
+    }
+}

--- a/crates/device/src/cgrom.rs
+++ b/crates/device/src/cgrom.rs
@@ -155,16 +155,17 @@ impl Cgrom {
     /// Only meaningful on VX+ machines (GRCG chip >= 2). On VM, the caller should
     /// not route through this path.
     ///
-    /// `font_7x13_mode`: true when mode1 bit 3 (font select) is set. Affects
-    /// the half-width character offset (+0x2000 when false).
-    pub fn compute_window(&self, font_7x13_mode: bool) -> CgWindow {
+    /// `font_8x16_mode`: true when mode1 bit 3 (font select) is set, which
+    /// selects the 8x16-cell font (7x13-dot font in 400-line). Affects the
+    /// half-width character offset (+0x2000 when false, i.e. 6x8 mode).
+    pub fn compute_window(&self, font_8x16_mode: bool) -> CgWindow {
         let code = self.state.code;
         let low_byte = (code & 0x007F) as u8;
 
         if code & 0xFF00 == 0 {
             // Half-width (ANK) character.
             let mut high = HALFWIDTH_BASE + ((code as usize) << 4);
-            if !font_7x13_mode {
+            if !font_8x16_mode {
                 high += 0x2000;
             }
             CgWindow {

--- a/crates/device/src/display_control.rs
+++ b/crates/device/src/display_control.rs
@@ -265,8 +265,13 @@ impl DisplayControl {
         self.state.video_mode & MODE1_COLUMN_WIDTH != 0
     }
 
-    /// Returns whether font select is set to 7x13 mode (mode1 bit 3).
-    pub fn is_font_7x13_mode(&self) -> bool {
+    /// Returns whether the 8x16-cell font is selected (mode1 bit 3 set).
+    ///
+    /// Per `undoc98`, mode1 bit 3 = 1 selects the 7x13-dot font for 400-line
+    /// displays, which is rendered inside 8x16 cells. The rest of the
+    /// text-rendering code uses cell-size terminology (`ANK_8X16_BASE`,
+    /// `fontsel_8x16`); this helper matches that.
+    pub fn is_font_8x16_mode(&self) -> bool {
         self.state.video_mode & MODE1_FONT_SEL != 0
     }
 
@@ -314,7 +319,7 @@ mod tests {
 
         assert!(!display_control.is_attr_semigraphics_enabled());
         assert!(!display_control.is_text_40_columns());
-        assert!(!display_control.is_font_7x13_mode());
+        assert!(!display_control.is_font_8x16_mode());
         assert!(!display_control.is_hide_odd_rasters_enabled());
         assert!(!display_control.is_kac_dot_access_mode());
 
@@ -326,7 +331,7 @@ mod tests {
 
         assert!(display_control.is_attr_semigraphics_enabled());
         assert!(display_control.is_text_40_columns());
-        assert!(display_control.is_font_7x13_mode());
+        assert!(display_control.is_font_8x16_mode());
         assert!(display_control.is_hide_odd_rasters_enabled());
         assert!(display_control.is_kac_dot_access_mode());
 
@@ -338,7 +343,7 @@ mod tests {
 
         assert!(!display_control.is_attr_semigraphics_enabled());
         assert!(!display_control.is_text_40_columns());
-        assert!(!display_control.is_font_7x13_mode());
+        assert!(!display_control.is_font_8x16_mode());
         assert!(!display_control.is_hide_odd_rasters_enabled());
         assert!(!display_control.is_kac_dot_access_mode());
     }

--- a/crates/graphics_engine/shaders/passes/compose/compose.slang
+++ b/crates/graphics_engine/shaders/passes/compose/compose.slang
@@ -22,7 +22,7 @@ struct DisplaySnapshotUpload {
     uint text_cursor;
     uint gdc_graphics_al;
     uint reserved_header_words[26];
-    uint text_vram_words[4096];
+    uint text_cells[4096];
     uint graphics_b_plane[8192];
     uint graphics_r_plane[8192];
     uint graphics_g_plane[8192];
@@ -232,8 +232,6 @@ func compute_text_pixel(x: uint, y: uint, out pixel_on: bool, out color_index: u
     let video_mode = upload_buffer[0].video_mode;
     let width40_mode = (video_mode & 0x04) != 0;
     let fontsel_8x16 = (video_mode & 0x08) != 0;
-    let attr_semigraphics_mode = (video_mode & 0x01) != 0;
-    let kanji_high_mask = upload_buffer[0].gdc_text_kanji_high_mask;
 
     // CRTC register extraction (all registers are 5-bit, 0-31).
     let crtc_pl_bl = upload_buffer[0].crtc_pl_bl;
@@ -333,110 +331,29 @@ func compute_text_pixel(x: uint, y: uint, out pixel_on: bool, out color_index: u
     let glyph_x = width40_mode ? ((x / 2) % 8) : (x % 8);
     let memory_col = width40_mode ? ((x / 16) * 2) : (x / 8);
 
-    let char_byte_offset = (scroll_start + row * pitch + memory_col) * 2;
-    let attr_byte_offset = char_byte_offset + 0x2000;
+    // The text plane is pre-normalized on the CPU: each cell carries its own
+    // font ROM offset, color, and rendering flags so this shader does not need
+    // any neighbor lookups.
+    let cell_index = scroll_start + row * pitch + memory_col;
+    let cell = upload_buffer[0].text_cells[cell_index & 0xFFF];
+    let font_offset    = cell & 0xFFFFF;
+    color_index        = (cell >> 20) & 0x07;
+    let blank          = ((cell >> 23) & 1) != 0;
+    let is_reverse     = ((cell >> 24) & 1) != 0;
+    let is_underline   = ((cell >> 25) & 1) != 0;
+    let underline_left = ((cell >> 26) & 1) != 0;
+    let is_vline       = ((cell >> 27) & 1) != 0;
+    let cursor_cell    = ((cell >> 28) & 1) != 0;
 
-    let char_low = read_text_vram_byte(char_byte_offset);
-    let char_high = read_text_vram_byte(char_byte_offset + 1);
-    let attr_byte = read_text_vram_byte(attr_byte_offset);
-
-    let semigraphics = attr_semigraphics_mode && ((attr_byte & 0x10) != 0);
-    let is_kanji = (char_high & kanji_high_mask) != 0;
-    let char_row_code = char_low & 0x7F;
-    let is_gaiji = is_kanji && ((char_row_code == 0x56) || (char_row_code == 0x57));
-    let character_step = width40_mode ? 2u : 1u;
-
-    var previous_char_low = 0u;
-    var previous_char_high = 0u;
-    var previous_is_kanji = false;
-    var previous_is_gaiji = false;
-    var previous_is_trail_code = false;
-    var previous_is_normal_doublewidth = false;
-    if (memory_col >= character_step) {
-        let previous_byte_offset = (scroll_start + row * pitch + memory_col - character_step) * 2;
-        previous_char_low = read_text_vram_byte(previous_byte_offset);
-        previous_char_high = read_text_vram_byte(previous_byte_offset + 1);
-        previous_is_kanji = (previous_char_high & kanji_high_mask) != 0;
-
-        if (previous_is_kanji) {
-            let previous_row_code = previous_char_low & 0x7F;
-            // Trail bytes (kanji right-half cells) have bit 7 set in at least one byte.
-            // Some programs set it in char_low, others in char_high. A genuine kanji
-            // left half never has bit 7 in either byte (row 0x01-0x5D, ten 0x21-0x7E).
-            previous_is_trail_code = ((previous_char_low | previous_char_high) & 0x80) != 0;
-            previous_is_gaiji = (previous_row_code == 0x56) || (previous_row_code == 0x57);
-            previous_is_normal_doublewidth =
-                !previous_is_trail_code &&
-                !previous_is_gaiji &&
-                ((previous_row_code < 0x09) || (previous_row_code >= 0x0C));
-        }
-    }
-
-    let gaiji_matches_previous =
-        is_gaiji &&
-        previous_is_gaiji &&
-        !previous_is_trail_code &&
-        (((char_high << 8) | char_low) & 0x7F7F) == (((previous_char_high << 8) | previous_char_low) & 0x7F7F);
-    let is_right_half = previous_is_normal_doublewidth || gaiji_matches_previous;
     var on: bool;
-
-    if (!font_visible) {
-        // Outside CL range or negative font_line: render blank (background only).
+    if (!font_visible || blank) {
         on = false;
-    } else if (is_right_half || is_kanji) {
-        // Kanji (double-byte): 16x16 glyph from the kanji font ROM.
-        var kanji_low: uint;
-        var kanji_high: uint;
-        if (previous_is_normal_doublewidth) {
-            kanji_low = previous_char_low;
-            kanji_high = previous_char_high;
-        } else {
-            kanji_low = char_low;
-            kanji_high = char_high;
-        }
-
-        let kanji_code = (kanji_high << 8) | kanji_low;
-        var font_addr: uint = ((kanji_code & 0x7F7F) << 4) + font_rom_line;
-        if (is_right_half) {
-            font_addr += 0x800;
-        }
-
-        let font_byte = read_font_rom_byte(font_addr);
-        on = ((font_byte >> (7u - glyph_x)) & 1u) != 0;
-    } else if (fontsel_8x16) {
-        // 8x16 mode: ANK16 at 0x80000, chargraph16 at 0x81000.
-        var font_base: uint = 0x80000 + char_low * 16 + font_rom_line;
-        if (semigraphics) {
-            font_base += 0x1000;
-        }
-        let font_byte = read_font_rom_byte(font_base);
-        on = ((font_byte >> (7u - glyph_x)) & 1u) != 0;
     } else {
-        // 6x8 mode: ANK8 at 0x82000, chargraph8 at 0x82000+8.
-        // Line number is halved (display rows -> font rows).
-        let half_line = font_rom_line / 2;
-        var font_base: uint = 0x82000 + char_low * 16 + half_line;
-        if (semigraphics) {
-            font_base += 8;
-        }
-        let font_byte = read_font_rom_byte(font_base);
+        // In 6x8 mode the font line is halved for both ANK and kanji glyphs.
+        let is_6x8_mode = !fontsel_8x16;
+        let font_byte_offset = is_6x8_mode ? font_offset + (font_rom_line / 2) : font_offset + font_rom_line;
+        let font_byte = read_font_rom_byte(font_byte_offset);
         on = ((font_byte >> (7u - glyph_x)) & 1u) != 0;
-    }
-
-    let is_secret    = (attr_byte & 0x01) == 0;
-    let is_blink     = (attr_byte & 0x02) != 0;
-    let is_reverse   = (attr_byte & 0x04) != 0;
-    let is_underline = (attr_byte & 0x08) != 0;
-    let is_vline     = !attr_semigraphics_mode && ((attr_byte & 0x10) != 0);
-    color_index      = (attr_byte >> 5) & 0x07;
-
-    if (is_secret) {
-        on = false;
-    }
-
-    let blink_visible = (upload_buffer[0].display_flags & 0x02) != 0;
-    if (is_blink && !blink_visible) {
-        on = false;
     }
 
     if (is_reverse) {
@@ -444,22 +361,14 @@ func compute_text_pixel(x: uint, y: uint, out pixel_on: bool, out color_index: u
     }
 
     // Text cursor overlay: XOR between cursor_top and cursor_bottom scanlines.
-    // Applied before underline/vline so those overlays cannot be punched through.
-    // For kanji characters, the cursor spans both the left and right halves.
-    let text_cursor = upload_buffer[0].text_cursor;
-    let cursor_visible = (text_cursor & 0x80000000) != 0;
-    if (cursor_visible) {
-        let cursor_addr = text_cursor & 0x3FFFF;
-        let char_addr = scroll_start + row * pitch + memory_col;
-        let cursor_hit = (char_addr == cursor_addr)
-            || (is_right_half && memory_col >= character_step
-                && (scroll_start + row * pitch + memory_col - character_step) == cursor_addr);
-        if (cursor_hit) {
-            let cursor_top = int((text_cursor >> 18) & 0x1F);
-            let cursor_bottom = int((text_cursor >> 23) & 0x1F);
-            if (font_line >= cursor_top && font_line <= cursor_bottom) {
-                on = !on;
-            }
+    // The CPU pre-marks cursor cells (including the right half of kanji pairs);
+    // only the raster line range check remains here.
+    if (cursor_cell) {
+        let text_cursor = upload_buffer[0].text_cursor;
+        let cursor_top = int((text_cursor >> 18) & 0x1F);
+        let cursor_bottom = int((text_cursor >> 23) & 0x1F);
+        if (font_line >= cursor_top && font_line <= cursor_bottom) {
+            on = !on;
         }
     }
 
@@ -470,12 +379,8 @@ func compute_text_pixel(x: uint, y: uint, out pixel_on: bool, out color_index: u
         if (is_underline && glyph_x >= 4u) {
             on = true;
         }
-        if (glyph_x < 4u && memory_col >= character_step) {
-            let prev_attr_offset = (scroll_start + row * pitch + memory_col - character_step) * 2u + 0x2000u;
-            let prev_attr = read_text_vram_byte(prev_attr_offset);
-            if ((prev_attr & 0x08) != 0) {
-                on = true;
-            }
+        if (underline_left && glyph_x < 4u) {
+            on = true;
         }
     }
 
@@ -503,14 +408,6 @@ func unpack_low_u16(uint packed_value) -> uint {
 [ForceInline]
 func unpack_high_u16(uint packed_value) -> uint {
     return (packed_value >> 16) & 0xFFFF;
-}
-
-[ForceInline]
-func read_text_vram_byte(uint byte_offset) -> uint {
-    let word_index = byte_offset / 4;
-    let byte_position = byte_offset % 4;
-    let word = upload_buffer[0].text_vram_words[word_index];
-    return (word >> (byte_position * 8)) & 0xFF;
 }
 
 [ForceInline]

--- a/crates/machine/src/bus.rs
+++ b/crates/machine/src/bus.rs
@@ -17,7 +17,8 @@ use std::path::PathBuf;
 
 use common::{
     CpuType, DISPLAY_FLAG_PEGC_256_COLOR, DisplaySnapshotUpload, EventKind, MachineModel,
-    PegcSnapshotUpload, Scheduler, StackVec, cast_u32_slice_as_bytes_mut,
+    PegcSnapshotUpload, Scheduler, StackVec, TextNormalizerInputs, cast_u32_slice_as_bytes_mut,
+    normalize_text_plane,
 };
 use device::{
     beeper::Beeper,
@@ -937,7 +938,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             0xA4000..=0xA4FFF if self.grcg.state.chip >= 2 => {
                 let window = self
                     .cgrom
-                    .compute_window(self.display_control.is_font_7x13_mode());
+                    .compute_window(self.display_control.is_font_8x16_mode());
                 let line = ((address >> 1) & 0x0F) as usize;
                 if address & 1 != 0 {
                     self.memory.font_read(window.high + line)
@@ -1045,7 +1046,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             0xA4000..=0xA4FFF if self.grcg.state.chip >= 2 => {
                 let window = self
                     .cgrom
-                    .compute_window(self.display_control.is_font_7x13_mode());
+                    .compute_window(self.display_control.is_font_8x16_mode());
                 if (address & 1 != 0) && window.writable {
                     let line = ((address >> 1) & 0x0F) as usize;
                     self.memory.font_write(window.high + line, value);
@@ -1240,12 +1241,9 @@ impl<T: Tracing> Pc9801Bus<T> {
             snapshot.gdc_graphics_scroll[i] = area.start_address | (u32::from(line_count) << 16);
         }
 
-        // Text VRAM.
-        let text_vram_words = cast_u32_slice_as_bytes_mut(&mut snapshot.text_vram_words);
-        text_vram_words.copy_from_slice(&*self.memory.state.text_vram);
-
-        // KAC-mode-derived mask for kanji high-byte detection in compose.
-        snapshot.gdc_text_kanji_high_mask = if is_kac_dot_access_mode { 0x00 } else { 0xFF };
+        // KAC-mode-derived mask for kanji high-byte detection.
+        let kanji_high_mask: u8 = if is_kac_dot_access_mode { 0x00 } else { 0xFF };
+        snapshot.gdc_text_kanji_high_mask = u32::from(kanji_high_mask);
 
         // CRTC registers.
         snapshot.crtc_pl_bl =
@@ -1271,6 +1269,19 @@ impl<T: Tracing> Pc9801Bus<T> {
         } else {
             0
         };
+
+        // Normalize the text plane into self-contained per-cell descriptors.
+        let normalizer_inputs = TextNormalizerInputs {
+            text_vram: &self.memory.state.text_vram,
+            pitch: u32::from(self.gdc_master.state.pitch),
+            kanji_high_mask,
+            attr_semigraphics_mode: self.display_control.is_attr_semigraphics_enabled(),
+            fontsel_8x16: self.display_control.is_font_8x16_mode(),
+            blink_visible: text_blink_visible,
+            cursor_visible: cursor_enabled,
+            cursor_addr,
+        };
+        normalize_text_plane(&normalizer_inputs, &mut snapshot.text_cells);
 
         // Graphics GDC active display lines.
         snapshot.gdc_graphics_al = u32::from(self.gdc_slave.state.al);
@@ -2431,10 +2442,6 @@ mod tests {
         bus.gdc_master.state.blink_counter = 64;
         bus.gdc_master.state.scroll[0].start_address = 0x1234;
         bus.gdc_master.state.scroll[0].line_count = 0x00AB;
-        bus.memory.state.text_vram[0..8].copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
-        bus.memory.state.text_vram[0x1234..0x1238].copy_from_slice(&[9, 10, 11, 12]);
-        bus.memory.state.text_vram[0x3FFC..0x4000].copy_from_slice(&[13, 14, 15, 16]);
-
         bus.gdc_slave.state.scroll[0].start_address = 0x5678;
         bus.gdc_slave.state.scroll[0].line_count = 0x00CD;
         bus.gdc_slave.state.pitch = 40;
@@ -2455,22 +2462,6 @@ mod tests {
         assert_eq!(snapshot.gdc_graphics_scroll[0], 0x00CD_5678);
         assert_eq!(snapshot.gdc_graphics_pitch, 80);
         assert_eq!(snapshot.video_mode, 0x1C);
-        assert_eq!(
-            snapshot.text_vram_words[0],
-            u32::from_le_bytes([1, 2, 3, 4])
-        );
-        assert_eq!(
-            snapshot.text_vram_words[1],
-            u32::from_le_bytes([5, 6, 7, 8])
-        );
-        assert_eq!(
-            snapshot.text_vram_words[0x1234 / 4],
-            u32::from_le_bytes([9, 10, 11, 12])
-        );
-        assert_eq!(
-            snapshot.text_vram_words[0x3FFC / 4],
-            u32::from_le_bytes([13, 14, 15, 16])
-        );
         assert_eq!(snapshot.graphics_b_plane[0] & 0xFF, 0xAA);
         assert_eq!(snapshot.graphics_r_plane[0] & 0xFF, 0xBB);
         assert_eq!(snapshot.graphics_g_plane[0] & 0xFF, 0xCC);

--- a/src/image_selector.rs
+++ b/src/image_selector.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
-use common::{DisplaySnapshotUpload, JisChar, StackVec, cast_u32_slice_as_bytes_mut, str_to_jis};
+use common::{
+    DisplaySnapshotUpload, JisChar, StackVec, TEXT_VRAM_BYTES, TextNormalizerInputs,
+    normalize_text_plane, str_to_jis,
+};
 
 const VISIBLE_ITEMS: usize = 19;
 const COLS: usize = 80;
@@ -47,6 +50,7 @@ pub struct ImageSelector {
     cursor: usize,
     scroll_offset: usize,
     snapshot: Box<DisplaySnapshotUpload>,
+    text_vram: Box<TextVram>,
     title_jis: Vec<JisChar>,
     dirty: bool,
 }
@@ -60,11 +64,16 @@ impl ImageSelector {
             0
         };
         let title_jis = str_to_jis(media_title(&media_type));
+        let text_vram: Box<TextVram> = vec![0u8; TEXT_VRAM_BYTES]
+            .into_boxed_slice()
+            .try_into()
+            .expect("TEXT_VRAM_BYTES");
         Self {
             media_type,
             cursor,
             scroll_offset,
             snapshot: Box::new(DisplaySnapshotUpload::zeroed()),
+            text_vram,
             title_jis,
             dirty: true,
         }
@@ -122,6 +131,7 @@ impl ImageSelector {
         self.dirty = false;
         rebuild_snapshot(
             &mut self.snapshot,
+            &mut self.text_vram,
             entries,
             &self.title_jis,
             self.cursor,
@@ -135,51 +145,46 @@ impl ImageSelector {
     }
 }
 
-/// Writes a single byte into the text VRAM region of a snapshot.
-fn write_vram_byte(snapshot: &mut DisplaySnapshotUpload, byte_offset: usize, value: u8) {
-    let vram_bytes = cast_u32_slice_as_bytes_mut(&mut snapshot.text_vram_words);
-    vram_bytes[byte_offset] = value;
+type TextVram = [u8; TEXT_VRAM_BYTES];
+
+/// Writes a single byte into a text VRAM buffer.
+fn write_vram_byte(text_vram: &mut TextVram, byte_offset: usize, value: u8) {
+    text_vram[byte_offset] = value;
 }
 
 /// Writes a single ANK character and its attribute into one VRAM cell.
-fn write_ank_cell(snapshot: &mut DisplaySnapshotUpload, row: usize, col: usize, ch: u8, attr: u8) {
+fn write_ank_cell(text_vram: &mut TextVram, row: usize, col: usize, ch: u8, attr: u8) {
     let offset = (row * COLS + col) * 2;
-    write_vram_byte(snapshot, offset, ch);
-    write_vram_byte(snapshot, offset + 1, 0x00);
-    write_vram_byte(snapshot, 0x2000 + offset, attr);
-    write_vram_byte(snapshot, 0x2000 + offset + 1, attr);
+    write_vram_byte(text_vram, offset, ch);
+    write_vram_byte(text_vram, offset + 1, 0x00);
+    write_vram_byte(text_vram, 0x2000 + offset, attr);
+    write_vram_byte(text_vram, 0x2000 + offset + 1, attr);
 }
 
 /// Writes a full-width JIS character into the VRAM at (row, col), occupying two screen columns.
 ///
 /// The first cell stores the JIS code. The second cell (col+1) is written as a dummy ANK (0x00);
-/// the compose shader detects that the previous cell was kanji and automatically renders the
+/// the normalizer detects that the previous cell was kanji and automatically renders the
 /// right half of the glyph there.
-fn write_fullwidth_cell(
-    snapshot: &mut DisplaySnapshotUpload,
-    row: usize,
-    col: usize,
-    jis: JisChar,
-    attr: u8,
-) {
+fn write_fullwidth_cell(text_vram: &mut TextVram, row: usize, col: usize, jis: JisChar, attr: u8) {
     let offset = (row * COLS + col) * 2;
     let (even, odd) = jis.to_vram_bytes();
-    write_vram_byte(snapshot, offset, even);
-    write_vram_byte(snapshot, offset + 1, odd);
-    write_vram_byte(snapshot, 0x2000 + offset, attr);
-    write_vram_byte(snapshot, 0x2000 + offset + 1, attr);
+    write_vram_byte(text_vram, offset, even);
+    write_vram_byte(text_vram, offset + 1, odd);
+    write_vram_byte(text_vram, 0x2000 + offset, attr);
+    write_vram_byte(text_vram, 0x2000 + offset + 1, attr);
 
     // Right-half placeholder: dummy ANK with the same attribute.
     let offset2 = (row * COLS + col + 1) * 2;
-    write_vram_byte(snapshot, offset2, 0x00);
-    write_vram_byte(snapshot, offset2 + 1, 0x00);
-    write_vram_byte(snapshot, 0x2000 + offset2, attr);
-    write_vram_byte(snapshot, 0x2000 + offset2 + 1, attr);
+    write_vram_byte(text_vram, offset2, 0x00);
+    write_vram_byte(text_vram, offset2 + 1, 0x00);
+    write_vram_byte(text_vram, 0x2000 + offset2, attr);
+    write_vram_byte(text_vram, 0x2000 + offset2 + 1, attr);
 }
 
 /// Draws a mixed ANK/full-width JIS string, returning the number of columns consumed.
 fn draw_jis_string(
-    snapshot: &mut DisplaySnapshotUpload,
+    text_vram: &mut TextVram,
     row: usize,
     start_col: usize,
     chars: &[JisChar],
@@ -193,68 +198,56 @@ fn draw_jis_string(
             if col >= limit {
                 break;
             }
-            write_ank_cell(snapshot, row, col, jis.as_u16() as u8, attr);
+            write_ank_cell(text_vram, row, col, jis.as_u16() as u8, attr);
             col += 1;
         } else {
             if col + 2 > limit {
                 break;
             }
-            write_fullwidth_cell(snapshot, row, col, jis, attr);
+            write_fullwidth_cell(text_vram, row, col, jis, attr);
             col += 2;
         }
     }
     col - start_col
 }
 
-fn draw_ank_str(
-    snapshot: &mut DisplaySnapshotUpload,
-    row: usize,
-    start_col: usize,
-    text: &str,
-    attr: u8,
-) {
+fn draw_ank_str(text_vram: &mut TextVram, row: usize, start_col: usize, text: &str, attr: u8) {
     for (i, byte) in text.bytes().enumerate() {
-        write_ank_cell(snapshot, row, start_col + i, byte, attr);
+        write_ank_cell(text_vram, row, start_col + i, byte, attr);
     }
 }
 
 /// Writes a half-width JIS character (rows 0x29-0x2B) into a single VRAM column.
-fn write_halfwidth_cell(
-    snapshot: &mut DisplaySnapshotUpload,
-    row: usize,
-    col: usize,
-    jis: JisChar,
-    attr: u8,
-) {
+fn write_halfwidth_cell(text_vram: &mut TextVram, row: usize, col: usize, jis: JisChar, attr: u8) {
     let offset = (row * COLS + col) * 2;
     let (even, odd) = jis.to_vram_bytes();
-    write_vram_byte(snapshot, offset, even);
-    write_vram_byte(snapshot, offset + 1, odd);
-    write_vram_byte(snapshot, 0x2000 + offset, attr);
-    write_vram_byte(snapshot, 0x2000 + offset + 1, attr);
+    write_vram_byte(text_vram, offset, even);
+    write_vram_byte(text_vram, offset + 1, odd);
+    write_vram_byte(text_vram, 0x2000 + offset, attr);
+    write_vram_byte(text_vram, 0x2000 + offset + 1, attr);
 }
 
 /// Draws a horizontal border line using half-width box-drawing characters.
 ///
 /// Layout: left corner (col 0) + 78 horizontal segments (cols 1-78) + right corner (col 79).
 fn draw_horizontal_line(
-    snapshot: &mut DisplaySnapshotUpload,
+    text_vram: &mut TextVram,
     row: usize,
     left: JisChar,
     right: JisChar,
     attr: u8,
 ) {
-    write_halfwidth_cell(snapshot, row, 0, left, attr);
+    write_halfwidth_cell(text_vram, row, 0, left, attr);
     for col in 1..79 {
-        write_halfwidth_cell(snapshot, row, col, BOX_HORIZONTAL, attr);
+        write_halfwidth_cell(text_vram, row, col, BOX_HORIZONTAL, attr);
     }
-    write_halfwidth_cell(snapshot, row, 79, right, attr);
+    write_halfwidth_cell(text_vram, row, 79, right, attr);
 }
 
 /// Draws left and right vertical border characters for a content row.
-fn draw_vertical_borders(snapshot: &mut DisplaySnapshotUpload, row: usize, attr: u8) {
-    write_halfwidth_cell(snapshot, row, 0, BOX_VERTICAL, attr);
-    write_halfwidth_cell(snapshot, row, 79, BOX_VERTICAL, attr);
+fn draw_vertical_borders(text_vram: &mut TextVram, row: usize, attr: u8) {
+    write_halfwidth_cell(text_vram, row, 0, BOX_VERTICAL, attr);
+    write_halfwidth_cell(text_vram, row, 79, BOX_VERTICAL, attr);
 }
 
 fn media_title(media_type: &MediaType) -> &'static str {
@@ -267,6 +260,7 @@ fn media_title(media_type: &MediaType) -> &'static str {
 
 fn rebuild_snapshot(
     snapshot: &mut DisplaySnapshotUpload,
+    text_vram: &mut TextVram,
     entries: &[ImageEntry],
     title_jis: &[JisChar],
     cursor: usize,
@@ -274,6 +268,7 @@ fn rebuild_snapshot(
     current_index: Option<usize>,
 ) {
     *snapshot = DisplaySnapshotUpload::zeroed();
+    text_vram.fill(0);
 
     snapshot.palette_rgba[0] = 0xFF000000; // black
     snapshot.palette_rgba[1] = 0xFF0000BB; // blue
@@ -295,12 +290,12 @@ fn rebuild_snapshot(
 
     let attr = ATTR_WHITE;
 
-    draw_horizontal_line(snapshot, 0, BOX_TOP_LEFT, BOX_TOP_RIGHT, attr);
+    draw_horizontal_line(text_vram, 0, BOX_TOP_LEFT, BOX_TOP_RIGHT, attr);
 
-    draw_vertical_borders(snapshot, 1, attr);
-    draw_jis_string(snapshot, 1, 2, title_jis, attr, 76);
+    draw_vertical_borders(text_vram, 1, attr);
+    draw_jis_string(text_vram, 1, 2, title_jis, attr, 76);
 
-    draw_horizontal_line(snapshot, 2, BOX_T_LEFT, BOX_T_RIGHT, attr);
+    draw_horizontal_line(text_vram, 2, BOX_T_LEFT, BOX_T_RIGHT, attr);
 
     // Display list: index 0 = "<Empty>", indices 1..=N = disk image entries.
     let total = entries.len() + 1;
@@ -314,7 +309,7 @@ fn rebuild_snapshot(
         let row = 3 + i;
         let display_index = scroll_offset + i;
 
-        draw_vertical_borders(snapshot, row, attr);
+        draw_vertical_borders(text_vram, row, attr);
 
         if display_index >= total {
             continue;
@@ -335,15 +330,15 @@ fn rebuild_snapshot(
         };
 
         for col in 1..79 {
-            write_ank_cell(snapshot, row, col, b' ', line_attr);
+            write_ank_cell(text_vram, row, col, b' ', line_attr);
         }
 
         if is_cursor {
-            draw_ank_str(snapshot, row, 1, " >", line_attr);
+            draw_ank_str(text_vram, row, 1, " >", line_attr);
         }
 
         if display_index == 0 {
-            draw_ank_str(snapshot, row, 3, "<Empty>", line_attr);
+            draw_ank_str(text_vram, row, 3, "<Empty>", line_attr);
         } else {
             let entry = &entries[display_index - 1];
             let jis = &entry.jis_filename;
@@ -351,7 +346,7 @@ fn rebuild_snapshot(
             if cols_needed > FILENAME_MAX_COLS {
                 let truncated = truncate_jis(jis, FILENAME_MAX_COLS - 2);
                 draw_jis_string(
-                    snapshot,
+                    text_vram,
                     row,
                     3,
                     &truncated,
@@ -359,36 +354,49 @@ fn rebuild_snapshot(
                     FILENAME_MAX_COLS - 2,
                 );
                 let end_col = 3 + jis_display_width(&truncated);
-                draw_ank_str(snapshot, row, end_col, "..", line_attr);
+                draw_ank_str(text_vram, row, end_col, "..", line_attr);
             } else {
-                draw_jis_string(snapshot, row, 3, jis, line_attr, FILENAME_MAX_COLS);
+                draw_jis_string(text_vram, row, 3, jis, line_attr, FILENAME_MAX_COLS);
             }
         }
 
         if is_loaded {
-            draw_ank_str(snapshot, row, 70, "[loaded]", line_attr);
+            draw_ank_str(text_vram, row, 70, "[loaded]", line_attr);
         }
 
         if i == 0 && can_scroll_up {
-            write_ank_cell(snapshot, row, 78, b'^', line_attr);
+            write_ank_cell(text_vram, row, 78, b'^', line_attr);
         }
         if i == VISIBLE_ITEMS - 1 && can_scroll_down {
-            write_ank_cell(snapshot, row, 78, b'v', line_attr);
+            write_ank_cell(text_vram, row, 78, b'v', line_attr);
         }
     }
 
-    draw_horizontal_line(snapshot, 22, BOX_T_LEFT, BOX_T_RIGHT, attr);
+    draw_horizontal_line(text_vram, 22, BOX_T_LEFT, BOX_T_RIGHT, attr);
 
-    draw_vertical_borders(snapshot, 23, attr);
+    draw_vertical_borders(text_vram, 23, attr);
     draw_ank_str(
-        snapshot,
+        text_vram,
         23,
         2,
         "Up/Down:Move  Enter:Select/Eject  ESC:Cancel",
         attr,
     );
 
-    draw_horizontal_line(snapshot, 24, BOX_BOTTOM_LEFT, BOX_BOTTOM_RIGHT, attr);
+    draw_horizontal_line(text_vram, 24, BOX_BOTTOM_LEFT, BOX_BOTTOM_RIGHT, attr);
+
+    let inputs = TextNormalizerInputs {
+        text_vram,
+        pitch: 80,
+        kanji_high_mask: 0xFF,
+        attr_semigraphics_mode: false,
+        fontsel_8x16: true,
+        blink_visible: true,
+        cursor_visible: false,
+        cursor_addr: 0,
+    };
+
+    normalize_text_plane(&inputs, &mut snapshot.text_cells);
 }
 
 fn jis_display_width(chars: &[JisChar]) -> usize {


### PR DESCRIPTION
The compose shader used to walk the text plane per pixel and reach back into neighboring cells twice: once to detect kanji lead/trail pairs (and gaiji bank pairing), and once on the bottom raster line to read the previous cell's attribute byte for the underline bleed. Both lookups exist because PC-98 text rendering is partly stateful, and pushing that state through a stateless GPU shader is awkward.

Walk the 80x25 text plane on the CPU once per VSYNC instead. Each cell is flattened into a self-contained u32: bits 0-19 hold the font ROM offset (the kanji right half is encoded as left + 0x800), bits 20-22 the foreground color, and the upper byte holds blank / reverse / underline_this / underline_left / vertical_line / cursor_cell flags. The 16 KiB upload is identical in size to the previous raw TVRAM mirror.

The new normalizer in common::text_normalizer mirrors NP21W's maketext() and MAME's pc9801_v::draw_text() per-row state machines: kanji_pending + kanji_lead_offset for double-byte chars, gaiji_first toggling on 0x56/0x57, prev_underline for the bleed, and prev_was_cursor / prev_gaiji_was_cursor so the cursor flag inherits onto the right half of a kanji or gaiji pair. Half-width kana lead bytes (row codes 0x09-0x0B) are correctly excluded from kanji pairing. KAC dot-access mode is honored via kanji_high_mask=0x00 to disable kanji decoding.

Wire the normalizer into Pc9801Bus::update_display_snapshot, dropping the prior text_vram memcpy. Rewrite compute_text_pixel in compose.slang to read one packed cell per pixel: it now owns only the (x, y) ->
(scroll_start, row, glyph_y) math, the 6x8 line halving, the cursor raster-line check, the underline/vline overlays, and the final pixel color. The kanji and gaiji backward lookbacks, the prev-attribute underline lookback, and the per-pixel attribute decode are all gone.