### PR TITLE
chore: lower Vulkan requirement from 1.4 to 1.3

### DIFF
--- a/crates/graphics_engine/build.rs
+++ b/crates/graphics_engine/build.rs
@@ -81,7 +81,7 @@ fn compile_shader(shader_file: &Path, output_dir: &Path, modules_dir: &Path) -> 
         .arg("-I")
         .arg(modules_dir)
         .arg("-profile")
-        .arg("spirv_1_6")
+        .arg("spirv_1_5")
         // Uses column major layout for matrices.
         .arg("-matrix-layout-column-major")
         // Uses the entrypoint name from the source instead of 'main' in the spirv output.

--- a/crates/graphics_engine/src/plumbing/device.rs
+++ b/crates/graphics_engine/src/plumbing/device.rs
@@ -53,8 +53,6 @@ pub(crate) struct DeviceConfiguration {
     pub(crate) features_1_2: vk::PhysicalDeviceVulkan12Features<'static>,
     /// Vulkan 1.3 features to request.
     pub(crate) features_1_3: vk::PhysicalDeviceVulkan13Features<'static>,
-    /// Vulkan 1.4 features to request.
-    pub(crate) features_1_4: vk::PhysicalDeviceVulkan14Features<'static>,
     /// VK_KHR_present_id2 features.
     pub(crate) present_id2: Option<vk::PhysicalDevicePresentId2FeaturesKHR<'static>>,
     /// VK_KHR_present_wait2 features.
@@ -63,7 +61,7 @@ pub(crate) struct DeviceConfiguration {
 
 impl DeviceConfiguration {
     /// Creates a new DeviceConfiguration with all the required features.
-    /// Aims to use all best practises for modern Vulkan 1.4.
+    /// Aims to use all best practises for modern Vulkan 1.3.
     pub(crate) fn new(platform_extensions: Vec<*const c_char>) -> Self {
         let mut extensions = vec![
             // Standard swap chain extension (always supported).
@@ -89,8 +87,9 @@ impl DeviceConfiguration {
         };
 
         let features_1_2 = vk::PhysicalDeviceVulkan12Features {
-            // Required support since Vulkan 1.4.
+            // Required by our shader scalar layout.
             scalar_block_layout: vk::TRUE,
+            // Required by our frame resource management.
             timeline_semaphore: vk::TRUE,
             ..Default::default()
         };
@@ -98,12 +97,6 @@ impl DeviceConfiguration {
         let features_1_3 = vk::PhysicalDeviceVulkan13Features {
             dynamic_rendering: vk::TRUE,
             synchronization2: vk::TRUE,
-            ..Default::default()
-        };
-
-        let features_1_4 = vk::PhysicalDeviceVulkan14Features {
-            // Removes the need to create shader modules.
-            maintenance5: vk::TRUE,
             ..Default::default()
         };
 
@@ -119,7 +112,6 @@ impl DeviceConfiguration {
             features_1_1,
             features_1_2,
             features_1_3,
-            features_1_4,
             present_id2: Some(present_id2),
             present_wait2: Some(present_wait2),
         }
@@ -134,7 +126,6 @@ impl DeviceConfiguration {
             features_1_1: self.features_1_1,
             features_1_2: self.features_1_2,
             features_1_3: self.features_1_3,
-            features_1_4: self.features_1_4,
             present_id2: self.present_id2,
             present_wait2: self.present_wait2,
         }
@@ -164,11 +155,11 @@ impl Device {
             .context("Failed to enumerate instance version")?
             .unwrap_or(vk::make_api_version(0, 1, 0, 0));
 
-        if api_version < vk::make_api_version(0, 1, 4, 0) {
-            bail!("Unsupported Vulkan API version (requires 1.4+)");
+        if api_version < vk::make_api_version(0, 1, 3, 0) {
+            bail!("Unsupported Vulkan API version (requires 1.3+)");
         }
 
-        let api_version = vk::make_api_version(0, 1, 4, 0);
+        let api_version = vk::make_api_version(0, 1, 3, 0);
 
         info!(
             "Using Vulkan API Version: {api_version}",
@@ -239,8 +230,8 @@ impl Device {
             unsafe { CStr::from_ptr(device_properties.device_name.as_ptr()).to_string_lossy() };
         info!("Selected physical device: {device_name}");
 
-        // We do not need to check for limits, since our requirements are well within the
-        // requirements for Vulkan 1.4 support:
+        // We do not check for limits, since our requirements are well within the
+        // common desktop class limits:
         //
         // maxImageDimension2D = 8192 (we need 640x400 and the device has to support the color target for the viewport size)
         // maxMemoryAllocationCount = 4096 (we only allocate a couple of images and buffers)

--- a/crates/graphics_engine/src/plumbing/features.rs
+++ b/crates/graphics_engine/src/plumbing/features.rs
@@ -1,4 +1,4 @@
-//! Vulkan physical device feature management for Vulkan 1.0-1.4.
+//! Vulkan physical device feature management for Vulkan 1.0-1.3.
 
 use common::{bail, error, info, warn};
 use jay_ash::vk;
@@ -7,7 +7,7 @@ use crate::{Result, plumbing::extensions::ExtensionSet};
 
 /// Configuration for which device features to request.
 ///
-/// Features are organized by Vulkan version (1.0-1.4) and by extension.
+/// Features are organized by Vulkan version (1.0-1.3) and by extension.
 /// Only features that are both requested AND available will be enabled.
 #[derive(Default, Clone)]
 pub(crate) struct DeviceFeatures {
@@ -19,8 +19,6 @@ pub(crate) struct DeviceFeatures {
     pub(crate) features_1_2: vk::PhysicalDeviceVulkan12Features<'static>,
     /// Vulkan 1.3 features.
     pub(crate) features_1_3: vk::PhysicalDeviceVulkan13Features<'static>,
-    /// Vulkan 1.4 features.
-    pub(crate) features_1_4: vk::PhysicalDeviceVulkan14Features<'static>,
     /// VK_KHR_present_id2 features.
     pub(crate) present_id2: Option<vk::PhysicalDevicePresentId2FeaturesKHR<'static>>,
     /// VK_KHR_present_wait2 features.
@@ -114,7 +112,6 @@ pub(crate) fn query_physical_device_features(
     let mut features_1_1 = vk::PhysicalDeviceVulkan11Features::default();
     let mut features_1_2 = vk::PhysicalDeviceVulkan12Features::default();
     let mut features_1_3 = vk::PhysicalDeviceVulkan13Features::default();
-    let mut features_1_4 = vk::PhysicalDeviceVulkan14Features::default();
 
     init_extension_features! {
         extension_set;
@@ -128,8 +125,7 @@ pub(crate) fn query_physical_device_features(
     features_1_1.p_next = std::ptr::null_mut();
     features_1_2.p_next = &mut features_1_1 as *mut _ as *mut std::ffi::c_void;
     features_1_3.p_next = &mut features_1_2 as *mut _ as *mut std::ffi::c_void;
-    features_1_4.p_next = &mut features_1_3 as *mut _ as *mut std::ffi::c_void;
-    features2.p_next = &mut features_1_4 as *mut _ as *mut std::ffi::c_void;
+    features2.p_next = &mut features_1_3 as *mut _ as *mut std::ffi::c_void;
 
     chain_extension_features! {
         features2;
@@ -147,7 +143,6 @@ pub(crate) fn query_physical_device_features(
         features_1_1,
         features_1_2,
         features_1_3,
-        features_1_4,
         present_id2,
         present_wait2,
     }
@@ -241,21 +236,6 @@ pub(crate) fn validate_features(
         }
     );
 
-    let mut requested_1_4_list: Vec<&str> = Vec::new();
-    let mut available_1_4_list: Vec<&str> = Vec::new();
-
-    impl_feature_check!(
-        requested.features_1_4, available.features_1_4, requested_1_4_list, available_1_4_list;
-        {
-            global_priority_query shader_subgroup_rotate shader_subgroup_rotate_clustered
-            shader_float_controls2 shader_expect_assume rectangular_lines bresenham_lines
-            smooth_lines stippled_rectangular_lines stippled_bresenham_lines stippled_smooth_lines
-            vertex_attribute_instance_rate_divisor vertex_attribute_instance_rate_zero_divisor
-            index_type_uint8 dynamic_rendering_local_read maintenance5 maintenance6
-            pipeline_protected_access pipeline_robustness host_image_copy push_descriptor
-        }
-    );
-
     log_and_validate_features(
         &requested_1_0_list,
         &available_1_0_list,
@@ -284,14 +264,6 @@ pub(crate) fn validate_features(
         &requested_1_3_list,
         &available_1_3_list,
         "Vulkan 1.3",
-        &mut missing_features,
-        true,
-    );
-
-    log_and_validate_features(
-        &requested_1_4_list,
-        &available_1_4_list,
-        "Vulkan 1.4",
         &mut missing_features,
         true,
     );
@@ -345,8 +317,7 @@ pub(crate) unsafe fn build_features_chain(
     requested.features_1_1.p_next = std::ptr::null_mut();
     requested.features_1_2.p_next = &mut requested.features_1_1 as *mut _ as *mut std::ffi::c_void;
     requested.features_1_3.p_next = &mut requested.features_1_2 as *mut _ as *mut std::ffi::c_void;
-    requested.features_1_4.p_next = &mut requested.features_1_3 as *mut _ as *mut std::ffi::c_void;
-    features2.p_next = &mut requested.features_1_4 as *mut _ as *mut std::ffi::c_void;
+    features2.p_next = &mut requested.features_1_3 as *mut _ as *mut std::ffi::c_void;
 
     chain_extension_features! {
         features2;

--- a/crates/graphics_engine/src/plumbing/graphics_pipeline.rs
+++ b/crates/graphics_engine/src/plumbing/graphics_pipeline.rs
@@ -127,23 +127,22 @@ impl GraphicsPipeline {
     ) -> Result<Self, vk::Result> {
         let device = context.device();
 
-        let mut vertex_module_info = vk::ShaderModuleCreateInfo::default().code(spirv);
-        let mut fragment_module_info = vk::ShaderModuleCreateInfo::default().code(spirv);
+        let shader_module_info = vk::ShaderModuleCreateInfo::default().code(spirv);
+        let shader_module = unsafe { device.create_shader_module(&shader_module_info, None) }?;
 
         let vertex_stage = vk::PipelineShaderStageCreateInfo::default()
             .stage(vk::ShaderStageFlags::VERTEX)
-            .name(vertex_entry)
-            .push_next(&mut vertex_module_info);
+            .module(shader_module)
+            .name(vertex_entry);
 
         let mut fragment_stage = vk::PipelineShaderStageCreateInfo::default()
             .stage(vk::ShaderStageFlags::FRAGMENT)
+            .module(shader_module)
             .name(fragment_entry);
 
         if let Some(spec_info) = config.specialization_info {
             fragment_stage = fragment_stage.specialization_info(spec_info);
         }
-
-        let fragment_stage = fragment_stage.push_next(&mut fragment_module_info);
 
         let stages = [vertex_stage, fragment_stage];
 
@@ -258,8 +257,12 @@ impl GraphicsPipeline {
                 None,
             )
         } {
-            Ok(pipelines) => pipelines[0],
+            Ok(pipelines) => {
+                unsafe { device.destroy_shader_module(shader_module, None) };
+                pipelines[0]
+            }
             Err((_, err)) => {
+                unsafe { device.destroy_shader_module(shader_module, None) };
                 return Err(err);
             }
         };


### PR DESCRIPTION
Also lowers SPIR-V version from 1.6 to 1.5 since some older 1.3 driver might not support SPIR-V 1.6.