### PR TITLE
feature: support CPU mode for all PC-9801

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ files is supported, but should provide no additional benefit.
 
 Currently, we aim to support all 16-bit era DOS games and emulate them accurately for 6 idealized machine targets:
 
-| Machine   | CPU      | CPU Speed | FPU (x87) | Extended RAM | Graphics | Interface | CD-ROM |
-|-----------|----------|-----------|-----------|--------------|----------|-----------|--------|
-| PC-9801F  | 8086     | 5 / 8 Mhz | No        | None         | GDC      | SASI      | No     |
-| PC-9801VM | V30      | 10 Mhz    | No        | None         | GRCG     | SASI      | No     |
-| PC-9801VX | 80286    | 10 Mhz    | No        | 4 MiB        | ECG      | SASI      | No     |
-| PC-9801RA | 80386DX  | 20 Mhz    | Yes       | 12 MiB       | ECG      | SASI      | No     |
-| PC-9821AS | 80486DX  | 33 Mhz    | Yes       | 14 MiB       | PEGC     | IDE       | Yes    |
-| PC-9821AP | 80486DX2 | 66 Mhz    | Yes       | 14 MiB       | PEGC     | IDE       | Yes    |
+| Machine   | CPU      | CPU Speed   | FPU (x87) | Extended RAM | Graphics | Interface | CD-ROM |
+|-----------|----------|-------------|-----------|--------------|----------|-----------|--------|
+| PC-9801F  | 8086     | 5 / 8 MHz   | No        | None         | GDC      | SASI      | No     |
+| PC-9801VM | V30      | 8 / 10 MHz  | No        | None         | GRCG     | SASI      | No     |
+| PC-9801VX | 80286    | 8 / 10 MHz  | No        | 4 MiB        | ECG      | SASI      | No     |
+| PC-9801RA | 80386DX  | 16 / 20 MHz | Yes       | 12 MiB       | ECG      | SASI      | No     |
+| PC-9821AS | 80486DX  | 33 MHz      | Yes       | 14 MiB       | PEGC     | IDE       | Yes    |
+| PC-9821AP | 80486DX2 | 66 MHz      | Yes       | 14 MiB       | PEGC     | IDE       | Yes    |
 
 All targets have the full 640 KiB conventional RAM. The 8086 and V30 are cycle-count accurately emulated.
 The emulated 286 is calibrated to run at the same speed as the original 286 using trace data. The 386 and the 486
@@ -56,7 +56,7 @@ neetan <COMMAND>
 |------------------------------|-------------------------------------------------------------------------------------|------------|
 | `-c, --config <PATH>`        | Load configuration from file                                                        | -          |
 | `--machine <TYPE>`           | Machine type: `PC9801F`, `PC9801VM`, `PC9801VX`, `PC9801RA`, `PC9821AS`, `PC9821AP` | `PC9801RA` |
-| `--cpu-mode <MODE>`          | CPU speed mode: low or high (default: high; only affects PC9801F)                   | high       |
+| `--cpu-mode <MODE>`          | CPU speed mode: low or high (default: high; PC-9801 only)                           | high       |
 | `--fdd1 <PATH>`              | Floppy disk image for drive 1 (repeatable)                                          | -          |
 | `--fdd2 <PATH>`              | Floppy disk image for drive 2 (repeatable)                                          | -          |
 | `--hdd1 <PATH>`              | Hard disk image for hard disk drive 1                                               | -          |

--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -8,17 +8,21 @@
 ; Machine
 ; ---------------------------------------------------------------------------
 
-; Machine type: PC9801F  (PC-9801F, 8086 5/8MHz)
-;               PC9801VM (PC-9801VM, V30 10MHz)
-;               PC9801VX (PC-9801VX, 80286)
-;               PC9801RA (PC-9801RA, 80386DX)
-;               PC9821AS (PC-9801AS, 80486DX)
-;               PC9821AP (PC-9801AP, 80486DX2)
+; Machine type: PC9801F  (PC-9801F, 8086 5/8 MHz)
+;               PC9801VM (PC-9801VM, V30 8/10 MHz)
+;               PC9801VX (PC-9801VX, 80286 8/10 MHz)
+;               PC9801RA (PC-9801RA, 80386DX 16/20 MHz)
+;               PC9821AS (PC-9821AS, 80486DX)
+;               PC9821AP (PC-9821AP, 80486DX2)
 ; machine = PC9801RA
 
 ; CPU speed mode: low or high (default: high).
 ; Machine speeds:
 ;   PC9801F: low = 5 MHz, high = 8 MHz
+;   PC9801VM: low = 8 MHz, high = 10 MHz
+;   PC9801VX: low = 8 MHz, high = 10 MHz
+;   PC9801RA: low = 16 MHz, high = 20 MHz
+;   PC9821AS/PC9821AP: fixed speed, ignores cpu-mode
 ; cpu-mode = high
 
 ; ---------------------------------------------------------------------------

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -127,11 +127,11 @@ pub enum BeeperKind {
 pub enum MachineModel {
     /// PC-9801F (8086, 5/8 MHz, basic µPD7220 only, 20-bit address space).
     PC9801F,
-    /// PC-9801VM (V30, 10 MHz, GRCG v1, 20-bit address space, SASI built-in).
+    /// PC-9801VM (V30, 8/10 MHz, GRCG v1, 20-bit address space, SASI built-in).
     PC9801VM,
-    /// PC-9801VX (80286, 10 MHz, EGC, 24-bit address space, SASI built-in).
+    /// PC-9801VX (80286, 8/10 MHz, EGC, 24-bit address space, SASI built-in).
     PC9801VX,
-    /// PC-9801RA (80386, 20 MHz, EGC, 32-bit address space, SASI built-in).
+    /// PC-9801RA (80386, 16/20 MHz, EGC, 32-bit address space, SASI built-in).
     PC9801RA,
     /// PC-9821AS (486DX, 33 MHz, PEGC, 32-bit address space, IDE built-in).
     PC9821AS,
@@ -165,16 +165,22 @@ impl MachineModel {
 
     /// Returns the CPU clock frequency in Hz for the given CPU mode.
     ///
-    /// Machines with a fixed CPU clock ignore `mode`; only the PC-9801F
-    /// switches between Low (5 MHz) and High (8 MHz).
+    /// PC-9801 models switch between Low and High speeds. PC-9821 models
+    /// ignore `mode`.
     pub const fn cpu_clock_hz(self, mode: CpuMode) -> u32 {
         match self {
             Self::PC9801F => match mode {
                 CpuMode::Low => 5_000_000,
                 CpuMode::High => 8_000_000,
             },
-            Self::PC9801VM | Self::PC9801VX => 10_000_000,
-            Self::PC9801RA => 20_000_000,
+            Self::PC9801VM | Self::PC9801VX => match mode {
+                CpuMode::Low => 8_000_000,
+                CpuMode::High => 10_000_000,
+            },
+            Self::PC9801RA => match mode {
+                CpuMode::Low => 16_000_000,
+                CpuMode::High => 20_000_000,
+            },
             Self::PC9821AS => 33_000_000,
             Self::PC9821AP => 66_000_000,
         }
@@ -440,6 +446,28 @@ impl std::str::FromStr for MachineModel {
             _ => Err(format!(
                 "unknown machine model '{s}', expected PC9801F, PC9801VM, PC9801VX, PC9801RA, PC9821AS, or PC9821AP"
             )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CpuMode, MachineModel};
+
+    #[test]
+    fn machine_cpu_clock_hz_uses_cpu_mode_for_pc9801_models() {
+        let cases = [
+            (MachineModel::PC9801F, 5_000_000, 8_000_000),
+            (MachineModel::PC9801VM, 8_000_000, 10_000_000),
+            (MachineModel::PC9801VX, 8_000_000, 10_000_000),
+            (MachineModel::PC9801RA, 16_000_000, 20_000_000),
+            (MachineModel::PC9821AS, 33_000_000, 33_000_000),
+            (MachineModel::PC9821AP, 66_000_000, 66_000_000),
+        ];
+
+        for (model, low_clock_hz, high_clock_hz) in cases {
+            assert_eq!(model.cpu_clock_hz(CpuMode::Low), low_clock_hz);
+            assert_eq!(model.cpu_clock_hz(CpuMode::High), high_clock_hz);
         }
     }
 }

--- a/crates/machine/src/bus/init.rs
+++ b/crates/machine/src/bus/init.rs
@@ -164,9 +164,8 @@ const KEYBOARD_TABLES: [[u8; 0x60]; 8] = [
 impl<T: Tracing> Pc9801Bus<T> {
     /// Creates a new bus configured for the given machine model and CPU mode.
     ///
-    /// `cpu_mode` selects between Low and High CPU clock for machines that
-    /// support speed switching (currently only the PC-9801F). Other models
-    /// ignore this value.
+    /// `cpu_mode` selects between Low and High CPU clock for PC-9801 models.
+    /// PC-9821 models ignore this value.
     pub fn new(machine_model: MachineModel, cpu_mode: CpuMode, sample_rate: u32) -> Self
     where
         T: Default,

--- a/crates/machine/src/machine.rs
+++ b/crates/machine/src/machine.rs
@@ -130,13 +130,13 @@ impl<C: Cpu, T: Tracing> Machine<C, T> {
 /// PC-9801F machine type (8086 CPU at 5 / 8 MHz, basic µPD7220, 20-bit address space).
 pub type Pc9801F = Machine<cpu::I8086>;
 
-/// PC-9801VM machine type (V30 CPU at 10 MHz).
+/// PC-9801VM machine type (V30 CPU at 8 / 10 MHz).
 pub type Pc9801Vm = Machine<cpu::VX0>;
 
-/// PC-9801VX machine type (80286 CPU at 10 MHz).
+/// PC-9801VX machine type (80286 CPU at 8 / 10 MHz).
 pub type Pc9801Vx = Machine<cpu::I286>;
 
-/// PC-9801RA machine type (80386 SX CPU at 20 MHz).
+/// PC-9801RA machine type (80386 SX CPU at 16 / 20 MHz).
 pub type Pc9801Ra = Machine<cpu::I386>;
 
 /// PC-9821AS machine type (486DX CPU at 33 MHz, IDE, PEGC).

--- a/crates/machine/tests/bios/data.rs
+++ b/crates/machine/tests/bios/data.rs
@@ -211,7 +211,7 @@ fn bios_reset_vector_targets_bios_segment_f() {
 // §4.5 BDA Setup - System configuration
 // ============================================================================
 
-/// PC-9801VM (V30 @ 10 MHz, single-bank BIOS ROM).
+/// PC-9801VM (V30 @ 8 / 10 MHz, single-bank BIOS ROM).
 #[test]
 fn system_config_vm() {
     let mut machine = create_machine_vm();
@@ -233,7 +233,7 @@ fn system_config_vm() {
     assert_eq!(machine.bus.read_byte(BDA_BIOS_FLAG1), 0x64, "BIOS_FLAG1");
 }
 
-/// PC-9801VX (80286 @ 10 MHz, dual-bank BIOS ROM).
+/// PC-9801VX (80286 @ 8 / 10 MHz, dual-bank BIOS ROM).
 #[test]
 fn system_config_vx() {
     let mut machine = create_machine_vx();
@@ -277,7 +277,7 @@ fn system_config_f() {
     assert_eq!(machine.bus.read_byte(BDA_BIOS_FLAG1), 0xA4, "BIOS_FLAG1");
 }
 
-/// PC-9801RA (80386 @ 20 MHz, dual-bank BIOS ROM).
+/// PC-9801RA (80386 @ 16 / 20 MHz, dual-bank BIOS ROM).
 #[test]
 fn system_config_ra() {
     let mut machine = create_machine_ra();

--- a/crates/machine/tests/bus.rs
+++ b/crates/machine/tests/bus.rs
@@ -73,6 +73,28 @@ fn graphics_vram_access() {
 }
 
 #[test]
+fn bus_clock_config_uses_cpu_mode_without_changing_pit_lineage() {
+    let cases = [
+        (MachineModel::PC9801F, 5_000_000, 8_000_000, 1_996_800),
+        (MachineModel::PC9801VM, 8_000_000, 10_000_000, 2_457_600),
+        (MachineModel::PC9801VX, 8_000_000, 10_000_000, 2_457_600),
+        (MachineModel::PC9801RA, 16_000_000, 20_000_000, 1_996_800),
+        (MachineModel::PC9821AS, 33_000_000, 33_000_000, 1_996_800),
+        (MachineModel::PC9821AP, 66_000_000, 66_000_000, 1_996_800),
+    ];
+
+    for (model, low_clock_hz, high_clock_hz, pit_clock_hz) in cases {
+        let low_bus = Pc9801Bus::<NoTracing>::new(model, CpuMode::Low, 48000);
+        let high_bus = Pc9801Bus::<NoTracing>::new(model, CpuMode::High, 48000);
+
+        assert_eq!(low_bus.cpu_clock_hz(), low_clock_hz, "{model} low clock");
+        assert_eq!(high_bus.cpu_clock_hz(), high_clock_hz, "{model} high clock");
+        assert_eq!(low_bus.pit_clock_hz(), pit_clock_hz, "{model} low PIT");
+        assert_eq!(high_bus.pit_clock_hz(), pit_clock_hz, "{model} high PIT");
+    }
+}
+
+#[test]
 fn kanji_ram_stub() {
     let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801VM, CpuMode::High, 48000);
 
@@ -338,7 +360,7 @@ fn pit_mirror_ports() {
 
 #[test]
 fn timer_full_cycle() {
-    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::Low, 48000);
+    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::High, 48000);
 
     // Set up PIC: unmask all.
     bus.io_write_byte(0x00, 0x11);
@@ -376,7 +398,7 @@ fn timer_full_cycle() {
 
 #[test]
 fn timer_value_zero_65536_period() {
-    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::Low, 48000);
+    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::High, 48000);
 
     // Set up PIC: enable only IRQ 0 (timer). Mask IRQ 2 (VSYNC) since this
     // test advances past the VSYNC period.
@@ -401,7 +423,7 @@ fn timer_value_zero_65536_period() {
 
 #[test]
 fn control_word_write_clears_irq0() {
-    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::Low, 48000);
+    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::High, 48000);
 
     // Set up PIC.
     bus.io_write_byte(0x00, 0x11);
@@ -426,7 +448,7 @@ fn control_word_write_clears_irq0() {
 
 #[test]
 fn pit_latch_command_does_not_clear_irq0() {
-    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::Low, 48000);
+    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::High, 48000);
 
     init_pic(&mut bus);
 
@@ -458,7 +480,7 @@ fn init_pic(bus: &mut Pc9801Bus) {
 
 #[test]
 fn timer_reprogram_mid_count() {
-    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::Low, 48000);
+    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::High, 48000);
     init_pic(&mut bus);
 
     // PIT ch0: mode 2, reload = 100 -> fire at cycle 1001
@@ -487,7 +509,7 @@ fn timer_reprogram_mid_count() {
 
 #[test]
 fn timer_reprogram_larger_value_delays_fire() {
-    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::Low, 48000);
+    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::High, 48000);
     init_pic(&mut bus);
 
     // PIT ch0: mode 2, reload = 100 -> fire at cycle 1001
@@ -541,7 +563,7 @@ fn pit_channels_1_and_2_no_irq() {
 
 #[test]
 fn multiple_timer_periods_accumulate() {
-    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::Low, 48000);
+    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::High, 48000);
     init_pic(&mut bus);
 
     // PIT ch0: mode 2, reload = 100 -> fire every 1001 cycles
@@ -566,7 +588,7 @@ fn multiple_timer_periods_accumulate() {
 
 #[test]
 fn timer_count_readable_while_running() {
-    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::Low, 48000);
+    let mut bus = Pc9801Bus::<NoTracing>::new(MachineModel::PC9801RA, CpuMode::High, 48000);
     init_pic(&mut bus);
 
     // PIT ch0: mode 2, reload = 1000 -> fire at cycle ~10016

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,7 @@ Commands:
 Options:
   -c, --config <PATH>           Load configuration from file
       --machine <TYPE>          Machine type: PC9801F, PC9801VM, PC9801VX, PC9801RA, PC9821AS, PC9821AP
-      --cpu-mode <MODE>         CPU speed mode: low or high (default: high; only affects PC9801F)
+      --cpu-mode <MODE>         CPU speed mode: low or high (default: high; PC-9801 only)
       --fdd1 <PATH>             Floppy disk image for drive 1 (repeatable)
       --fdd2 <PATH>             Floppy disk image for drive 2 (repeatable)
       --hdd1 <PATH>             Hard disk image for drive 1 (SASI or IDE)


### PR DESCRIPTION
| CPU model | DMIPS  |
|:----------|:------:|
|8086@5Mhz | 0.3|
|8086@8Mhz | 0.5|
|V30@8Mhz | 0.7|
|V30@10Mhz|  0.9|
|286@8Mhz | 1.6|
|286@10Mhz|  2.1|
|386DX@16Mhz | 3.1|
|386DX@20Mhz | 3.9|
|486DX@33Mhz | 13.5|
|486DX2@66Mhz | 27.0|