### PR TITLE
fix(machine): BIOS keyboard compatibility

### DIFF
--- a/crates/machine/src/bus.rs
+++ b/crates/machine/src/bus.rs
@@ -259,6 +259,8 @@ pub struct Pc9801Bus<T: Tracing = NoTracing> {
     pit: I8253Pit,
     dma: I8237Dma,
     keyboard: I8251Keyboard,
+    /// Scan code already consumed from port 41h by a guest INT 09h pre-handler.
+    keyboard_chained_raw_code: Option<u8>,
     serial: I8251Serial,
     gdc_master: Gdc,
     gdc_slave: Gdc,
@@ -611,6 +613,7 @@ impl<T: Tracing> Pc9801Bus<T> {
     /// Injects one keyboard scan code and raises IRQ1.
     pub fn push_keyboard_scancode(&mut self, code: u8) {
         self.keyboard.push_scancode(code);
+        self.keyboard_chained_raw_code = None;
         self.pic.set_irq(1);
     }
 
@@ -1492,6 +1495,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         self.gdc_master.state = state.gdc_master.clone();
         self.gdc_slave.state = state.gdc_slave.clone();
         self.keyboard.state = state.keyboard.clone();
+        self.keyboard_chained_raw_code = None;
         self.serial.state = state.serial.clone();
         self.a20_enabled = state.a20_enabled;
         self.floppy.fdc_1mb_mut().state = state.fdc_1mb.clone();

--- a/crates/machine/src/bus/bios.rs
+++ b/crates/machine/src/bus/bios.rs
@@ -258,6 +258,52 @@ impl<T: Tracing> Pc9801Bus<T> {
     }
 
     fn hle_int09h(&mut self, cpu: &mut impl Cpu) {
+        let Some(raw_code) = self
+            .keyboard_chained_raw_code
+            .take()
+            .or_else(|| self.read_pending_keyboard_scan_code())
+        else {
+            self.pic.write_port0(0, 0x20);
+            return;
+        };
+        let (key_code, is_release) = self.buffer_keyboard_scan_code(raw_code);
+        self.pic.write_port0(0, 0x20);
+
+        // COPY key (0x60) -> INT 06H, STOP key (0x61) -> INT 05H.
+        // The real BIOS dispatches these after EOI via the assembly wrapper.
+        if !is_release {
+            let int_vector = match key_code {
+                0x60 => Some(0x06u8),
+                0x61 => Some(0x05u8),
+                _ => None,
+            };
+            if let Some(vector) = int_vector {
+                let iret_base = iret_stack_base(cpu);
+                let callback_offset = self.ram_read_u16((vector as usize) * 4);
+                let callback_segment = self.ram_read_u16((vector as usize) * 4 + 2);
+                if callback_offset != 0 || callback_segment != 0 {
+                    // Rewrite the IRQ handler's IRET frame so it returns into
+                    // the COPY/STOP vector first, with the original return
+                    // frame stacked behind it.
+                    let orig_ip = self.read_word_direct(iret_base);
+                    let orig_cs = self.read_word_direct(iret_base + 0x02);
+                    let orig_flags = self.read_word_direct(iret_base + 0x04);
+                    self.write_mem_word(iret_base + 0x06, orig_ip);
+                    self.write_mem_word(iret_base + 0x08, orig_cs);
+                    self.write_mem_word(iret_base + 0x0A, orig_flags);
+                    self.write_mem_word(iret_base, callback_offset);
+                    self.write_mem_word(iret_base + 0x02, callback_segment);
+                    self.write_mem_word(iret_base + 0x04, orig_flags & !0x0200);
+                }
+            }
+        }
+    }
+
+    fn read_pending_keyboard_scan_code(&mut self) -> Option<u8> {
+        if !self.keyboard.has_rx_ready() {
+            return None;
+        }
+
         let (raw_code, clear_irq, retrigger_irq) = self.keyboard.read_data();
         if clear_irq {
             self.pic.clear_irq(1);
@@ -265,15 +311,25 @@ impl<T: Tracing> Pc9801Bus<T> {
         if retrigger_irq {
             self.pic.set_irq(1);
         }
+        Some(raw_code)
+    }
 
+    fn poll_keyboard_scan_codes(&mut self) {
+        while let Some(raw_code) = self.read_pending_keyboard_scan_code() {
+            self.buffer_keyboard_scan_code(raw_code);
+        }
+    }
+
+    fn buffer_keyboard_scan_code(&mut self, raw_code: u8) -> (u8, bool) {
         let key_code = raw_code & 0x7F;
         let is_release = raw_code & 0x80 != 0;
         let group = (key_code >> 3) as usize;
         let bit = 1u8 << (key_code & 0x07);
+        let key_state_addr = 0x052A + group;
 
         if is_release {
             // Key release: clear key status bit.
-            self.memory.state.ram[0x052A + group] &= !bit;
+            self.memory.state.ram[key_state_addr] &= !bit;
 
             // Update shift state for modifier key releases.
             if (0x70..0x75).contains(&key_code) || key_code == 0x7D {
@@ -286,7 +342,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             }
         } else {
             // Key press: set key status bit.
-            self.memory.state.ram[0x052A + group] |= bit;
+            self.memory.state.ram[key_state_addr] |= bit;
 
             // Update shift state for modifier key presses.
             if key_code == 0x70 || key_code == 0x7D {
@@ -315,34 +371,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             }
         }
 
-        // Send EOI to master PIC.
-        self.pic.write_port0(0, 0x20);
-
-        // COPY key (0x60) -> INT 06H, STOP key (0x61) -> INT 05H.
-        // The real BIOS dispatches these after EOI via the assembly wrapper.
-        if !is_release {
-            let int_vector = match key_code {
-                0x60 => Some(0x06u8),
-                0x61 => Some(0x05u8),
-                _ => None,
-            };
-            if let Some(vector) = int_vector {
-                let iret_base = iret_stack_base(cpu);
-                let callback_offset = self.ram_read_u16((vector as usize) * 4);
-                let callback_segment = self.ram_read_u16((vector as usize) * 4 + 2);
-                if callback_offset != 0 || callback_segment != 0 {
-                    let orig_ip = self.read_word_direct(iret_base);
-                    let orig_cs = self.read_word_direct(iret_base + 0x02);
-                    let orig_flags = self.read_word_direct(iret_base + 0x04);
-                    self.write_mem_word(iret_base + 0x06, orig_ip);
-                    self.write_mem_word(iret_base + 0x08, orig_cs);
-                    self.write_mem_word(iret_base + 0x0A, orig_flags);
-                    self.write_mem_word(iret_base, callback_offset);
-                    self.write_mem_word(iret_base + 0x02, callback_segment);
-                    self.write_mem_word(iret_base + 0x04, orig_flags & !0x0200);
-                }
-            }
-        }
+        (key_code, is_release)
     }
 
     fn update_shift_key(&mut self) {
@@ -379,24 +408,27 @@ impl<T: Tracing> Pc9801Bus<T> {
             if key_code == 0x51 || key_code == 0x35 || key_code == 0x3E {
                 let val = self.read_byte_direct(table_base + key_code as u32);
                 if val == 0xFF {
-                    return 0xFFFF;
+                    0xFFFF
+                } else {
+                    (val as u16) << 8
                 }
-                (val as u16) << 8
             } else {
                 let val = self.read_byte_direct(table_base + key_code as u32);
                 if val == 0xFF {
-                    return 0xFFFF;
+                    0xFFFF
+                } else {
+                    val as u16 + ((key_code as u16) << 8)
                 }
-                val as u16 + ((key_code as u16) << 8)
             }
         } else if key_code < 0x60 {
             if key_code == 0x5E { 0xAE00 } else { 0xFFFF }
         } else if (0x62..0x70).contains(&key_code) {
             let val = self.read_byte_direct(table_base + (key_code - 0x0C) as u32);
             if val == 0xFF {
-                return 0xFFFF;
+                0xFFFF
+            } else {
+                (val as u16) << 8
             }
-            (val as u16) << 8
         } else {
             0xFFFF
         }
@@ -695,6 +727,7 @@ impl<T: Tracing> Pc9801Bus<T> {
     }
 
     fn int18h_key_read(&mut self, cpu: &mut impl Cpu) {
+        self.poll_keyboard_scan_codes();
         let count = self.memory.state.ram[0x0528];
         if count == 0 {
             // Block until a key is available by rewinding the caller's return IP
@@ -728,6 +761,7 @@ impl<T: Tracing> Pc9801Bus<T> {
     }
 
     fn int18h_buffer_sense(&mut self, cpu: &mut impl Cpu) {
+        self.poll_keyboard_scan_codes();
         let count = self.memory.state.ram[0x0528];
         if count == 0 {
             cpu.set_bh(0x00);
@@ -777,6 +811,7 @@ impl<T: Tracing> Pc9801Bus<T> {
     }
 
     fn int18h_key_code_read(&mut self, cpu: &mut impl Cpu) {
+        self.poll_keyboard_scan_codes();
         let count = self.memory.state.ram[0x0528];
         if count == 0 {
             cpu.set_bh(0x00);

--- a/crates/machine/src/bus/init.rs
+++ b/crates/machine/src/bus/init.rs
@@ -188,6 +188,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             pit: I8253Pit::new(is_8mhz_lineage),
             dma: I8237Dma::new(),
             keyboard: I8251Keyboard::new(),
+            keyboard_chained_raw_code: None,
             serial: I8251Serial::new(),
             gdc_master: Gdc::new_master(clocks.cpu_clock_hz),
             gdc_slave: Gdc::new_slave(clocks.cpu_clock_hz),

--- a/crates/machine/src/bus/io_read.rs
+++ b/crates/machine/src/bus/io_read.rs
@@ -127,6 +127,9 @@ impl<T: Tracing> Pc9801Bus<T> {
                     self.pic.set_irq(1);
                     self.tracer.trace_irq_raise(1);
                 }
+                if clear_irq || retrigger_irq {
+                    self.keyboard_chained_raw_code = Some(data);
+                }
                 data
             }
             // Keyboard µPD8251A status register (port 0x43 read).

--- a/crates/machine/tests/bios.rs
+++ b/crates/machine/tests/bios.rs
@@ -270,6 +270,9 @@ mod cdrom_boot;
 #[path = "bios/int18h.rs"]
 mod int18h;
 
+#[path = "bios/int09h.rs"]
+mod int09h;
+
 #[path = "bios/int19h.rs"]
 mod int19h;
 

--- a/crates/machine/tests/bios/int09h.rs
+++ b/crates/machine/tests/bios/int09h.rs
@@ -1,0 +1,73 @@
+use common::{Bus, Cpu};
+
+use super::create_machine_f;
+
+const RESULT_AX: u32 = 0x0600;
+const RESULT_BH: u32 = 0x0602;
+const RESULT_FLAGS: u32 = 0x0604;
+const N_KEY_MAKE: u8 = 0x2E;
+const N_KEY_BUFFER_ENTRY: u16 = 0x2E6E;
+
+#[test]
+fn int18h_key_code_read_polls_pending_scancode_when_interrupts_disabled() {
+    let mut machine = create_machine_f();
+
+    let program = [
+        0xB4, 0x05, // MOV AH,05h
+        0xCD, 0x18, // INT 18h
+        0xA3, 0x00, 0x06, // MOV [0600h],AX
+        0x88, 0x3E, 0x02, 0x06, // MOV [0602h],BH
+        0x9C, // PUSHF
+        0x58, // POP AX
+        0xA3, 0x04, 0x06, // MOV [0604h],AX
+        0xF4, // HLT
+    ];
+    for (offset, &byte) in program.iter().enumerate() {
+        machine.bus.write_byte(0x0100 + offset as u32, byte);
+    }
+
+    machine.bus.push_keyboard_scancode(N_KEY_MAKE);
+    machine.cpu.load_state(&{
+        let mut state = cpu::I8086State {
+            ip: 0x0100,
+            ..Default::default()
+        };
+        state.set_sp(0x4000);
+        state.set_compressed_flags(0x0002);
+        state
+    });
+
+    machine.run_for(100_000);
+
+    assert!(machine.cpu.halted(), "guest program should halt");
+    assert_eq!(
+        machine.bus.read_word(RESULT_AX),
+        N_KEY_BUFFER_ENTRY,
+        "INT 18h AH=05h should return the pending n key even though IF was clear"
+    );
+    assert_eq!(
+        machine.bus.read_byte(RESULT_BH),
+        0x01,
+        "INT 18h AH=05h should report a key was available"
+    );
+    assert_eq!(
+        machine.bus.read_word(RESULT_FLAGS) & 0x0200,
+        0,
+        "the test must keep IF clear across the BIOS call"
+    );
+
+    let state = machine.save_state();
+    assert_eq!(
+        state.memory.ram[0x0528], 0,
+        "the BIOS keyboard buffer entry should have been consumed"
+    );
+    assert_eq!(
+        state.pic.chips[0].isr & 0x02,
+        0,
+        "IRQ 1 should not have been acknowledged while IF was clear"
+    );
+    assert!(
+        !state.keyboard.rx_ready && state.keyboard.rx_fifo.is_empty(),
+        "the pending controller scan code should have been drained by INT 18h polling"
+    );
+}

--- a/crates/machine/tests/bios/int18h.rs
+++ b/crates/machine/tests/bios/int18h.rs
@@ -1,7 +1,7 @@
 //! Note: AH=44h (border color set) is not tested here - NP21W's implementation is
 //! fully commented out, and the real BIOS ROMs for VM/VX/RA do not appear to
 //! write to port 0x6C either.
-use common::Bus;
+use common::{Bus, Cpu};
 
 use super::{
     KB_COUNT, KB_HEAD, KB_TAIL, TEST_CODE, boot_inject_run_f, boot_inject_run_ra,
@@ -92,6 +92,40 @@ fn make_kb_int18h(ah: u8, al: u8, num_irqs: usize) -> Vec<u8> {
         0xF4,                   // HLT
     ]);
     code
+}
+
+#[rustfmt::skip]
+fn make_dosshell_chained_int09h_program() -> Vec<u8> {
+    vec![
+        0xFB,                   // STI
+        0xF4,                   // HLT (wait for key IRQ)
+        0xB4, 0x02,             // MOV AH,02h
+        0xCD, 0x18,             // INT 18h
+        0xB4, 0x01,             // MOV AH,01h
+        0xCD, 0x18,             // INT 18h
+        0xA3, 0x00, 0x06,       // MOV [RESULT], AX
+        0x89, 0x1E, 0x02, 0x06, // MOV [RESULT+2], BX
+        0xF4,                   // HLT
+    ]
+}
+
+#[rustfmt::skip]
+fn make_dosshell_int09h_prehandler(original_segment: u16, original_offset: u16) -> Vec<u8> {
+    vec![
+        0x50,                    // PUSH AX
+        0x52,                    // PUSH DX
+        0xBA, 0x43, 0x00,        // MOV DX,0043h
+        0xEC,                    // IN AL,DX
+        0xBA, 0x41, 0x00,        // MOV DX,0041h
+        0xEC,                    // IN AL,DX
+        0x5A,                    // POP DX
+        0x58,                    // POP AX
+        0xEA,                    // JMP FAR original INT 09h
+        (original_offset & 0xFF) as u8,
+        (original_offset >> 8) as u8,
+        (original_segment & 0xFF) as u8,
+        (original_segment >> 8) as u8,
+    ]
 }
 
 // Pattern F: AH+CH call (display area set, draw mode set).
@@ -429,6 +463,62 @@ fn buffer_sense_data_ra() {
     assert_eq!(
         state.memory.ram[KB_COUNT], 1,
         "AH=01h should not remove key from buffer"
+    );
+}
+
+#[test]
+fn buffer_sense_after_chained_int09h_prehandler_vm() {
+    const HANDLER: u32 = DATA_TABLE;
+
+    let mut machine = create_machine_vm();
+    boot_to_halt!(machine);
+
+    let state = machine.save_state();
+    let (original_segment, original_offset) = read_ivt_vector(&state.memory.ram, 0x09);
+    let handler = make_dosshell_int09h_prehandler(original_segment, original_offset);
+    write_bytes(&mut machine.bus, HANDLER, &handler);
+    write_bytes(
+        &mut machine.bus,
+        0x09 * 4,
+        &[
+            (HANDLER & 0xFF) as u8,
+            ((HANDLER >> 8) & 0xFF) as u8,
+            0x00,
+            0x00,
+        ],
+    );
+
+    let code = make_dosshell_chained_int09h_program();
+    write_bytes(&mut machine.bus, TEST_CODE, &code);
+    machine.bus.push_keyboard_scancode(0x4B);
+    machine.cpu.load_state(&{
+        let mut state = cpu::V30State {
+            ip: TEST_CODE as u16,
+            ..Default::default()
+        };
+        state.set_sp(0x4000);
+        state
+    });
+
+    machine.run_for(INT18H_BUDGET);
+
+    assert!(machine.cpu.halted(), "guest program should halt");
+    let ax = machine.bus.read_word(RESULT);
+    let bh = machine.bus.read_byte(RESULT + 3);
+    let state = machine.save_state();
+
+    assert_eq!(
+        bh, 0x01,
+        "AH=01h should see the cursor key buffered by the chained INT 09h path"
+    );
+    assert_ne!(ax, 0x0000, "AH=01h should return a buffered key code");
+    assert_eq!(
+        state.memory.ram[KB_COUNT], 1,
+        "AH=01h should not consume the buffered key"
+    );
+    assert!(
+        !state.keyboard.rx_ready && state.keyboard.rx_fifo.is_empty(),
+        "the chained INT 09h path should not leave the controller byte pending"
     );
 }
 


### PR DESCRIPTION
Preserve keyboard input when programs like DOS Shell install an INT 09h pre-handler that reads the keyboard controller before chaining to BIOS.

Keep direct INT 18h keyboard polling working for programs like Albatross that depend on BIOS key services even when IRQ delivery is not doing the buffering.