### PR TITLE
refactor: target Vulkan 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "neetan"
-version = "2026.4.0"
+version = "2026.5.2"
 dependencies = [
  "audio_engine",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ zlib-rs = { version = "0.6", default-features = false, features = ["rust-allocat
 
 [package]
 name = "neetan"
-version = "2026.4.0"
+version = "2026.5.2"
 publish = false
 authors.workspace = true
 edition.workspace = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Neetan (ねーたん)
 
-An emulator for the PC-98 written in Rust and using a Vulkan graphics engine.
+An emulator for the PC-98 written in Rust and using a Vulkan based graphics engine.
 
 [Game Compatibility](https://github.com/hasenbanck/neetan/wiki/Game-Compatibility)
 

--- a/crates/graphics_engine/build.rs
+++ b/crates/graphics_engine/build.rs
@@ -81,14 +81,11 @@ fn compile_shader(shader_file: &Path, output_dir: &Path, modules_dir: &Path) -> 
         .arg("-I")
         .arg(modules_dir)
         .arg("-profile")
-        .arg("spirv_1_5")
+        .arg("spirv_1_0")
         // Uses column major layout for matrices.
         .arg("-matrix-layout-column-major")
         // Uses the entrypoint name from the source instead of 'main' in the spirv output.
-        .arg("-fvk-use-entrypoint-name")
-        // Make data accessed through ConstantBuffer, ParameterBlock, StructuredBuffer,
-        // ByteAddressBuffer and general pointers follow the 'scalar' layout.
-        .arg("-fvk-use-scalar-layout");
+        .arg("-fvk-use-entrypoint-name");
 
     cmd.arg("-o").arg(&output_file).arg(shader_file);
 

--- a/crates/graphics_engine/src/layout_transitioner.rs
+++ b/crates/graphics_engine/src/layout_transitioner.rs
@@ -75,12 +75,9 @@ impl LayoutTransitioner {
 
         drop(encoder);
 
-        let command_buffer_info =
-            vk::CommandBufferSubmitInfo::default().command_buffer(self.command_buffer.handle());
+        let command_buffers = [self.command_buffer.handle()];
 
-        let command_buffers = [command_buffer_info];
-
-        let submit_info = vk::SubmitInfo2::default().command_buffer_infos(&command_buffers);
+        let submit_info = vk::SubmitInfo::default().command_buffers(&command_buffers);
 
         let submits = [submit_info];
 
@@ -111,10 +108,8 @@ impl LayoutTransitioner {
         let (src_stage, src_access, dst_stage, dst_access) =
             layout_transition_masks(old_layout, new_layout);
 
-        let barrier = vk::ImageMemoryBarrier2::default()
-            .src_stage_mask(src_stage)
+        let barrier = vk::ImageMemoryBarrier::default()
             .src_access_mask(src_access)
-            .dst_stage_mask(dst_stage)
             .dst_access_mask(dst_access)
             .old_layout(old_layout)
             .new_layout(new_layout)
@@ -123,13 +118,16 @@ impl LayoutTransitioner {
             .image(handle)
             .subresource_range(subresource_range);
 
-        let dependency_info =
-            vk::DependencyInfo::default().image_memory_barriers(std::slice::from_ref(&barrier));
-
         unsafe {
-            self.context
-                .device()
-                .cmd_pipeline_barrier2(command_buffer, &dependency_info);
+            self.context.device().cmd_pipeline_barrier(
+                command_buffer,
+                src_stage,
+                dst_stage,
+                vk::DependencyFlags::empty(),
+                &[],
+                &[],
+                std::slice::from_ref(&barrier),
+            );
         }
     }
 }
@@ -139,36 +137,37 @@ fn layout_transition_masks(
     old_layout: vk::ImageLayout,
     new_layout: vk::ImageLayout,
 ) -> (
-    vk::PipelineStageFlags2,
-    vk::AccessFlags2,
-    vk::PipelineStageFlags2,
-    vk::AccessFlags2,
+    vk::PipelineStageFlags,
+    vk::AccessFlags,
+    vk::PipelineStageFlags,
+    vk::AccessFlags,
 ) {
     let (src_stage, src_access) = match old_layout {
-        vk::ImageLayout::UNDEFINED => {
-            (vk::PipelineStageFlags2::TOP_OF_PIPE, vk::AccessFlags2::NONE)
-        }
+        vk::ImageLayout::UNDEFINED => (
+            vk::PipelineStageFlags::TOP_OF_PIPE,
+            vk::AccessFlags::empty(),
+        ),
         vk::ImageLayout::TRANSFER_DST_OPTIMAL => (
-            vk::PipelineStageFlags2::COPY,
-            vk::AccessFlags2::TRANSFER_WRITE,
+            vk::PipelineStageFlags::TRANSFER,
+            vk::AccessFlags::TRANSFER_WRITE,
         ),
         // For all other layouts, use generic masks.
         _ => (
-            vk::PipelineStageFlags2::ALL_COMMANDS,
-            vk::AccessFlags2::MEMORY_READ | vk::AccessFlags2::MEMORY_WRITE,
+            vk::PipelineStageFlags::ALL_COMMANDS,
+            vk::AccessFlags::MEMORY_READ | vk::AccessFlags::MEMORY_WRITE,
         ),
     };
 
     let (dst_stage, dst_access) = match new_layout {
         vk::ImageLayout::TRANSFER_DST_OPTIMAL => (
-            vk::PipelineStageFlags2::COPY,
-            vk::AccessFlags2::TRANSFER_WRITE,
+            vk::PipelineStageFlags::TRANSFER,
+            vk::AccessFlags::TRANSFER_WRITE,
         ),
         // For all other layouts (GENERAL, SHADER_READ_ONLY_OPTIMAL, etc.),
         // use generic masks safe.
         _ => (
-            vk::PipelineStageFlags2::ALL_COMMANDS,
-            vk::AccessFlags2::MEMORY_READ,
+            vk::PipelineStageFlags::ALL_COMMANDS,
+            vk::AccessFlags::MEMORY_READ,
         ),
     };
 

--- a/crates/graphics_engine/src/lib.rs
+++ b/crates/graphics_engine/src/lib.rs
@@ -30,7 +30,7 @@ use crate::{
     pipeline_loader::PipelineLoader,
     plumbing::{
         Binary, CommandPool, Device, DeviceConfiguration, Fence, FrameResources, FrameTarget,
-        IntoCString, MappedBuffer, Semaphore, Surface, Timeline,
+        IntoCString, MappedBuffer, RenderPass, Semaphore, Surface, Timeline,
     },
     resources::Resources,
 };
@@ -44,7 +44,6 @@ const INITIAL_WINDOW_HEIGHT_1_BY_1: u32 = 800;
 const NATIVE_WIDTH: u32 = 640;
 const NATIVE_HEIGHT: u32 = 480;
 const FRAMEBUFFER_BYTES: u64 = (NATIVE_WIDTH * NATIVE_HEIGHT * 4) as u64;
-const DEFAULT_BLITTER_IMAGE_FORMAT: vk::Format = vk::Format::R8G8B8A8_SRGB;
 
 /// Display aspect mode for scaling and startup dimensions.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -101,7 +100,9 @@ pub struct GraphicsEngine {
     /// Applies CRT scaling from the native-resolution image to the window resolution.
     crt: Crt,
     /// Copies the color target to the swapchain.
-    blitter: Blitter,
+    blitter: Option<Blitter>,
+    /// Render pass for offscreen color target rendering.
+    color_render_pass: RenderPass,
     /// Pipeline loader for creating graphics pipelines.
     pipeline_loader: PipelineLoader,
     /// Pool of frame resources, one per frame slot.
@@ -167,27 +168,40 @@ impl GraphicsEngine {
         let descriptor_resources = DescriptorResources::new(device.context())
             .context("Can't create descriptor resources")?;
 
+        let color_render_pass = RenderPass::new_color_target(
+            Rc::clone(device.context()),
+            c"color_target_render_pass",
+            vk::Format::R8G8B8A8_SRGB,
+        )
+        .context("Can't create color target render pass")?;
+
         let (color_width, color_height) = compute_color_target_extent(
             initial_width,
             initial_height,
             display_aspect_mode.display_aspect_ratio(),
         );
-        let resources =
-            Resources::new(&device, &mut layout_transitioner, color_width, color_height)
-                .context("Can't initialize resources")?;
+        let resources = Resources::new(
+            &device,
+            &mut layout_transitioner,
+            color_render_pass.handle(),
+            color_width,
+            color_height,
+        )
+        .context("Can't initialize resources")?;
 
-        let scale = Scale::new(&pipeline_loader, descriptor_resources.pipeline_layout())
-            .context("Can't create scale pipeline")?;
-
-        let crt = Crt::new(&pipeline_loader, descriptor_resources.pipeline_layout())
-            .context("Can't create crt pipeline")?;
-
-        let blitter = Blitter::new(
+        let scale = Scale::new(
             &pipeline_loader,
-            DEFAULT_BLITTER_IMAGE_FORMAT,
+            color_render_pass.handle(),
             descriptor_resources.pipeline_layout(),
         )
-        .context("Can't create blitter")?;
+        .context("Can't create scale pipeline")?;
+
+        let crt = Crt::new(
+            &pipeline_loader,
+            color_render_pass.handle(),
+            descriptor_resources.pipeline_layout(),
+        )
+        .context("Can't create crt pipeline")?;
 
         info!("Graphics engine initialized");
 
@@ -197,7 +211,8 @@ impl GraphicsEngine {
             layout_transitioner,
             scale,
             crt,
-            blitter,
+            blitter: None,
+            color_render_pass,
             pipeline_loader,
             frame_resources: None,
             render_finished_semaphores: None,
@@ -267,13 +282,26 @@ impl GraphicsEngine {
             .create_command_pool(c"graphics_command_pool")
             .context("Failed to create graphics command pool")?;
 
-        if surface_format != self.blitter.color_target_image_format() {
-            self.blitter = Blitter::new(
-                &self.pipeline_loader,
-                surface_format,
-                self.descriptor_resources.pipeline_layout(),
-            )
-            .context("Can't create blitter")?;
+        let surface_render_pass = self
+            .surface
+            .as_ref()
+            .context("Surface not initialized")?
+            .render_pass();
+
+        if self
+            .blitter
+            .as_ref()
+            .is_none_or(|blitter| !blitter.is_compatible(surface_format, surface_render_pass))
+        {
+            self.blitter = Some(
+                Blitter::new(
+                    &self.pipeline_loader,
+                    surface_format,
+                    surface_render_pass,
+                    self.descriptor_resources.pipeline_layout(),
+                )
+                .context("Can't create blitter")?,
+            );
         }
 
         let frame_resources = (0..frame_count)
@@ -417,7 +445,6 @@ impl GraphicsEngine {
                         .record()
                         .context("Failed to create command encoder")?;
 
-                    encoder.set_default_dynamic_state();
                     clear_frame_pass(&mut encoder, extent, &frame);
                 }
                 Some(render_instructions) => {
@@ -451,7 +478,6 @@ impl GraphicsEngine {
                     {
                         encoder.begin_debug_label(c"Setup Phase", [0.5, 0.5, 0.5, 1.0]);
 
-                        encoder.set_default_dynamic_state();
                         self.descriptor_resources
                             .bind_descriptors(&encoder, &frame_resources.descriptors);
 
@@ -466,10 +492,10 @@ impl GraphicsEngine {
                         let native_target = self.resources.native_target();
                         encoder.image_barrier(
                             native_target.handle(),
-                            vk::PipelineStageFlags2::FRAGMENT_SHADER,
-                            vk::AccessFlags2::SHADER_SAMPLED_READ,
-                            vk::PipelineStageFlags2::COPY,
-                            vk::AccessFlags2::TRANSFER_WRITE,
+                            vk::PipelineStageFlags::FRAGMENT_SHADER,
+                            vk::AccessFlags::SHADER_READ,
+                            vk::PipelineStageFlags::TRANSFER,
+                            vk::AccessFlags::TRANSFER_WRITE,
                             vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
                             vk::ImageLayout::TRANSFER_DST_OPTIMAL,
                         );
@@ -481,10 +507,10 @@ impl GraphicsEngine {
                         );
                         encoder.image_barrier(
                             native_target.handle(),
-                            vk::PipelineStageFlags2::COPY,
-                            vk::AccessFlags2::TRANSFER_WRITE,
-                            vk::PipelineStageFlags2::FRAGMENT_SHADER,
-                            vk::AccessFlags2::SHADER_SAMPLED_READ,
+                            vk::PipelineStageFlags::TRANSFER,
+                            vk::AccessFlags::TRANSFER_WRITE,
+                            vk::PipelineStageFlags::FRAGMENT_SHADER,
+                            vk::AccessFlags::SHADER_READ,
                             vk::ImageLayout::TRANSFER_DST_OPTIMAL,
                             vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
                         );
@@ -500,6 +526,7 @@ impl GraphicsEngine {
                             render_crt_pass(
                                 &mut encoder,
                                 self.resources.color_target(),
+                                self.color_render_pass.handle(),
                                 &self.crt,
                                 native_height,
                                 self.descriptor_resources.pipeline_layout(),
@@ -509,6 +536,7 @@ impl GraphicsEngine {
                             render_scale_pass(
                                 &mut encoder,
                                 self.resources.color_target(),
+                                self.color_render_pass.handle(),
                                 &self.scale,
                                 native_height,
                                 self.descriptor_resources.pipeline_layout(),
@@ -530,7 +558,7 @@ impl GraphicsEngine {
                             extent,
                             color_target_extent,
                             &frame,
-                            &self.blitter,
+                            self.blitter.as_ref().context("Blitter not initialized")?,
                             self.descriptor_resources.pipeline_layout(),
                         );
                         encoder.end_debug_label();
@@ -563,37 +591,27 @@ impl GraphicsEngine {
             .as_ref()
             .context("Frame resources not initialized")?[frame_index];
 
-        // Binary semaphore wait for swapchain image.
-        let binary_wait = vk::SemaphoreSubmitInfo::default()
-            .semaphore(resources.image_available_semaphore.handle())
-            .stage_mask(vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT)
-            .value(0);
-
-        let wait_semaphores = [binary_wait];
+        let wait_semaphores = [resources.image_available_semaphore.handle()];
+        let wait_stages = [vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT];
 
         self.frame_timeline_value += 1;
 
-        // Binary semaphore signal for presentation.
-        let render_finished_signal = vk::SemaphoreSubmitInfo::default()
-            .semaphore(render_finished_semaphore)
-            .stage_mask(vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT)
-            .value(0);
+        let signal_semaphores = [render_finished_semaphore, self.frame_timeline.handle()];
+        let wait_values = [0];
+        let signal_values = [0, self.frame_timeline_value];
 
-        // Timeline semaphore signal for graveyard ordering.
-        let timeline_signal = vk::SemaphoreSubmitInfo::default()
-            .semaphore(self.frame_timeline.handle())
-            .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-            .value(self.frame_timeline_value);
+        let mut timeline_info = vk::TimelineSemaphoreSubmitInfoKHR::default()
+            .wait_semaphore_values(&wait_values)
+            .signal_semaphore_values(&signal_values);
 
-        let signal_semaphores = [render_finished_signal, timeline_signal];
+        let command_buffers = [resources.graphics_command_buffer.handle()];
 
-        let command_buffer_info = vk::CommandBufferSubmitInfo::default()
-            .command_buffer(resources.graphics_command_buffer.handle());
-
-        let submit_info = vk::SubmitInfo2::default()
-            .wait_semaphore_infos(&wait_semaphores)
-            .command_buffer_infos(std::slice::from_ref(&command_buffer_info))
-            .signal_semaphore_infos(&signal_semaphores);
+        let submit_info = vk::SubmitInfo::default()
+            .wait_semaphores(&wait_semaphores)
+            .wait_dst_stage_mask(&wait_stages)
+            .command_buffers(&command_buffers)
+            .signal_semaphores(&signal_semaphores)
+            .push_next(&mut timeline_info);
 
         self.device
             .graphics_queue()
@@ -655,10 +673,10 @@ impl GraphicsEngine {
             .reset()
             .context("Failed to reset present fence")?;
 
-        let image_view = surface.image_views()[image_index as usize];
-        let image = surface.images()[image_index as usize];
+        let framebuffer = surface.framebuffers()[image_index as usize];
+        let render_pass = surface.render_pass();
 
-        Ok(FrameTarget::new(image_index, image_view, image))
+        Ok(FrameTarget::new(image_index, framebuffer, render_pass))
     }
 
     /// Presents a frame to the swapchain.
@@ -723,6 +741,21 @@ impl GraphicsEngine {
         }
 
         surface.on_resize(width, height, &fences)?;
+        let surface_format = surface.format();
+        let surface_render_pass = surface.render_pass();
+
+        if self
+            .blitter
+            .as_ref()
+            .is_none_or(|blitter| !blitter.is_compatible(surface_format, surface_render_pass))
+        {
+            self.blitter = Some(Blitter::new(
+                &self.pipeline_loader,
+                surface_format,
+                surface_render_pass,
+                self.descriptor_resources.pipeline_layout(),
+            )?);
+        }
 
         let (color_width, color_height) = compute_color_target_extent(
             width,
@@ -733,6 +766,7 @@ impl GraphicsEngine {
         self.resources.on_resize(
             &self.device,
             &mut self.layout_transitioner,
+            self.color_render_pass.handle(),
             color_width,
             color_height,
         );

--- a/crates/graphics_engine/src/passes.rs
+++ b/crates/graphics_engine/src/passes.rs
@@ -1,6 +1,6 @@
 use jay_ash::vk;
 
-use crate::plumbing::RenderingEncoder;
+use crate::plumbing::RenderPassEncoder;
 
 mod blitter;
 mod clear;
@@ -46,6 +46,6 @@ impl UpscalePushConstants {
 pub(crate) trait Renderer {
     type DrawData;
 
-    /// Records the render commands within a dynamic rendering pass.
-    fn render(&self, encoder: &RenderingEncoder<'_>, draw_data: Self::DrawData);
+    /// Records the render commands within a render pass.
+    fn render(&self, encoder: &RenderPassEncoder<'_>, draw_data: Self::DrawData);
 }

--- a/crates/graphics_engine/src/passes/blitter.rs
+++ b/crates/graphics_engine/src/passes/blitter.rs
@@ -27,42 +27,26 @@ pub(crate) fn render_blitter_pass(
         .saturating_sub(color_target_extent.height)
         / 2;
 
-    // Transition from UNDEFINED to GENERAL.
-    // Use COLOR_ATTACHMENT_OUTPUT as srcStageMask to synchronize with the
-    // semaphore wait from vkAcquireNextImageKHR.
-    encoder.image_barrier(
-        frame.image(),
-        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
-        vk::AccessFlags2::NONE,
-        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
-        vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
-        vk::ImageLayout::UNDEFINED,
-        vk::ImageLayout::GENERAL,
-    );
+    let clear_values = [vk::ClearValue {
+        color: vk::ClearColorValue {
+            float32: [0.0, 0.0, 0.0, 0.0],
+        },
+    }];
 
-    let color_attachment = vk::RenderingAttachmentInfo::default()
-        .image_view(frame.view())
-        .image_layout(vk::ImageLayout::GENERAL)
-        .load_op(vk::AttachmentLoadOp::CLEAR)
-        .store_op(vk::AttachmentStoreOp::STORE)
-        .clear_value(vk::ClearValue {
-            color: vk::ClearColorValue {
-                float32: [0.0, 0.0, 0.0, 0.0],
-            },
-        });
-
-    let rendering_info = vk::RenderingInfo::default()
-        .render_area(vk::Rect2D {
-            offset: vk::Offset2D::default(),
-            extent: surface_extent,
-        })
-        .layer_count(1)
-        .color_attachments(std::slice::from_ref(&color_attachment));
+    let render_area = vk::Rect2D {
+        offset: vk::Offset2D::default(),
+        extent: surface_extent,
+    };
 
     {
-        let rendering_encoder = encoder.begin_rendering(&rendering_info);
+        let render_pass_encoder = encoder.begin_render_pass(
+            frame.render_pass(),
+            frame.framebuffer(),
+            render_area,
+            &clear_values,
+        );
 
-        rendering_encoder.set_viewport(&[vk::Viewport {
+        render_pass_encoder.set_viewport(&[vk::Viewport {
             x: offset_x as f32,
             y: offset_y as f32,
             width: color_target_extent.width as f32,
@@ -70,7 +54,7 @@ pub(crate) fn render_blitter_pass(
             min_depth: 0.0,
             max_depth: 1.0,
         }]);
-        rendering_encoder.set_scissor(&[vk::Rect2D {
+        render_pass_encoder.set_scissor(&[vk::Rect2D {
             offset: vk::Offset2D {
                 x: offset_x as i32,
                 y: offset_y as i32,
@@ -81,24 +65,13 @@ pub(crate) fn render_blitter_pass(
         let mut push_bytes = [0u8; 8];
         push_bytes[0..4].copy_from_slice(&(offset_x as i32).to_le_bytes());
         push_bytes[4..8].copy_from_slice(&(offset_y as i32).to_le_bytes());
-        rendering_encoder.push_constants(
+        render_pass_encoder.push_constants(
             pipeline_layout,
             vk::ShaderStageFlags::FRAGMENT,
             0,
             &push_bytes,
         );
 
-        blitter.render(&rendering_encoder, ());
+        blitter.render(&render_pass_encoder, ());
     }
-
-    // Transition to PRESENT_SRC_KHR for swapchain present (still required).
-    encoder.image_barrier(
-        frame.image(),
-        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
-        vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
-        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
-        vk::AccessFlags2::NONE,
-        vk::ImageLayout::GENERAL,
-        vk::ImageLayout::PRESENT_SRC_KHR,
-    );
 }

--- a/crates/graphics_engine/src/passes/blitter/blitter.rs
+++ b/crates/graphics_engine/src/passes/blitter/blitter.rs
@@ -6,7 +6,7 @@ use crate::{
     pipeline_loader::PipelineLoader,
     plumbing::{
         GraphicsPipeline, PipelineBlendState, PipelineConfig, PipelineMultisampleState,
-        RenderingEncoder,
+        RenderPassEncoder,
     },
 };
 
@@ -22,12 +22,14 @@ static BLITTER_SRGB_SPV: &[u8] = include_bytes!(concat!(
 pub(crate) struct Blitter {
     pipeline: GraphicsPipeline,
     color_target_image_format: vk::Format,
+    render_pass: vk::RenderPass,
 }
 
 impl Blitter {
     pub(crate) fn new(
         pipeline_loader: &PipelineLoader,
         color_target_image_format: vk::Format,
+        render_pass: vk::RenderPass,
         pipeline_layout: vk::PipelineLayout,
     ) -> crate::Result<Self> {
         let (shader_name, spv_data) = match color_target_image_format {
@@ -44,8 +46,8 @@ impl Blitter {
                 c"vs_main",
                 c"fs_main",
                 &PipelineConfig {
-                    color_formats: vec![color_target_image_format],
-                    depth_format: None,
+                    render_pass,
+                    subpass: 0,
                     blend_state: PipelineBlendState::default(),
                     multisample_state: PipelineMultisampleState::default(),
                     specialization_info: None,
@@ -58,18 +60,24 @@ impl Blitter {
         Ok(Self {
             pipeline,
             color_target_image_format,
+            render_pass,
         })
     }
 
-    pub(crate) fn color_target_image_format(&self) -> vk::Format {
-        self.color_target_image_format
+    pub(crate) fn is_compatible(
+        &self,
+        color_target_image_format: vk::Format,
+        render_pass: vk::RenderPass,
+    ) -> bool {
+        self.color_target_image_format == color_target_image_format
+            && self.render_pass == render_pass
     }
 }
 
 impl Renderer for Blitter {
     type DrawData = ();
 
-    fn render(&self, encoder: &RenderingEncoder<'_>, _draw_data: Self::DrawData) {
+    fn render(&self, encoder: &RenderPassEncoder<'_>, _draw_data: Self::DrawData) {
         encoder.bind_pipeline(&self.pipeline);
         encoder.draw(3, 1, 0, 0);
     }

--- a/crates/graphics_engine/src/passes/clear.rs
+++ b/crates/graphics_engine/src/passes/clear.rs
@@ -8,48 +8,21 @@ pub(crate) fn clear_frame_pass(
     extent: vk::Extent2D,
     frame: &FrameTarget,
 ) {
-    // Transition from UNDEFINED to GENERAL.
-    // Use COLOR_ATTACHMENT_OUTPUT as srcStageMask to synchronize with the
-    // semaphore wait from vkAcquireNextImageKHR.
-    encoder.image_barrier(
-        frame.image(),
-        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
-        vk::AccessFlags2::NONE,
-        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
-        vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
-        vk::ImageLayout::UNDEFINED,
-        vk::ImageLayout::GENERAL,
-    );
+    let clear_values = [vk::ClearValue {
+        color: vk::ClearColorValue {
+            float32: [0.0, 0.0, 0.0, 0.0],
+        },
+    }];
 
-    let color_attachment = vk::RenderingAttachmentInfo::default()
-        .image_view(frame.view())
-        .image_layout(vk::ImageLayout::GENERAL)
-        .load_op(vk::AttachmentLoadOp::CLEAR)
-        .store_op(vk::AttachmentStoreOp::STORE)
-        .clear_value(vk::ClearValue {
-            color: vk::ClearColorValue {
-                float32: [0.0, 0.0, 0.0, 0.0],
-            },
-        });
+    let render_area = vk::Rect2D {
+        offset: vk::Offset2D::default(),
+        extent,
+    };
 
-    let rendering_info = vk::RenderingInfo::default()
-        .render_area(vk::Rect2D {
-            offset: vk::Offset2D::default(),
-            extent,
-        })
-        .layer_count(1)
-        .color_attachments(std::slice::from_ref(&color_attachment));
-
-    encoder.begin_rendering(&rendering_info);
-
-    // Transition to PRESENT_SRC_KHR for swapchain present.
-    encoder.image_barrier(
-        frame.image(),
-        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
-        vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
-        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
-        vk::AccessFlags2::NONE,
-        vk::ImageLayout::GENERAL,
-        vk::ImageLayout::PRESENT_SRC_KHR,
+    let _render_pass_encoder = encoder.begin_render_pass(
+        frame.render_pass(),
+        frame.framebuffer(),
+        render_area,
+        &clear_values,
     );
 }

--- a/crates/graphics_engine/src/passes/crt.rs
+++ b/crates/graphics_engine/src/passes/crt.rs
@@ -13,6 +13,7 @@ use crate::{
 pub(crate) fn render_crt_pass(
     encoder: &mut CommandEncoder,
     color_target: &ColorTargetImage,
+    render_pass: vk::RenderPass,
     crt: &Crt,
     native_height: u32,
     pipeline_layout: vk::PipelineLayout,
@@ -21,40 +22,37 @@ pub(crate) fn render_crt_pass(
 
     encoder.image_barrier(
         color_target.handle(),
-        vk::PipelineStageFlags2::FRAGMENT_SHADER,
-        vk::AccessFlags2::SHADER_SAMPLED_READ,
-        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
-        vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
+        vk::PipelineStageFlags::FRAGMENT_SHADER,
+        vk::AccessFlags::SHADER_READ,
+        vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+        vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
         vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
         vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
     );
 
-    let color_attachment = vk::RenderingAttachmentInfo::default()
-        .image_view(color_target.view())
-        .image_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-        .load_op(vk::AttachmentLoadOp::CLEAR)
-        .store_op(vk::AttachmentStoreOp::STORE)
-        .clear_value(vk::ClearValue {
-            color: vk::ClearColorValue {
-                float32: [0.0, 0.0, 0.0, 1.0],
-            },
-        });
+    let clear_values = [vk::ClearValue {
+        color: vk::ClearColorValue {
+            float32: [0.0, 0.0, 0.0, 1.0],
+        },
+    }];
 
-    let rendering_info = vk::RenderingInfo::default()
-        .render_area(vk::Rect2D {
-            offset: vk::Offset2D::default(),
-            extent: vk::Extent2D {
-                width: extent.width,
-                height: extent.height,
-            },
-        })
-        .layer_count(1)
-        .color_attachments(std::slice::from_ref(&color_attachment));
+    let render_area = vk::Rect2D {
+        offset: vk::Offset2D::default(),
+        extent: vk::Extent2D {
+            width: extent.width,
+            height: extent.height,
+        },
+    };
 
     {
-        let rendering_encoder = encoder.begin_rendering(&rendering_info);
+        let render_pass_encoder = encoder.begin_render_pass(
+            render_pass,
+            color_target.framebuffer(),
+            render_area,
+            &clear_values,
+        );
 
-        rendering_encoder.set_viewport(&[vk::Viewport {
+        render_pass_encoder.set_viewport(&[vk::Viewport {
             x: 0.0,
             y: 0.0,
             width: extent.width as f32,
@@ -62,7 +60,7 @@ pub(crate) fn render_crt_pass(
             min_depth: 0.0,
             max_depth: 1.0,
         }]);
-        rendering_encoder.set_scissor(&[vk::Rect2D {
+        render_pass_encoder.set_scissor(&[vk::Rect2D {
             offset: vk::Offset2D::default(),
             extent: vk::Extent2D {
                 width: extent.width,
@@ -79,22 +77,22 @@ pub(crate) fn render_crt_pass(
             native_height,
             native_height,
         );
-        rendering_encoder.push_constants(
+        render_pass_encoder.push_constants(
             pipeline_layout,
             vk::ShaderStageFlags::FRAGMENT,
             0,
             &push_constants.to_le_bytes(),
         );
 
-        crt.render(&rendering_encoder, ());
+        crt.render(&render_pass_encoder, ());
     }
 
     encoder.image_barrier(
         color_target.handle(),
-        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
-        vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
-        vk::PipelineStageFlags2::FRAGMENT_SHADER,
-        vk::AccessFlags2::SHADER_SAMPLED_READ,
+        vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+        vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
+        vk::PipelineStageFlags::FRAGMENT_SHADER,
+        vk::AccessFlags::SHADER_READ,
         vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
         vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
     );

--- a/crates/graphics_engine/src/passes/crt/crt.rs
+++ b/crates/graphics_engine/src/passes/crt/crt.rs
@@ -6,7 +6,7 @@ use crate::{
     pipeline_loader::PipelineLoader,
     plumbing::{
         GraphicsPipeline, PipelineBlendState, PipelineConfig, PipelineMultisampleState,
-        RenderingEncoder,
+        RenderPassEncoder,
     },
 };
 
@@ -22,6 +22,7 @@ pub(crate) struct Crt {
 impl Crt {
     pub(crate) fn new(
         pipeline_loader: &PipelineLoader,
+        render_pass: vk::RenderPass,
         pipeline_layout: vk::PipelineLayout,
     ) -> crate::Result<Self> {
         let pipeline = pipeline_loader
@@ -31,8 +32,8 @@ impl Crt {
                 c"vs_main",
                 c"fs_main",
                 &PipelineConfig {
-                    color_formats: vec![vk::Format::R8G8B8A8_SRGB],
-                    depth_format: None,
+                    render_pass,
+                    subpass: 0,
                     blend_state: PipelineBlendState::default(),
                     multisample_state: PipelineMultisampleState::default(),
                     specialization_info: None,
@@ -49,7 +50,7 @@ impl Crt {
 impl Renderer for Crt {
     type DrawData = ();
 
-    fn render(&self, encoder: &RenderingEncoder<'_>, _draw_data: Self::DrawData) {
+    fn render(&self, encoder: &RenderPassEncoder<'_>, _draw_data: Self::DrawData) {
         encoder.bind_pipeline(&self.pipeline);
         encoder.draw(3, 1, 0, 0);
     }

--- a/crates/graphics_engine/src/passes/scale.rs
+++ b/crates/graphics_engine/src/passes/scale.rs
@@ -13,6 +13,7 @@ use crate::{
 pub(crate) fn render_scale_pass(
     encoder: &mut CommandEncoder,
     color_target: &ColorTargetImage,
+    render_pass: vk::RenderPass,
     scale: &Scale,
     native_height: u32,
     pipeline_layout: vk::PipelineLayout,
@@ -21,40 +22,37 @@ pub(crate) fn render_scale_pass(
 
     encoder.image_barrier(
         color_target.handle(),
-        vk::PipelineStageFlags2::FRAGMENT_SHADER,
-        vk::AccessFlags2::SHADER_SAMPLED_READ,
-        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
-        vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
+        vk::PipelineStageFlags::FRAGMENT_SHADER,
+        vk::AccessFlags::SHADER_READ,
+        vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+        vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
         vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
         vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
     );
 
-    let color_attachment = vk::RenderingAttachmentInfo::default()
-        .image_view(color_target.view())
-        .image_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-        .load_op(vk::AttachmentLoadOp::CLEAR)
-        .store_op(vk::AttachmentStoreOp::STORE)
-        .clear_value(vk::ClearValue {
-            color: vk::ClearColorValue {
-                float32: [0.0, 0.0, 0.0, 1.0],
-            },
-        });
+    let clear_values = [vk::ClearValue {
+        color: vk::ClearColorValue {
+            float32: [0.0, 0.0, 0.0, 1.0],
+        },
+    }];
 
-    let rendering_info = vk::RenderingInfo::default()
-        .render_area(vk::Rect2D {
-            offset: vk::Offset2D::default(),
-            extent: vk::Extent2D {
-                width: extent.width,
-                height: extent.height,
-            },
-        })
-        .layer_count(1)
-        .color_attachments(std::slice::from_ref(&color_attachment));
+    let render_area = vk::Rect2D {
+        offset: vk::Offset2D::default(),
+        extent: vk::Extent2D {
+            width: extent.width,
+            height: extent.height,
+        },
+    };
 
     {
-        let rendering_encoder = encoder.begin_rendering(&rendering_info);
+        let render_pass_encoder = encoder.begin_render_pass(
+            render_pass,
+            color_target.framebuffer(),
+            render_area,
+            &clear_values,
+        );
 
-        rendering_encoder.set_viewport(&[vk::Viewport {
+        render_pass_encoder.set_viewport(&[vk::Viewport {
             x: 0.0,
             y: 0.0,
             width: extent.width as f32,
@@ -62,7 +60,7 @@ pub(crate) fn render_scale_pass(
             min_depth: 0.0,
             max_depth: 1.0,
         }]);
-        rendering_encoder.set_scissor(&[vk::Rect2D {
+        render_pass_encoder.set_scissor(&[vk::Rect2D {
             offset: vk::Offset2D::default(),
             extent: vk::Extent2D {
                 width: extent.width,
@@ -79,22 +77,22 @@ pub(crate) fn render_scale_pass(
             native_height,
             native_height,
         );
-        rendering_encoder.push_constants(
+        render_pass_encoder.push_constants(
             pipeline_layout,
             vk::ShaderStageFlags::FRAGMENT,
             0,
             &push_constants.to_le_bytes(),
         );
 
-        scale.render(&rendering_encoder, ());
+        scale.render(&render_pass_encoder, ());
     }
 
     encoder.image_barrier(
         color_target.handle(),
-        vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
-        vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
-        vk::PipelineStageFlags2::FRAGMENT_SHADER,
-        vk::AccessFlags2::SHADER_SAMPLED_READ,
+        vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+        vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
+        vk::PipelineStageFlags::FRAGMENT_SHADER,
+        vk::AccessFlags::SHADER_READ,
         vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
         vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
     );

--- a/crates/graphics_engine/src/passes/scale/scale.rs
+++ b/crates/graphics_engine/src/passes/scale/scale.rs
@@ -6,7 +6,7 @@ use crate::{
     pipeline_loader::PipelineLoader,
     plumbing::{
         GraphicsPipeline, PipelineBlendState, PipelineConfig, PipelineMultisampleState,
-        RenderingEncoder,
+        RenderPassEncoder,
     },
 };
 
@@ -22,6 +22,7 @@ pub(crate) struct Scale {
 impl Scale {
     pub(crate) fn new(
         pipeline_loader: &PipelineLoader,
+        render_pass: vk::RenderPass,
         pipeline_layout: vk::PipelineLayout,
     ) -> crate::Result<Self> {
         let pipeline = pipeline_loader
@@ -31,8 +32,8 @@ impl Scale {
                 c"vs_main",
                 c"fs_main",
                 &PipelineConfig {
-                    color_formats: vec![vk::Format::R8G8B8A8_SRGB],
-                    depth_format: None,
+                    render_pass,
+                    subpass: 0,
                     blend_state: PipelineBlendState::default(),
                     multisample_state: PipelineMultisampleState::default(),
                     specialization_info: None,
@@ -49,7 +50,7 @@ impl Scale {
 impl Renderer for Scale {
     type DrawData = ();
 
-    fn render(&self, encoder: &RenderingEncoder<'_>, _draw_data: Self::DrawData) {
+    fn render(&self, encoder: &RenderPassEncoder<'_>, _draw_data: Self::DrawData) {
         encoder.bind_pipeline(&self.pipeline);
         encoder.draw(3, 1, 0, 0);
     }

--- a/crates/graphics_engine/src/plumbing.rs
+++ b/crates/graphics_engine/src/plumbing.rs
@@ -10,12 +10,13 @@ mod graphics_pipeline;
 mod image;
 pub(crate) mod memory;
 mod queue;
+mod render_pass;
 mod surface;
 mod sync;
 mod utils;
 
 pub(crate) use buffer::MappedBuffer;
-pub(crate) use command::{CommandBuffer, CommandEncoder, CommandPool, RenderingEncoder};
+pub(crate) use command::{CommandBuffer, CommandEncoder, CommandPool, RenderPassEncoder};
 pub(crate) use context::Context;
 pub(crate) use device::{DeferredResource, Device, DeviceConfiguration};
 pub(crate) use frame_resource::FrameResources;
@@ -25,6 +26,7 @@ pub(crate) use graphics_pipeline::{
 };
 pub(crate) use image::{ColorTargetImage, SampledTransferImage};
 pub(crate) use queue::Queue;
+pub(crate) use render_pass::{RenderPass, create_framebuffer, framebuffer_name};
 pub(crate) use surface::Surface;
 pub(crate) use sync::{Binary, Fence, Semaphore, Timeline};
 pub(crate) use utils::IntoCString;

--- a/crates/graphics_engine/src/plumbing/buffer.rs
+++ b/crates/graphics_engine/src/plumbing/buffer.rs
@@ -8,8 +8,8 @@ use crate::{Result, plumbing::Context};
 
 /// A persistently mapped host-visible GPU buffer.
 ///
-/// Allocates with `HOST_ACCESS | FAST_DEVICE_ACCESS | DEVICE_ADDRESS`,
-/// falling back to host-visible heaps.
+/// Allocates with `HOST_ACCESS | FAST_DEVICE_ACCESS`, falling back to
+/// host-visible heaps.
 ///
 /// The entire buffer is mapped on construction and remains mapped until
 /// drop.
@@ -33,11 +33,10 @@ impl MappedBuffer {
         min_alignment: Option<u64>,
     ) -> Result<Self> {
         let byte_size = byte_size.max(1);
-        let buffer_usage = usage | vk::BufferUsageFlags::SHADER_DEVICE_ADDRESS;
 
         let buffer_create_info = vk::BufferCreateInfo::default()
             .size(byte_size)
-            .usage(buffer_usage)
+            .usage(usage)
             .sharing_mode(vk::SharingMode::EXCLUSIVE);
 
         let raw = unsafe {

--- a/crates/graphics_engine/src/plumbing/command.rs
+++ b/crates/graphics_engine/src/plumbing/command.rs
@@ -133,35 +133,26 @@ impl<'a> CommandEncoder<'a> {
         Ok(Self { context, buffer })
     }
 
-    /// Inserts a pipeline barrier using synchronization2.
-    pub(crate) fn pipeline_barrier2(&self, dependency_info: &vk::DependencyInfo) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_pipeline_barrier2(self.buffer, dependency_info)
-        };
-    }
-
     /// Begins a debug label region.
     pub(crate) fn begin_debug_label(&self, label: impl Into<Cow<'static, CStr>>, color: [f32; 4]) {
         let label = label.into();
         let label_info = vk::DebugUtilsLabelEXT::default()
             .label_name(&label)
             .color(color);
-        unsafe {
-            self.context
-                .debug_utils_device()
-                .cmd_begin_debug_utils_label(self.buffer, &label_info)
-        };
+        if let Some(debug_utils_device) = self.context.debug_utils_device() {
+            unsafe {
+                debug_utils_device.cmd_begin_debug_utils_label(self.buffer, &label_info);
+            }
+        }
     }
 
     /// Ends a debug label region.
     pub(crate) fn end_debug_label(&self) {
-        unsafe {
-            self.context
-                .debug_utils_device()
-                .cmd_end_debug_utils_label(self.buffer)
-        };
+        if let Some(debug_utils_device) = self.context.debug_utils_device() {
+            unsafe {
+                debug_utils_device.cmd_end_debug_utils_label(self.buffer);
+            }
+        }
     }
 }
 
@@ -177,239 +168,29 @@ impl Drop for CommandEncoder<'_> {
 }
 
 impl<'a> CommandEncoder<'a> {
-    /// Begins dynamic rendering. Returns an encoder that ends rendering on drop.
-    pub(crate) fn begin_rendering(
+    /// Begins a render pass. Returns an encoder that ends the render pass on drop.
+    pub(crate) fn begin_render_pass(
         &'a self,
-        rendering_info: &vk::RenderingInfo,
-    ) -> RenderingEncoder<'a> {
-        unsafe {
-            self.context
-                .device()
-                .cmd_begin_rendering(self.buffer, rendering_info)
-        };
-        RenderingEncoder { encoder: self }
-    }
+        render_pass: vk::RenderPass,
+        framebuffer: vk::Framebuffer,
+        render_area: vk::Rect2D,
+        clear_values: &'a [vk::ClearValue],
+    ) -> RenderPassEncoder<'a> {
+        let begin_info = vk::RenderPassBeginInfo::default()
+            .render_pass(render_pass)
+            .framebuffer(framebuffer)
+            .render_area(render_area)
+            .clear_values(clear_values);
 
-    /// Sets whether rasterizer discard is enabled.
-    pub(crate) fn set_rasterizer_discard_enable(&self, enable: bool) {
         unsafe {
-            self.context
-                .device()
-                .cmd_set_rasterizer_discard_enable(self.buffer, enable)
-        };
-    }
-
-    /// Sets the cull mode.
-    pub(crate) fn set_cull_mode(&self, cull_mode: vk::CullModeFlags) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_cull_mode(self.buffer, cull_mode)
-        };
-    }
-
-    /// Sets whether depth testing is enabled.
-    pub(crate) fn set_depth_test_enable(&self, enable: bool) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_depth_test_enable(self.buffer, enable)
-        };
-    }
-
-    /// Sets whether depth writing is enabled.
-    pub(crate) fn set_depth_write_enable(&self, enable: bool) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_depth_write_enable(self.buffer, enable)
-        };
-    }
-
-    /// Sets the front face orientation.
-    pub(crate) fn set_front_face(&self, front_face: vk::FrontFace) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_front_face(self.buffer, front_face)
-        };
-    }
-
-    /// Sets whether stencil testing is enabled.
-    pub(crate) fn set_stencil_test_enable(&self, enable: bool) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_stencil_test_enable(self.buffer, enable)
-        };
-    }
-
-    /// Sets whether depth bias is enabled.
-    pub(crate) fn set_depth_bias_enable(&self, enable: bool) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_depth_bias_enable(self.buffer, enable)
-        };
-    }
-
-    /// Sets the primitive topology.
-    pub(crate) fn set_primitive_topology(&self, topology: vk::PrimitiveTopology) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_primitive_topology(self.buffer, topology)
-        };
-    }
-
-    /// Sets whether primitive restart is enabled.
-    pub(crate) fn set_primitive_restart_enable(&self, enable: bool) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_primitive_restart_enable(self.buffer, enable)
-        };
-    }
-
-    /// Sets the depth compare operation.
-    pub(crate) fn set_depth_compare_op(&self, op: vk::CompareOp) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_depth_compare_op(self.buffer, op)
-        };
-    }
-
-    /// Sets the line width for line rasterization.
-    pub(crate) fn set_line_width(&self, line_width: f32) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_line_width(self.buffer, line_width)
-        };
-    }
-
-    /// Sets depth bias parameters.
-    pub(crate) fn set_depth_bias(&self, constant_factor: f32, clamp: f32, slope_factor: f32) {
-        unsafe {
-            self.context.device().cmd_set_depth_bias(
+            self.context.device().cmd_begin_render_pass(
                 self.buffer,
-                constant_factor,
-                clamp,
-                slope_factor,
+                &begin_info,
+                vk::SubpassContents::INLINE,
             )
         };
-    }
 
-    /// Sets the blend constant color.
-    pub(crate) fn set_blend_constants(&self, blend_constants: [f32; 4]) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_blend_constants(self.buffer, &blend_constants)
-        };
-    }
-
-    /// Sets the depth bounds test range.
-    pub(crate) fn set_depth_bounds(&self, min: f32, max: f32) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_depth_bounds(self.buffer, min, max)
-        };
-    }
-
-    /// Sets whether depth bounds testing is enabled.
-    pub(crate) fn set_depth_bounds_test_enable(&self, enable: bool) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_depth_bounds_test_enable(self.buffer, enable)
-        };
-    }
-
-    /// Sets the stencil compare mask.
-    pub(crate) fn set_stencil_compare_mask(
-        &self,
-        face_mask: vk::StencilFaceFlags,
-        compare_mask: u32,
-    ) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_stencil_compare_mask(self.buffer, face_mask, compare_mask)
-        };
-    }
-
-    /// Sets the stencil write mask.
-    pub(crate) fn set_stencil_write_mask(&self, face_mask: vk::StencilFaceFlags, write_mask: u32) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_stencil_write_mask(self.buffer, face_mask, write_mask)
-        };
-    }
-
-    /// Sets the stencil reference value.
-    pub(crate) fn set_stencil_reference(&self, face_mask: vk::StencilFaceFlags, reference: u32) {
-        unsafe {
-            self.context
-                .device()
-                .cmd_set_stencil_reference(self.buffer, face_mask, reference)
-        };
-    }
-
-    /// Sets the stencil test operations.
-    pub(crate) fn set_stencil_op(
-        &self,
-        face_mask: vk::StencilFaceFlags,
-        fail_op: vk::StencilOp,
-        pass_op: vk::StencilOp,
-        depth_fail_op: vk::StencilOp,
-        compare_op: vk::CompareOp,
-    ) {
-        unsafe {
-            self.context.device().cmd_set_stencil_op(
-                self.buffer,
-                face_mask,
-                fail_op,
-                pass_op,
-                depth_fail_op,
-                compare_op,
-            )
-        };
-    }
-
-    /// Sets Vulkan 1.3 core dynamic states to their default values.
-    ///
-    /// Call this once after creating the encoder, before any render passes.
-    /// Blend state, polygon mode, and multisample state are baked into pipelines.
-    pub(crate) fn set_default_dynamic_state(&mut self) {
-        self.set_depth_test_enable(false);
-        self.set_depth_compare_op(vk::CompareOp::ALWAYS);
-        self.set_depth_write_enable(false);
-        self.set_depth_bias_enable(false);
-        self.set_depth_bias(0.0, 0.0, 0.0);
-        self.set_depth_bounds(0.0, 1.0);
-        self.set_depth_bounds_test_enable(false);
-        self.set_stencil_test_enable(false);
-        self.set_stencil_compare_mask(vk::StencilFaceFlags::FRONT_AND_BACK, 0xFF);
-        self.set_stencil_write_mask(vk::StencilFaceFlags::FRONT_AND_BACK, 0xFF);
-        self.set_stencil_reference(vk::StencilFaceFlags::FRONT_AND_BACK, 0x00);
-        self.set_stencil_op(
-            vk::StencilFaceFlags::FRONT_AND_BACK,
-            vk::StencilOp::KEEP,
-            vk::StencilOp::KEEP,
-            vk::StencilOp::KEEP,
-            vk::CompareOp::ALWAYS,
-        );
-        self.set_rasterizer_discard_enable(false);
-        self.set_cull_mode(vk::CullModeFlags::NONE);
-        self.set_front_face(vk::FrontFace::COUNTER_CLOCKWISE);
-        self.set_primitive_topology(vk::PrimitiveTopology::TRIANGLE_LIST);
-        self.set_primitive_restart_enable(false);
-        self.set_blend_constants([0.0, 0.0, 0.0, 0.0]);
-        self.set_line_width(1.0);
+        RenderPassEncoder { encoder: self }
     }
 
     /// Binds descriptor sets to the graphics pipeline bind point.
@@ -474,17 +255,15 @@ impl<'a> CommandEncoder<'a> {
     pub(crate) fn image_barrier(
         &mut self,
         image: vk::Image,
-        src_stage: vk::PipelineStageFlags2,
-        src_access: vk::AccessFlags2,
-        dst_stage: vk::PipelineStageFlags2,
-        dst_access: vk::AccessFlags2,
+        src_stage: vk::PipelineStageFlags,
+        src_access: vk::AccessFlags,
+        dst_stage: vk::PipelineStageFlags,
+        dst_access: vk::AccessFlags,
         old_layout: vk::ImageLayout,
         new_layout: vk::ImageLayout,
     ) {
-        let barrier = vk::ImageMemoryBarrier2::default()
-            .src_stage_mask(src_stage)
+        let barrier = vk::ImageMemoryBarrier::default()
             .src_access_mask(src_access)
-            .dst_stage_mask(dst_stage)
             .dst_access_mask(dst_access)
             .old_layout(old_layout)
             .new_layout(new_layout)
@@ -499,20 +278,28 @@ impl<'a> CommandEncoder<'a> {
                     .base_array_layer(0)
                     .layer_count(1),
             );
-        self.pipeline_barrier2(
-            &vk::DependencyInfo::default().image_memory_barriers(std::slice::from_ref(&barrier)),
-        );
+        unsafe {
+            self.context.device().cmd_pipeline_barrier(
+                self.buffer,
+                src_stage,
+                dst_stage,
+                vk::DependencyFlags::empty(),
+                &[],
+                &[],
+                std::slice::from_ref(&barrier),
+            );
+        }
     }
 }
 
-/// RAII guard for dynamic rendering scope.
+/// RAII guard for a render pass scope.
 ///
-/// Calls `cmd_end_rendering` on drop.
-pub(crate) struct RenderingEncoder<'a> {
+/// Calls `cmd_end_render_pass` on drop.
+pub(crate) struct RenderPassEncoder<'a> {
     encoder: &'a CommandEncoder<'a>,
 }
 
-impl RenderingEncoder<'_> {
+impl RenderPassEncoder<'_> {
     /// Binds a graphics pipeline.
     pub(crate) fn bind_pipeline(&self, pipeline: &GraphicsPipeline) {
         unsafe {
@@ -524,23 +311,23 @@ impl RenderingEncoder<'_> {
         };
     }
 
-    /// Sets the viewport with count (required for shader objects).
+    /// Sets the viewport.
     pub(crate) fn set_viewport(&self, viewports: &[vk::Viewport]) {
         unsafe {
             self.encoder
                 .context
                 .device()
-                .cmd_set_viewport_with_count(self.encoder.buffer, viewports)
+                .cmd_set_viewport(self.encoder.buffer, 0, viewports)
         };
     }
 
-    /// Sets the scissor rectangles with count (required for shader objects).
+    /// Sets the scissor rectangles.
     pub(crate) fn set_scissor(&self, scissors: &[vk::Rect2D]) {
         unsafe {
             self.encoder
                 .context
                 .device()
-                .cmd_set_scissor_with_count(self.encoder.buffer, scissors)
+                .cmd_set_scissor(self.encoder.buffer, 0, scissors)
         };
     }
 
@@ -583,13 +370,13 @@ impl RenderingEncoder<'_> {
     }
 }
 
-impl Drop for RenderingEncoder<'_> {
+impl Drop for RenderPassEncoder<'_> {
     fn drop(&mut self) {
         unsafe {
             self.encoder
                 .context
                 .device()
-                .cmd_end_rendering(self.encoder.buffer)
+                .cmd_end_render_pass(self.encoder.buffer)
         };
     }
 }

--- a/crates/graphics_engine/src/plumbing/context.rs
+++ b/crates/graphics_engine/src/plumbing/context.rs
@@ -12,9 +12,10 @@ use crate::plumbing::utils::vk_result_to_string;
 /// The internal context.
 pub(crate) struct Context {
     allocator: RefCell<GpuAllocator>,
-    debug_utils_device: jay_ash::ext::debug_utils::Device,
+    debug_utils_device: Option<jay_ash::ext::debug_utils::Device>,
     debug_utils_instance: Option<jay_ash::ext::debug_utils::Instance>,
     debug_messenger: Option<vk::DebugUtilsMessengerEXT>,
+    timeline_semaphore: jay_ash::khr::timeline_semaphore::Device,
     present_wait2: Option<jay_ash::khr::present_wait2::Device>,
     device: jay_ash::Device,
     physical_device: vk::PhysicalDevice,
@@ -43,9 +44,10 @@ impl Context {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         allocator: GpuAllocator,
-        debug_utils_device: jay_ash::ext::debug_utils::Device,
+        debug_utils_device: Option<jay_ash::ext::debug_utils::Device>,
         debug_utils_instance: Option<jay_ash::ext::debug_utils::Instance>,
         debug_messenger: Option<vk::DebugUtilsMessengerEXT>,
+        timeline_semaphore: jay_ash::khr::timeline_semaphore::Device,
         present_wait2: Option<jay_ash::khr::present_wait2::Device>,
         instance: jay_ash::Instance,
         device: jay_ash::Device,
@@ -57,6 +59,7 @@ impl Context {
             debug_utils_device,
             debug_utils_instance,
             debug_messenger,
+            timeline_semaphore,
             present_wait2,
             device,
             physical_device,
@@ -67,11 +70,15 @@ impl Context {
 
     /// Sets a debug name for an object.
     pub(crate) fn set_object_name(&self, name: &CStr, object: impl vk::Handle) {
+        let Some(debug_utils_device) = &self.debug_utils_device else {
+            return;
+        };
+
         let info = vk::DebugUtilsObjectNameInfoEXT::default()
             .object_name(name)
             .object_handle(object);
 
-        if let Err(error) = unsafe { self.debug_utils_device.set_debug_utils_object_name(&info) } {
+        if let Err(error) = unsafe { debug_utils_device.set_debug_utils_object_name(&info) } {
             error!(
                 "Can't set object name: {error}",
                 error = vk_result_to_string(error)
@@ -97,6 +104,12 @@ impl Context {
     #[inline(always)]
     pub(crate) fn present_wait2(&self) -> Option<&jay_ash::khr::present_wait2::Device> {
         self.present_wait2.as_ref()
+    }
+
+    /// Returns a reference to the VK_KHR_timeline_semaphore extension loader.
+    #[inline(always)]
+    pub(crate) fn timeline_semaphore(&self) -> &jay_ash::khr::timeline_semaphore::Device {
+        &self.timeline_semaphore
     }
 
     /// Returns a reference to the Vulkan device.
@@ -125,7 +138,7 @@ impl Context {
 
     /// Returns a reference to the debug utils device extension loader.
     #[inline(always)]
-    pub(crate) fn debug_utils_device(&self) -> &jay_ash::ext::debug_utils::Device {
-        &self.debug_utils_device
+    pub(crate) fn debug_utils_device(&self) -> Option<&jay_ash::ext::debug_utils::Device> {
+        self.debug_utils_device.as_ref()
     }
 }

--- a/crates/graphics_engine/src/plumbing/device.rs
+++ b/crates/graphics_engine/src/plumbing/device.rs
@@ -25,6 +25,7 @@ pub(crate) enum DeferredResource {
     Image {
         handle: vk::Image,
         view: Option<vk::ImageView>,
+        framebuffer: Option<vk::Framebuffer>,
         memory: MemoryBlock,
     },
 }
@@ -39,20 +40,18 @@ pub(crate) struct DeviceConfiguration {
     /// Platform-specific instance extensions (e.g. from SDL3's `SDL_Vulkan_GetInstanceExtensions`).
     pub(crate) platform_extensions: Vec<*const c_char>,
 
-    /// Device extensions to request.
+    /// Required device extensions to request.
     ///
-    /// The engine automatically adds required extensions like VK_KHR_swapchain
-    /// and VK_KHR_synchronization2. Only available extensions will be enabled.
-    pub(crate) extensions: Vec<*const c_char>,
+    /// If any of these are unavailable, device initialization fails.
+    pub(crate) required_device_extensions: Vec<*const c_char>,
+
+    /// Optional device extensions to request.
+    pub(crate) optional_device_extensions: Vec<*const c_char>,
 
     /// Vulkan 1.0 features to request.
     pub(crate) features_1_0: vk::PhysicalDeviceFeatures,
-    /// Vulkan 1.1 features to request.
-    pub(crate) features_1_1: vk::PhysicalDeviceVulkan11Features<'static>,
-    /// Vulkan 1.2 features to request.
-    pub(crate) features_1_2: vk::PhysicalDeviceVulkan12Features<'static>,
-    /// Vulkan 1.3 features to request.
-    pub(crate) features_1_3: vk::PhysicalDeviceVulkan13Features<'static>,
+    /// VK_KHR_timeline_semaphore features.
+    pub(crate) timeline_semaphore: vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR<'static>,
     /// VK_KHR_present_id2 features.
     pub(crate) present_id2: Option<vk::PhysicalDevicePresentId2FeaturesKHR<'static>>,
     /// VK_KHR_present_wait2 features.
@@ -61,44 +60,27 @@ pub(crate) struct DeviceConfiguration {
 
 impl DeviceConfiguration {
     /// Creates a new DeviceConfiguration with all the required features.
-    /// Aims to use all best practises for modern Vulkan 1.3.
     pub(crate) fn new(platform_extensions: Vec<*const c_char>) -> Self {
-        let mut extensions = vec![
-            // Standard swap chain extension (always supported).
+        let mut required_device_extensions = vec![
             vk::KHR_SWAPCHAIN_EXTENSION_NAME.as_ptr(),
-            // Present wait for better frame pacing (optional).
-            //
-            // Allows waiting for previous frame presentation to complete, enabling
-            // more consistent frame timing and reduced input latency.
+            vk::KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME.as_ptr(),
+        ];
+
+        let optional_device_extensions = vec![
             vk::KHR_PRESENT_ID_2_EXTENSION_NAME.as_ptr(),
             vk::KHR_PRESENT_WAIT_2_EXTENSION_NAME.as_ptr(),
         ];
 
         if cfg!(target_os = "macos") {
-            extensions.push(vk::KHR_PORTABILITY_SUBSET_EXTENSION_NAME.as_ptr());
+            required_device_extensions.push(vk::KHR_PORTABILITY_SUBSET_EXTENSION_NAME.as_ptr());
         }
 
         let features_1_0 = vk::PhysicalDeviceFeatures {
             ..Default::default()
         };
 
-        let features_1_1 = vk::PhysicalDeviceVulkan11Features {
-            ..Default::default()
-        };
-
-        let features_1_2 = vk::PhysicalDeviceVulkan12Features {
-            // Required by our shader scalar layout.
-            scalar_block_layout: vk::TRUE,
-            // Required by our frame resource management.
-            timeline_semaphore: vk::TRUE,
-            ..Default::default()
-        };
-
-        let features_1_3 = vk::PhysicalDeviceVulkan13Features {
-            dynamic_rendering: vk::TRUE,
-            synchronization2: vk::TRUE,
-            ..Default::default()
-        };
+        let timeline_semaphore =
+            vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR::default().timeline_semaphore(true);
 
         let present_id2 = vk::PhysicalDevicePresentId2FeaturesKHR::default().present_id2(true);
 
@@ -107,11 +89,10 @@ impl DeviceConfiguration {
 
         Self {
             platform_extensions,
-            extensions,
+            required_device_extensions,
+            optional_device_extensions,
             features_1_0,
-            features_1_1,
-            features_1_2,
-            features_1_3,
+            timeline_semaphore,
             present_id2: Some(present_id2),
             present_wait2: Some(present_wait2),
         }
@@ -119,13 +100,19 @@ impl DeviceConfiguration {
 }
 
 impl DeviceConfiguration {
+    fn device_extensions(&self) -> Vec<*const c_char> {
+        self.required_device_extensions
+            .iter()
+            .chain(self.optional_device_extensions.iter())
+            .copied()
+            .collect()
+    }
+
     /// Converts this configuration into a DeviceFeatures struct.
     fn into_device_features(self) -> DeviceFeatures {
         DeviceFeatures {
             features_1_0: self.features_1_0,
-            features_1_1: self.features_1_1,
-            features_1_2: self.features_1_2,
-            features_1_3: self.features_1_3,
+            timeline_semaphore: Some(self.timeline_semaphore),
             present_id2: self.present_id2,
             present_wait2: self.present_wait2,
         }
@@ -151,15 +138,7 @@ impl Device {
 
         let entry = load_vulkan_entry().context("Failed to load Vulkan entry")?;
 
-        let api_version = unsafe { entry.try_enumerate_instance_version() }
-            .context("Failed to enumerate instance version")?
-            .unwrap_or(vk::make_api_version(0, 1, 0, 0));
-
-        if api_version < vk::make_api_version(0, 1, 3, 0) {
-            bail!("Unsupported Vulkan API version (requires 1.3+)");
-        }
-
-        let api_version = vk::make_api_version(0, 1, 3, 0);
+        let api_version = vk::make_api_version(0, 1, 0, 0);
 
         info!(
             "Using Vulkan API Version: {api_version}",
@@ -168,7 +147,7 @@ impl Device {
 
         let (enable_validation, layer_names) = enable_validation_layers(&entry)?;
 
-        let extension_names = create_instance_extensions(&config.platform_extensions);
+        let instance_extensions = create_instance_extensions(&entry, &config.platform_extensions)?;
 
         let app_info = vk::ApplicationInfo::default()
             .engine_name(c"shinsekai_engine")
@@ -180,7 +159,7 @@ impl Device {
         let mut instance_create_info = vk::InstanceCreateInfo::default()
             .application_info(&app_info)
             .enabled_layer_names(&layer_names)
-            .enabled_extension_names(&extension_names);
+            .enabled_extension_names(&instance_extensions.names);
 
         if cfg!(target_os = "macos") {
             instance_create_info =
@@ -200,32 +179,41 @@ impl Device {
             )
             .pfn_user_callback(Some(vulkan_debug_callback));
 
-        if enable_validation && !layer_names.is_empty() {
+        if enable_validation && !layer_names.is_empty() && instance_extensions.debug_utils {
             instance_create_info = instance_create_info.push_next(&mut debug_create_info);
         }
 
         let instance = unsafe { entry.create_instance(&instance_create_info, None) }
             .context("Failed to create Vulkan instance")?;
 
-        let (debug_utils_instance, debug_messenger) = if enable_validation
-            && !layer_names.is_empty()
-        {
-            let debug_utils_instance = jay_ash::ext::debug_utils::Instance::new(&entry, &instance);
-            let messenger = unsafe {
-                debug_utils_instance.create_debug_utils_messenger(&debug_create_info, None)
-            }
-            .context("Failed to create debug messenger")?;
-            (Some(debug_utils_instance), Some(messenger))
-        } else {
-            (None, None)
-        };
+        let (debug_utils_instance, debug_messenger) =
+            if enable_validation && !layer_names.is_empty() && instance_extensions.debug_utils {
+                let debug_utils_instance =
+                    jay_ash::ext::debug_utils::Instance::new(&entry, &instance);
+                let messenger = unsafe {
+                    debug_utils_instance.create_debug_utils_messenger(&debug_create_info, None)
+                }
+                .context("Failed to create debug messenger")?;
+                (Some(debug_utils_instance), Some(messenger))
+            } else {
+                (None, None)
+            };
+
+        let physical_device_properties2 =
+            jay_ash::khr::get_physical_device_properties2::Instance::new(&entry, &instance);
 
         let physical_devices = unsafe { instance.enumerate_physical_devices() }
             .context("Failed to enumerate physical devices")?;
 
-        let physical_device = select_physical_device(&instance, &physical_devices)?;
+        let physical_device = select_physical_device(
+            &instance,
+            &physical_device_properties2,
+            &physical_devices,
+            &config.required_device_extensions,
+        )?;
 
-        let device_properties = unsafe { instance.get_physical_device_properties(physical_device) };
+        let device_properties =
+            query_physical_device_properties(&physical_device_properties2, physical_device);
         let device_name =
             unsafe { CStr::from_ptr(device_properties.device_name.as_ptr()).to_string_lossy() };
         info!("Selected physical device: {device_name}");
@@ -240,16 +228,7 @@ impl Device {
         // maxPerStageDescriptorSampledImages = 16 (we need at most one)
         // maxBoundDescriptorSets = 4 (we need at most two)
 
-        let (mut extension_ptrs, extension_set) = extensions::build_extension_list(
-            &instance,
-            physical_device,
-            config.extensions.clone(),
-        )?;
-
-        let available_features =
-            features::query_physical_device_features(&instance, physical_device, &extension_set);
-
-        // Check present_id2 and present_wait2 availability.
+        // Handle extension presence before required-extension validation.
         let present_id2_available = extensions::is_extension_available(
             &instance,
             physical_device,
@@ -261,21 +240,73 @@ impl Device {
             vk::KHR_PRESENT_WAIT_2_EXTENSION_NAME,
         );
 
+        let mut present_wait_disabled_reason = None;
+
         if !present_id2_available || !present_wait2_available {
+            let mut missing_extensions = Vec::new();
             if !present_id2_available {
-                info!("VK_KHR_present_id2 not available on this device");
+                missing_extensions.push("VK_KHR_present_id2");
             }
             if !present_wait2_available {
-                info!("VK_KHR_present_wait2 not available on this device");
+                missing_extensions.push("VK_KHR_present_wait2");
             }
+
+            present_wait_disabled_reason = Some(format!(
+                "optional extension unavailable ({missing_extensions})",
+                missing_extensions = missing_extensions.join(", ")
+            ));
+            disable_present_wait2(&mut config);
+        }
+
+        let (mut extension_ptrs, extension_set) = extensions::build_extension_list(
+            &instance,
+            physical_device,
+            config.device_extensions(),
+        )?;
+
+        let available_features = features::query_physical_device_features(
+            &physical_device_properties2,
+            physical_device,
+            &extension_set,
+        );
+
+        let present_id2_feature_available = available_features
+            .present_id2
+            .as_ref()
+            .is_some_and(|features| features.present_id2 == vk::TRUE);
+        let present_wait2_feature_available = available_features
+            .present_wait2
+            .as_ref()
+            .is_some_and(|features| features.present_wait2 == vk::TRUE);
+
+        // Handle extension feature bits after querying the pNext feature chain.
+        if config.present_id2.is_some()
+            && config.present_wait2.is_some()
+            && (!present_id2_feature_available || !present_wait2_feature_available)
+        {
+            let mut missing_features = Vec::new();
+            if !present_id2_feature_available {
+                missing_features.push("present_id2");
+            }
+            if !present_wait2_feature_available {
+                missing_features.push("present_wait2");
+            }
+
+            present_wait_disabled_reason = Some(format!(
+                "optional extension feature unavailable ({missing_features})",
+                missing_features = missing_features.join(", ")
+            ));
             extension_ptrs.retain(|&ptr| {
                 ptr != vk::KHR_PRESENT_ID_2_EXTENSION_NAME.as_ptr()
                     && ptr != vk::KHR_PRESENT_WAIT_2_EXTENSION_NAME.as_ptr()
             });
-            config.present_id2 = None;
-            config.present_wait2 = None;
+            disable_present_wait2(&mut config);
+        }
+
+        if let Some(reason) = present_wait_disabled_reason {
+            info!("Disabling present wait: {reason}");
         } else {
-            info!("VK_KHR_present_id2 and VK_KHR_present_wait2 are available on this device");
+            info!("Present wait enabled via VK_KHR_present_id2 and VK_KHR_present_wait2");
         }
 
         info!("Device extensions:");
@@ -285,6 +316,7 @@ impl Device {
             info!("  - {name_str}");
         }
 
+        let enable_present_wait2 = config.present_id2.is_some() && config.present_wait2.is_some();
         let mut requested_features = config.into_device_features();
         features::validate_features(&requested_features, &available_features)?;
 
@@ -304,8 +336,11 @@ impl Device {
         let device = unsafe { instance.create_device(physical_device, &device_create_info, None) }
             .context("Failed to create logical device")?;
 
-        let debug_utils_device = jay_ash::ext::debug_utils::Device::new(&instance, &device);
-        let present_wait2 = if present_id2_available && present_wait2_available {
+        let debug_utils_device = instance_extensions
+            .debug_utils
+            .then(|| jay_ash::ext::debug_utils::Device::new(&instance, &device));
+        let timeline_semaphore = jay_ash::khr::timeline_semaphore::Device::new(&instance, &device);
+        let present_wait2 = if enable_present_wait2 {
             Some(jay_ash::khr::present_wait2::Device::new(&instance, &device))
         } else {
             None
@@ -319,6 +354,7 @@ impl Device {
             debug_utils_device,
             debug_utils_instance,
             debug_messenger,
+            timeline_semaphore,
             present_wait2,
             instance,
             device,
@@ -403,8 +439,12 @@ impl Device {
                     DeferredResource::Image {
                         handle,
                         view,
+                        framebuffer,
                         memory,
                     } => unsafe {
+                        if let Some(framebuffer) = framebuffer {
+                            self.context.device().destroy_framebuffer(framebuffer, None);
+                        }
                         if let Some(view) = view {
                             self.context.device().destroy_image_view(view, None);
                         }
@@ -419,6 +459,15 @@ impl Device {
             }
         }
     }
+}
+
+fn disable_present_wait2(config: &mut DeviceConfiguration) {
+    config.optional_device_extensions.retain(|&ptr| {
+        ptr != vk::KHR_PRESENT_ID_2_EXTENSION_NAME.as_ptr()
+            && ptr != vk::KHR_PRESENT_WAIT_2_EXTENSION_NAME.as_ptr()
+    });
+    config.present_id2 = None;
+    config.present_wait2 = None;
 }
 
 fn enable_validation_layers(entry: &jay_ash::Entry) -> Result<(bool, Vec<*const c_char>)> {
@@ -446,14 +495,50 @@ fn enable_validation_layers(entry: &jay_ash::Entry) -> Result<(bool, Vec<*const 
     Ok((enable_validation, layer_names))
 }
 
-fn create_instance_extensions(platform_extensions: &[*const c_char]) -> Vec<*const c_char> {
-    let mut extension_names = Vec::from(platform_extensions);
+struct InstanceExtensions {
+    names: Vec<*const c_char>,
+    debug_utils: bool,
+}
 
-    extension_names.push(jay_ash::khr::get_surface_capabilities2::NAME.as_ptr());
-    extension_names.push(jay_ash::ext::debug_utils::NAME.as_ptr());
+fn create_instance_extensions(
+    entry: &jay_ash::Entry,
+    platform_extensions: &[*const c_char],
+) -> Result<InstanceExtensions> {
+    let available_extensions = unsafe { entry.enumerate_instance_extension_properties(None) }
+        .context("Failed to enumerate instance extensions")?;
+
+    let mut extension_names = Vec::new();
+
+    for &extension in platform_extensions {
+        push_required_instance_extension(&available_extensions, &mut extension_names, extension)?;
+    }
+
+    push_required_instance_extension(
+        &available_extensions,
+        &mut extension_names,
+        jay_ash::khr::get_physical_device_properties2::NAME.as_ptr(),
+    )?;
+    push_required_instance_extension(
+        &available_extensions,
+        &mut extension_names,
+        jay_ash::khr::get_surface_capabilities2::NAME.as_ptr(),
+    )?;
 
     if cfg!(target_os = "macos") {
-        extension_names.push(jay_ash::khr::portability_enumeration::NAME.as_ptr());
+        push_required_instance_extension(
+            &available_extensions,
+            &mut extension_names,
+            jay_ash::khr::portability_enumeration::NAME.as_ptr(),
+        )?;
+    }
+
+    let debug_utils =
+        is_instance_extension_available(&available_extensions, jay_ash::ext::debug_utils::NAME);
+    if debug_utils {
+        push_unique_extension(
+            &mut extension_names,
+            jay_ash::ext::debug_utils::NAME.as_ptr(),
+        );
     }
 
     info!("Enabled instance extensions:");
@@ -462,7 +547,49 @@ fn create_instance_extensions(platform_extensions: &[*const c_char]) -> Vec<*con
         info!("  - {ext_name}", ext_name = ext_name.to_string_lossy());
     }
 
-    extension_names
+    Ok(InstanceExtensions {
+        names: extension_names,
+        debug_utils,
+    })
+}
+
+fn push_required_instance_extension(
+    available_extensions: &[vk::ExtensionProperties],
+    extension_names: &mut Vec<*const c_char>,
+    extension: *const c_char,
+) -> Result<()> {
+    let extension_name = unsafe { CStr::from_ptr(extension) };
+
+    if !is_instance_extension_available(available_extensions, extension_name) {
+        bail!(
+            "required instance extension {extension_name} not available",
+            extension_name = extension_name.to_string_lossy()
+        );
+    }
+
+    push_unique_extension(extension_names, extension);
+    Ok(())
+}
+
+fn push_unique_extension(extension_names: &mut Vec<*const c_char>, extension: *const c_char) {
+    let extension_name = unsafe { CStr::from_ptr(extension) };
+
+    if extension_names.iter().all(|&existing_extension| {
+        let existing_name = unsafe { CStr::from_ptr(existing_extension) };
+        existing_name != extension_name
+    }) {
+        extension_names.push(extension);
+    }
+}
+
+fn is_instance_extension_available(
+    available_extensions: &[vk::ExtensionProperties],
+    extension_name: &CStr,
+) -> bool {
+    available_extensions.iter().any(|extension| {
+        let available_name = unsafe { CStr::from_ptr(extension.extension_name.as_ptr()) };
+        available_name == extension_name
+    })
 }
 
 fn query_graphics_queue_family(
@@ -482,10 +609,23 @@ fn query_graphics_queue_family(
 
 /// Scores a physical device based on its type and capabilities.
 /// Higher score is better. Returns 0 if device is unsuitable.
-fn score_device(instance: &jay_ash::Instance, physical_device: vk::PhysicalDevice) -> u32 {
-    let properties = unsafe { instance.get_physical_device_properties(physical_device) };
+fn score_device(
+    instance: &jay_ash::Instance,
+    physical_device_properties2: &jay_ash::khr::get_physical_device_properties2::Instance,
+    physical_device: vk::PhysicalDevice,
+    required_device_extensions: &[*const c_char],
+) -> u32 {
+    let properties = query_physical_device_properties(physical_device_properties2, physical_device);
 
     if find_graphics_queue_family(instance, physical_device).is_none() {
+        return 0;
+    }
+
+    if !supports_required_device_extensions(instance, physical_device, required_device_extensions) {
+        return 0;
+    }
+
+    if !supports_required_device_features(physical_device_properties2, physical_device) {
         return 0;
     }
 
@@ -501,7 +641,9 @@ fn score_device(instance: &jay_ash::Instance, physical_device: vk::PhysicalDevic
 /// Selects the best physical device from the available devices.
 fn select_physical_device(
     instance: &jay_ash::Instance,
+    physical_device_properties2: &jay_ash::khr::get_physical_device_properties2::Instance,
     devices: &[vk::PhysicalDevice],
+    required_device_extensions: &[*const c_char],
 ) -> Result<vk::PhysicalDevice> {
     if devices.is_empty() {
         bail!("no physical devices found");
@@ -511,7 +653,12 @@ fn select_physical_device(
     let mut best_score = 0;
 
     for &device in devices {
-        let score = score_device(instance, device);
+        let score = score_device(
+            instance,
+            physical_device_properties2,
+            device,
+            required_device_extensions,
+        );
         if score > best_score {
             best_score = score;
             best_device = Some(device);
@@ -520,9 +667,52 @@ fn select_physical_device(
 
     best_device.ok_or_else(|| {
         Error::Message(common::StringError(
-            "no suitable physical device found (missing required queue families)".to_owned(),
+            "no suitable physical device found (missing graphics queue, required extensions, or required features)".to_owned(),
         ))
     })
+}
+
+fn query_physical_device_properties(
+    physical_device_properties2: &jay_ash::khr::get_physical_device_properties2::Instance,
+    physical_device: vk::PhysicalDevice,
+) -> vk::PhysicalDeviceProperties {
+    let mut properties2 = vk::PhysicalDeviceProperties2KHR::default();
+    unsafe {
+        physical_device_properties2
+            .get_physical_device_properties2(physical_device, &mut properties2);
+    }
+    properties2.properties
+}
+
+fn supports_required_device_extensions(
+    instance: &jay_ash::Instance,
+    physical_device: vk::PhysicalDevice,
+    required_device_extensions: &[*const c_char],
+) -> bool {
+    required_device_extensions.iter().all(|&extension| {
+        let extension_name = unsafe { CStr::from_ptr(extension) };
+        extensions::is_extension_available(instance, physical_device, extension_name)
+    })
+}
+
+fn supports_required_device_features(
+    physical_device_properties2: &jay_ash::khr::get_physical_device_properties2::Instance,
+    physical_device: vk::PhysicalDevice,
+) -> bool {
+    let extension_set = extensions::ExtensionSet {
+        timeline_semaphore: true,
+        ..Default::default()
+    };
+    let available_features = features::query_physical_device_features(
+        physical_device_properties2,
+        physical_device,
+        &extension_set,
+    );
+
+    available_features
+        .timeline_semaphore
+        .as_ref()
+        .is_some_and(|features| features.timeline_semaphore == vk::TRUE)
 }
 
 fn load_vulkan_entry() -> Result<jay_ash::Entry> {

--- a/crates/graphics_engine/src/plumbing/extensions.rs
+++ b/crates/graphics_engine/src/plumbing/extensions.rs
@@ -7,11 +7,11 @@ use jay_ash::vk;
 
 use crate::Result;
 
-/// Tracks which optional device extensions are enabled.
+/// Tracks which device extensions are enabled.
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct ExtensionSet {
-    /// Whether VK_EXT_descriptor_heap is enabled.
-    pub(crate) descriptor_heap: bool,
+    /// Whether VK_KHR_timeline_semaphore is enabled.
+    pub(crate) timeline_semaphore: bool,
     /// Whether VK_KHR_present_id2 is enabled.
     pub(crate) present_id2: bool,
     /// Whether VK_KHR_present_wait2 is enabled.
@@ -47,7 +47,10 @@ pub(crate) fn build_extension_list(
     validate_extensions(&available_extensions, &extensions)?;
 
     let extension_set = ExtensionSet {
-        descriptor_heap: extension_in_list(&extensions, vk::EXT_DESCRIPTOR_HEAP_EXTENSION_NAME),
+        timeline_semaphore: extension_in_list(
+            &extensions,
+            vk::KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+        ),
         present_id2: extension_in_list(&extensions, vk::KHR_PRESENT_ID_2_EXTENSION_NAME),
         present_wait2: extension_in_list(&extensions, vk::KHR_PRESENT_WAIT_2_EXTENSION_NAME),
     };

--- a/crates/graphics_engine/src/plumbing/features.rs
+++ b/crates/graphics_engine/src/plumbing/features.rs
@@ -1,4 +1,4 @@
-//! Vulkan physical device feature management for Vulkan 1.0-1.3.
+//! Vulkan physical device feature management for Vulkan 1.0 plus extensions.
 
 use common::{bail, error, info, warn};
 use jay_ash::vk;
@@ -7,18 +7,14 @@ use crate::{Result, plumbing::extensions::ExtensionSet};
 
 /// Configuration for which device features to request.
 ///
-/// Features are organized by Vulkan version (1.0-1.3) and by extension.
+/// Features are organized by Vulkan 1.0 core and by extension.
 /// Only features that are both requested AND available will be enabled.
 #[derive(Default, Clone)]
 pub(crate) struct DeviceFeatures {
     /// Vulkan 1.0 core features.
     pub(crate) features_1_0: vk::PhysicalDeviceFeatures,
-    /// Vulkan 1.1 features.
-    pub(crate) features_1_1: vk::PhysicalDeviceVulkan11Features<'static>,
-    /// Vulkan 1.2 features.
-    pub(crate) features_1_2: vk::PhysicalDeviceVulkan12Features<'static>,
-    /// Vulkan 1.3 features.
-    pub(crate) features_1_3: vk::PhysicalDeviceVulkan13Features<'static>,
+    /// VK_KHR_timeline_semaphore features.
+    pub(crate) timeline_semaphore: Option<vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR<'static>>,
     /// VK_KHR_present_id2 features.
     pub(crate) present_id2: Option<vk::PhysicalDevicePresentId2FeaturesKHR<'static>>,
     /// VK_KHR_present_wait2 features.
@@ -37,6 +33,22 @@ macro_rules! impl_feature_check {
             if $available.$name == vk::TRUE {
                 $available_list.push(stringify!($name));
             }
+            if $requested.$name == vk::TRUE {
+                $requested_list.push(stringify!($name));
+            }
+        )*
+    };
+}
+
+/// Macro to collect requested device features when the containing extension is unavailable.
+macro_rules! impl_requested_feature_check {
+    (
+        $requested:expr, $requested_list:expr;
+        {
+            $($name:ident)*
+        }
+    ) => {
+        $(
             if $requested.$name == vk::TRUE {
                 $requested_list.push(stringify!($name));
             }
@@ -89,6 +101,11 @@ macro_rules! validate_extension_features {
                         requested_ext, available_ext, requested_list, available_list;
                         { $($feature)* }
                     );
+                } else if let Some(requested_ext) = &$requested.$field {
+                    impl_requested_feature_check!(
+                        requested_ext, requested_list;
+                        { $($feature)* }
+                    );
                 }
 
                 log_and_validate_features(
@@ -105,44 +122,33 @@ macro_rules! validate_extension_features {
 
 /// Queries all available physical device features.
 pub(crate) fn query_physical_device_features(
-    instance: &jay_ash::Instance,
+    physical_device_properties2: &jay_ash::khr::get_physical_device_properties2::Instance,
     physical_device: vk::PhysicalDevice,
     extension_set: &ExtensionSet,
 ) -> DeviceFeatures {
-    let mut features_1_1 = vk::PhysicalDeviceVulkan11Features::default();
-    let mut features_1_2 = vk::PhysicalDeviceVulkan12Features::default();
-    let mut features_1_3 = vk::PhysicalDeviceVulkan13Features::default();
-
     init_extension_features! {
         extension_set;
-        descriptor_heap => vk::PhysicalDeviceDescriptorHeapFeaturesEXT,
+        timeline_semaphore => vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR,
         present_id2 => vk::PhysicalDevicePresentId2FeaturesKHR,
         present_wait2 => vk::PhysicalDevicePresentWait2FeaturesKHR,
     }
 
-    let mut features2 = vk::PhysicalDeviceFeatures2::default();
-
-    features_1_1.p_next = std::ptr::null_mut();
-    features_1_2.p_next = &mut features_1_1 as *mut _ as *mut std::ffi::c_void;
-    features_1_3.p_next = &mut features_1_2 as *mut _ as *mut std::ffi::c_void;
-    features2.p_next = &mut features_1_3 as *mut _ as *mut std::ffi::c_void;
+    let mut features2 = vk::PhysicalDeviceFeatures2KHR::default();
 
     chain_extension_features! {
         features2;
-        descriptor_heap,
+        timeline_semaphore,
         present_id2,
         present_wait2,
     }
 
     unsafe {
-        instance.get_physical_device_features2(physical_device, &mut features2);
+        physical_device_properties2.get_physical_device_features2(physical_device, &mut features2);
     }
 
     DeviceFeatures {
         features_1_0: features2.features,
-        features_1_1,
-        features_1_2,
-        features_1_3,
+        timeline_semaphore,
         present_id2,
         present_wait2,
     }
@@ -181,61 +187,6 @@ pub(crate) fn validate_features(
         }
     );
 
-    let mut requested_1_1_list: Vec<&str> = Vec::new();
-    let mut available_1_1_list: Vec<&str> = Vec::new();
-
-    impl_feature_check!(
-        requested.features_1_1, available.features_1_1, requested_1_1_list, available_1_1_list;
-        {
-            storage_buffer16_bit_access uniform_and_storage_buffer16_bit_access
-            storage_push_constant16 storage_input_output16 multiview multiview_geometry_shader
-            multiview_tessellation_shader variable_pointers_storage_buffer variable_pointers
-            protected_memory sampler_ycbcr_conversion shader_draw_parameters
-        }
-    );
-
-    let mut requested_1_2_list: Vec<&str> = Vec::new();
-    let mut available_1_2_list: Vec<&str> = Vec::new();
-
-    impl_feature_check!(
-        requested.features_1_2, available.features_1_2, requested_1_2_list, available_1_2_list;
-        {
-            sampler_mirror_clamp_to_edge draw_indirect_count storage_buffer8_bit_access
-            uniform_and_storage_buffer8_bit_access storage_push_constant8 shader_buffer_int64_atomics
-            shader_shared_int64_atomics shader_float16 shader_int8 descriptor_indexing
-            shader_input_attachment_array_dynamic_indexing shader_uniform_texel_buffer_array_dynamic_indexing
-            shader_storage_texel_buffer_array_dynamic_indexing shader_uniform_buffer_array_non_uniform_indexing
-            shader_sampled_image_array_non_uniform_indexing shader_storage_buffer_array_non_uniform_indexing
-            shader_storage_image_array_non_uniform_indexing shader_input_attachment_array_non_uniform_indexing
-            shader_uniform_texel_buffer_array_non_uniform_indexing shader_storage_texel_buffer_array_non_uniform_indexing
-            descriptor_binding_uniform_buffer_update_after_bind descriptor_binding_sampled_image_update_after_bind
-            descriptor_binding_storage_image_update_after_bind descriptor_binding_storage_buffer_update_after_bind
-            descriptor_binding_uniform_texel_buffer_update_after_bind descriptor_binding_storage_texel_buffer_update_after_bind
-            descriptor_binding_update_unused_while_pending descriptor_binding_partially_bound
-            descriptor_binding_variable_descriptor_count runtime_descriptor_array sampler_filter_minmax
-            scalar_block_layout imageless_framebuffer uniform_buffer_standard_layout
-            shader_subgroup_extended_types separate_depth_stencil_layouts host_query_reset
-            timeline_semaphore buffer_device_address buffer_device_address_capture_replay
-            buffer_device_address_multi_device vulkan_memory_model vulkan_memory_model_device_scope
-            vulkan_memory_model_availability_visibility_chains shader_output_viewport_index
-            shader_output_layer subgroup_broadcast_dynamic_id
-        }
-    );
-
-    let mut requested_1_3_list: Vec<&str> = Vec::new();
-    let mut available_1_3_list: Vec<&str> = Vec::new();
-
-    impl_feature_check!(
-        requested.features_1_3, available.features_1_3, requested_1_3_list, available_1_3_list;
-        {
-            robust_image_access inline_uniform_block descriptor_binding_inline_uniform_block_update_after_bind
-            pipeline_creation_cache_control private_data shader_demote_to_helper_invocation
-            shader_terminate_invocation subgroup_size_control compute_full_subgroups synchronization2
-            texture_compression_astc_hdr shader_zero_initialize_workgroup_memory dynamic_rendering
-            shader_integer_dot_product maintenance4
-        }
-    );
-
     log_and_validate_features(
         &requested_1_0_list,
         &available_1_0_list,
@@ -244,32 +195,9 @@ pub(crate) fn validate_features(
         true,
     );
 
-    log_and_validate_features(
-        &requested_1_1_list,
-        &available_1_1_list,
-        "Vulkan 1.1",
-        &mut missing_features,
-        true,
-    );
-
-    log_and_validate_features(
-        &requested_1_2_list,
-        &available_1_2_list,
-        "Vulkan 1.2",
-        &mut missing_features,
-        true,
-    );
-
-    log_and_validate_features(
-        &requested_1_3_list,
-        &available_1_3_list,
-        "Vulkan 1.3",
-        &mut missing_features,
-        true,
-    );
-
     validate_extension_features! {
         requested, available, missing_features;
+        timeline_semaphore: "VK_KHR_timeline_semaphore", true => { timeline_semaphore },
         present_wait2: "VK_KHR_present_wait2", false => { present_wait2 },
         present_id2: "VK_KHR_present_id2", false => { present_id2 },
     }
@@ -305,22 +233,18 @@ fn log_and_validate_features(
     }
 }
 
-/// Builds a `vk::PhysicalDeviceFeatures2` with the full pNext chain for device creation.
+/// Builds a `vk::PhysicalDeviceFeatures2KHR` with the full pNext chain for device creation.
 pub(crate) unsafe fn build_features_chain(
     requested: &mut DeviceFeatures,
-) -> vk::PhysicalDeviceFeatures2<'static> {
-    let mut features2 = vk::PhysicalDeviceFeatures2 {
+) -> vk::PhysicalDeviceFeatures2KHR<'static> {
+    let mut features2 = vk::PhysicalDeviceFeatures2KHR {
         features: requested.features_1_0,
         ..Default::default()
     };
 
-    requested.features_1_1.p_next = std::ptr::null_mut();
-    requested.features_1_2.p_next = &mut requested.features_1_1 as *mut _ as *mut std::ffi::c_void;
-    requested.features_1_3.p_next = &mut requested.features_1_2 as *mut _ as *mut std::ffi::c_void;
-    features2.p_next = &mut requested.features_1_3 as *mut _ as *mut std::ffi::c_void;
-
     chain_extension_features! {
         features2;
+        requested.timeline_semaphore,
         requested.present_id2,
         requested.present_wait2,
     }

--- a/crates/graphics_engine/src/plumbing/frame_target.rs
+++ b/crates/graphics_engine/src/plumbing/frame_target.rs
@@ -4,25 +4,29 @@ use jay_ash::vk;
 
 /// A frame acquired from the swapchain, ready to be used as a rendering target.
 ///
-/// Contains only swapchain-specific data. Synchronization primitives are
-/// owned by `FrameResources` and accessed via `current_frame_index`.
+/// Contains only swapchain-specific data. Synchronization primitives are owned
+/// by `FrameResources` and accessed via `current_frame_index`.
 #[derive(Copy, Clone)]
 pub(crate) struct FrameTarget {
     /// The swapchain image index for this frame.
     image_index: u32,
-    /// The image view for rendering to this frame.
-    image_view: vk::ImageView,
-    /// The raw swapchain image handle.
-    image: vk::Image,
+    /// The framebuffer for rendering to this frame.
+    framebuffer: vk::Framebuffer,
+    /// The render pass compatible with this frame.
+    render_pass: vk::RenderPass,
 }
 
 impl FrameTarget {
     /// Creates a new render frame with swapchain handles.
-    pub(crate) fn new(image_index: u32, image_view: vk::ImageView, image: vk::Image) -> Self {
+    pub(crate) fn new(
+        image_index: u32,
+        framebuffer: vk::Framebuffer,
+        render_pass: vk::RenderPass,
+    ) -> Self {
         Self {
             image_index,
-            image_view,
-            image,
+            framebuffer,
+            render_pass,
         }
     }
 
@@ -31,13 +35,13 @@ impl FrameTarget {
         self.image_index
     }
 
-    /// Returns the image view for rendering to this frame.
-    pub(crate) fn view(&self) -> vk::ImageView {
-        self.image_view
+    /// Returns the framebuffer for rendering to this frame.
+    pub(crate) fn framebuffer(&self) -> vk::Framebuffer {
+        self.framebuffer
     }
 
-    /// Returns the raw swapchain image handle.
-    pub(crate) fn image(&self) -> vk::Image {
-        self.image
+    /// Returns the render pass compatible with this frame.
+    pub(crate) fn render_pass(&self) -> vk::RenderPass {
+        self.render_pass
     }
 }

--- a/crates/graphics_engine/src/plumbing/graphics_pipeline.rs
+++ b/crates/graphics_engine/src/plumbing/graphics_pipeline.rs
@@ -1,4 +1,4 @@
-//! Graphics pipeline wrappers for traditional Vulkan pipelines with dynamic rendering.
+//! Graphics pipeline wrappers for traditional Vulkan render pass pipelines.
 
 use std::{ffi::CStr, rc::Rc};
 
@@ -65,10 +65,10 @@ impl Default for PipelineMultisampleState {
 
 /// Pipeline configuration for creation.
 pub(crate) struct PipelineConfig<'a> {
-    /// Color attachment formats for dynamic rendering.
-    pub color_formats: Vec<vk::Format>,
-    /// Depth attachment format for dynamic rendering.
-    pub depth_format: Option<vk::Format>,
+    /// Compatible render pass for this pipeline.
+    pub render_pass: vk::RenderPass,
+    /// Subpass index within the render pass.
+    pub subpass: u32,
     /// Blend state.
     pub blend_state: PipelineBlendState,
     /// Multisample state.
@@ -83,9 +83,7 @@ pub(crate) struct PipelineConfig<'a> {
 
 /// Graphics pipeline wrapping vertex and fragment shaders.
 ///
-/// Uses dynamic rendering with extensive dynamic state. Most state is set
-/// via command buffer commands; only blend state and multisample state are
-/// baked into the pipeline.
+/// Uses a single color attachment render pass with dynamic viewport and scissor.
 pub(crate) struct GraphicsPipeline {
     pipeline: vk::Pipeline,
     context: Rc<Context>,
@@ -94,28 +92,7 @@ pub(crate) struct GraphicsPipeline {
 impl GraphicsPipeline {
     /// Creates a graphics pipeline from SPIR-V with separate vertex and fragment entry points.
     ///
-    /// # Dynamic State
-    ///
-    /// The following states are dynamic (set via command buffer):
-    /// - Viewport with count
-    /// - Scissor with count
-    /// - Cull mode
-    /// - Front face
-    /// - Depth test enable/write enable/compare op
-    /// - Stencil test enable
-    /// - Depth bias enable
-    /// - Primitive topology
-    /// - Primitive restart enable
-    /// - Rasterizer discard enable
-    /// - Vertex input
-    ///
-    /// # Baked State
-    ///
-    /// The following states are baked into the pipeline:
-    /// - Blend enable/equation/write mask
-    /// - Polygon mode
-    /// - Sample count/mask
-    /// - Alpha to coverage enable
+    /// Viewport and scissor are dynamic; fixed-function rasterization state is baked.
     #[allow(clippy::too_many_lines)]
     pub(crate) fn new(
         context: Rc<Context>,
@@ -156,7 +133,9 @@ impl GraphicsPipeline {
             .topology(vk::PrimitiveTopology::TRIANGLE_LIST)
             .primitive_restart_enable(false);
 
-        let viewport_state = vk::PipelineViewportStateCreateInfo::default();
+        let viewport_state = vk::PipelineViewportStateCreateInfo::default()
+            .viewport_count(1)
+            .scissor_count(1);
 
         let rasterization_state = vk::PipelineRasterizationStateCreateInfo::default()
             .depth_clamp_enable(false)
@@ -194,7 +173,7 @@ impl GraphicsPipeline {
             .alpha_blend_op(config.blend_state.alpha_blend_op)
             .color_write_mask(config.blend_state.write_mask);
 
-        let color_blend_attachments = vec![color_blend_attachment; config.color_formats.len()];
+        let color_blend_attachments = [color_blend_attachment];
 
         let color_blend_state = vk::PipelineColorBlendStateCreateInfo::default()
             .logic_op_enable(false)
@@ -202,44 +181,16 @@ impl GraphicsPipeline {
             .attachments(&color_blend_attachments)
             .blend_constants([0.0, 0.0, 0.0, 0.0]);
 
-        // Activate all Vulkan 1.3 core dynamic states.
-        let dynamic_states = [
-            vk::DynamicState::LINE_WIDTH,
-            vk::DynamicState::DEPTH_BIAS,
-            vk::DynamicState::BLEND_CONSTANTS,
-            vk::DynamicState::DEPTH_BOUNDS,
-            vk::DynamicState::STENCIL_COMPARE_MASK,
-            vk::DynamicState::STENCIL_WRITE_MASK,
-            vk::DynamicState::STENCIL_REFERENCE,
-            vk::DynamicState::CULL_MODE,
-            vk::DynamicState::FRONT_FACE,
-            vk::DynamicState::PRIMITIVE_TOPOLOGY,
-            vk::DynamicState::VIEWPORT_WITH_COUNT,
-            vk::DynamicState::SCISSOR_WITH_COUNT,
-            vk::DynamicState::DEPTH_TEST_ENABLE,
-            vk::DynamicState::DEPTH_WRITE_ENABLE,
-            vk::DynamicState::DEPTH_COMPARE_OP,
-            vk::DynamicState::DEPTH_BOUNDS_TEST_ENABLE,
-            vk::DynamicState::STENCIL_TEST_ENABLE,
-            vk::DynamicState::STENCIL_OP,
-            vk::DynamicState::RASTERIZER_DISCARD_ENABLE,
-            vk::DynamicState::DEPTH_BIAS_ENABLE,
-            vk::DynamicState::PRIMITIVE_RESTART_ENABLE,
-        ];
+        let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
 
         let dynamic_state_info =
             vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
 
-        let mut pipeline_rendering_info = vk::PipelineRenderingCreateInfo::default()
-            .color_attachment_formats(&config.color_formats);
-
-        if let Some(depth_format) = config.depth_format {
-            pipeline_rendering_info = pipeline_rendering_info.depth_attachment_format(depth_format);
-        }
-
         let pipeline_create_info = vk::GraphicsPipelineCreateInfo::default()
             .stages(&stages)
             .layout(config.pipeline_layout)
+            .render_pass(config.render_pass)
+            .subpass(config.subpass)
             .vertex_input_state(vertex_input_state)
             .input_assembly_state(&input_assembly_state)
             .viewport_state(&viewport_state)
@@ -247,8 +198,7 @@ impl GraphicsPipeline {
             .multisample_state(&multisample_state)
             .depth_stencil_state(&depth_stencil_state)
             .color_blend_state(&color_blend_state)
-            .dynamic_state(&dynamic_state_info)
-            .push_next(&mut pipeline_rendering_info);
+            .dynamic_state(&dynamic_state_info);
 
         let pipeline = match unsafe {
             device.create_graphics_pipelines(

--- a/crates/graphics_engine/src/plumbing/image.rs
+++ b/crates/graphics_engine/src/plumbing/image.rs
@@ -7,7 +7,7 @@ use super::memory::{self, MemoryBlock};
 use crate::{
     Result,
     layout_transitioner::LayoutTransitioner,
-    plumbing::{Context, IntoCString},
+    plumbing::{Context, IntoCString, create_framebuffer, framebuffer_name},
 };
 
 /// A 2D color target image for rasterization rendering and subsequent sampling.
@@ -17,6 +17,7 @@ use crate::{
 pub(crate) struct ColorTargetImage {
     handle: vk::Image,
     view: vk::ImageView,
+    framebuffer: vk::Framebuffer,
     extent: vk::Extent3D,
     memory_block: Option<MemoryBlock>,
     context: Rc<Context>,
@@ -32,6 +33,7 @@ impl ColorTargetImage {
         context: Rc<Context>,
         name: &CStr,
         layout_transitioner: &mut LayoutTransitioner,
+        render_pass: vk::RenderPass,
         format: vk::Format,
         width: u32,
         height: u32,
@@ -125,6 +127,25 @@ impl ColorTargetImage {
         let view_name = format!("{}_view", name.to_string_lossy()).into_cstring();
         context.set_object_name(&view_name, view);
 
+        let framebuffer_extent = vk::Extent2D { width, height };
+        let framebuffer = match create_framebuffer(
+            &context,
+            &framebuffer_name(name),
+            render_pass,
+            view,
+            framebuffer_extent,
+        ) {
+            Ok(framebuffer) => framebuffer,
+            Err(error) => {
+                unsafe {
+                    context.device().destroy_image_view(view, None);
+                    context.device().destroy_image(handle, None);
+                    context.allocator().dealloc(context.device(), memory_block);
+                }
+                return Err(error).context("Failed to create color target framebuffer")?;
+            }
+        };
+
         let initial_image_layout = vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL;
 
         let subresource_range = vk::ImageSubresourceRange::default()
@@ -141,6 +162,7 @@ impl ColorTargetImage {
             subresource_range,
         ) {
             unsafe {
+                context.device().destroy_framebuffer(framebuffer, None);
                 context.device().destroy_image_view(view, None);
                 context.device().destroy_image(handle, None);
                 context.allocator().dealloc(context.device(), memory_block);
@@ -152,6 +174,7 @@ impl ColorTargetImage {
         Ok(Self {
             handle,
             view,
+            framebuffer,
             extent,
             memory_block: Some(memory_block),
             context,
@@ -162,6 +185,12 @@ impl ColorTargetImage {
     #[inline]
     pub(crate) fn view(&self) -> vk::ImageView {
         self.view
+    }
+
+    /// Returns the framebuffer.
+    #[inline]
+    pub(crate) fn framebuffer(&self) -> vk::Framebuffer {
+        self.framebuffer
     }
 
     /// Returns the dimensions of the image.
@@ -181,23 +210,29 @@ impl ColorTargetImage {
     /// The caller is responsible for eventually destroying the image view,
     /// image, and freeing the memory.
     ///
-    /// Returns `(image_handle, view_handle, memory_block)`.
-    pub(crate) fn into_raw_parts(mut self) -> (vk::Image, vk::ImageView, MemoryBlock) {
+    /// Returns `(image_handle, view_handle, framebuffer, memory_block)`.
+    pub(crate) fn into_raw_parts(
+        mut self,
+    ) -> (vk::Image, vk::ImageView, vk::Framebuffer, MemoryBlock) {
         let handle = self.handle;
         let view = self.view;
+        let framebuffer = self.framebuffer;
         let memory = self
             .memory_block
             .take()
             .expect("color target image memory already taken");
         // Prevent Drop from running.
         std::mem::forget(self);
-        (handle, view, memory)
+        (handle, view, framebuffer, memory)
     }
 }
 
 impl Drop for ColorTargetImage {
     fn drop(&mut self) {
         unsafe {
+            self.context
+                .device()
+                .destroy_framebuffer(self.framebuffer, None);
             self.context.device().destroy_image_view(self.view, None);
             self.context.device().destroy_image(self.handle, None);
 

--- a/crates/graphics_engine/src/plumbing/queue.rs
+++ b/crates/graphics_engine/src/plumbing/queue.rs
@@ -62,9 +62,9 @@ impl Queue {
         CommandPool::new(Rc::clone(&self.context), name, self)
     }
 
-    /// Submits command buffers to the queue using synchronization2.
-    pub(crate) fn submit(&self, submits: &[vk::SubmitInfo2], fence: vk::Fence) -> VkResult<()> {
+    /// Submits command buffers to the queue.
+    pub(crate) fn submit(&self, submits: &[vk::SubmitInfo], fence: vk::Fence) -> VkResult<()> {
         let handle = self.lock_handle();
-        unsafe { self.context.device().queue_submit2(*handle, submits, fence) }
+        unsafe { self.context.device().queue_submit(*handle, submits, fence) }
     }
 }

--- a/crates/graphics_engine/src/plumbing/render_pass.rs
+++ b/crates/graphics_engine/src/plumbing/render_pass.rs
@@ -1,0 +1,158 @@
+//! Render pass and framebuffer helpers.
+
+use std::{ffi::CStr, rc::Rc};
+
+use common::Context as _;
+use jay_ash::vk;
+
+use super::{Context, IntoCString};
+
+/// A single-color-attachment render pass.
+pub(crate) struct RenderPass {
+    handle: vk::RenderPass,
+    format: vk::Format,
+    context: Rc<Context>,
+}
+
+impl RenderPass {
+    /// Creates a render pass for the offscreen color target.
+    pub(crate) fn new_color_target(
+        context: Rc<Context>,
+        name: &CStr,
+        format: vk::Format,
+    ) -> crate::Result<Self> {
+        Self::new(
+            context,
+            name,
+            format,
+            vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            &[],
+        )
+    }
+
+    /// Creates a render pass for swapchain images.
+    pub(crate) fn new_swapchain(
+        context: Rc<Context>,
+        name: &CStr,
+        format: vk::Format,
+    ) -> crate::Result<Self> {
+        let dependencies = [vk::SubpassDependency::default()
+            .src_subpass(vk::SUBPASS_EXTERNAL)
+            .dst_subpass(0)
+            .src_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)
+            .dst_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)
+            .src_access_mask(vk::AccessFlags::empty())
+            .dst_access_mask(vk::AccessFlags::COLOR_ATTACHMENT_WRITE)];
+
+        Self::new(
+            context,
+            name,
+            format,
+            vk::ImageLayout::UNDEFINED,
+            vk::ImageLayout::PRESENT_SRC_KHR,
+            &dependencies,
+        )
+    }
+
+    fn new(
+        context: Rc<Context>,
+        name: &CStr,
+        format: vk::Format,
+        initial_layout: vk::ImageLayout,
+        final_layout: vk::ImageLayout,
+        dependencies: &[vk::SubpassDependency],
+    ) -> crate::Result<Self> {
+        let attachment = vk::AttachmentDescription::default()
+            .format(format)
+            .samples(vk::SampleCountFlags::TYPE_1)
+            .load_op(vk::AttachmentLoadOp::CLEAR)
+            .store_op(vk::AttachmentStoreOp::STORE)
+            .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
+            .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
+            .initial_layout(initial_layout)
+            .final_layout(final_layout);
+        let attachments = [attachment];
+
+        let color_attachment = vk::AttachmentReference::default()
+            .attachment(0)
+            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL);
+        let color_attachments = [color_attachment];
+
+        let subpass = vk::SubpassDescription::default()
+            .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
+            .color_attachments(&color_attachments);
+        let subpasses = [subpass];
+
+        let create_info = vk::RenderPassCreateInfo::default()
+            .attachments(&attachments)
+            .subpasses(&subpasses)
+            .dependencies(dependencies);
+
+        let handle = unsafe {
+            context
+                .device()
+                .create_render_pass(&create_info, None)
+                .context("Failed to create render pass")?
+        };
+
+        context.set_object_name(name, handle);
+
+        Ok(Self {
+            handle,
+            format,
+            context,
+        })
+    }
+
+    /// Returns the raw render pass handle.
+    pub(crate) fn handle(&self) -> vk::RenderPass {
+        self.handle
+    }
+
+    /// Returns the color attachment format.
+    pub(crate) fn format(&self) -> vk::Format {
+        self.format
+    }
+}
+
+impl Drop for RenderPass {
+    fn drop(&mut self) {
+        unsafe {
+            self.context.device().destroy_render_pass(self.handle, None);
+        }
+    }
+}
+
+/// Creates a single-attachment framebuffer.
+pub(crate) fn create_framebuffer(
+    context: &Rc<Context>,
+    name: &CStr,
+    render_pass: vk::RenderPass,
+    view: vk::ImageView,
+    extent: vk::Extent2D,
+) -> crate::Result<vk::Framebuffer> {
+    let attachments = [view];
+    let create_info = vk::FramebufferCreateInfo::default()
+        .render_pass(render_pass)
+        .attachments(&attachments)
+        .width(extent.width)
+        .height(extent.height)
+        .layers(1);
+
+    let framebuffer = unsafe {
+        context
+            .device()
+            .create_framebuffer(&create_info, None)
+            .context("Failed to create framebuffer")?
+    };
+
+    context.set_object_name(name, framebuffer);
+
+    Ok(framebuffer)
+}
+
+/// Creates a framebuffer name derived from an image name.
+pub(crate) fn framebuffer_name(name: &CStr) -> std::ffi::CString {
+    format!("{}_framebuffer", name.to_string_lossy()).into_cstring()
+}

--- a/crates/graphics_engine/src/plumbing/surface.rs
+++ b/crates/graphics_engine/src/plumbing/surface.rs
@@ -8,7 +8,7 @@ use jay_ash::vk;
 use super::context::Context;
 use crate::{
     Result,
-    plumbing::{FrameResources, Queue},
+    plumbing::{FrameResources, Queue, RenderPass, create_framebuffer},
 };
 
 /// Result of acquiring a swapchain image.
@@ -32,6 +32,8 @@ pub(crate) struct Surface {
     swapchain_loader: jay_ash::khr::swapchain::Device,
     images: Vec<vk::Image>,
     image_views: Vec<vk::ImageView>,
+    framebuffers: Vec<vk::Framebuffer>,
+    render_pass: Option<RenderPass>,
 
     format: vk::SurfaceFormatKHR,
     is_srgb: bool,
@@ -81,6 +83,8 @@ impl Surface {
             swapchain_loader,
             images: Vec::new(),
             image_views: Vec::new(),
+            framebuffers: Vec::new(),
+            render_pass: None,
             format: vk::SurfaceFormatKHR::default(),
             is_srgb: false,
             extent: vk::Extent2D::default(),
@@ -198,18 +202,23 @@ impl Surface {
 
         self.context.set_object_name(c"swapchain", swapchain);
 
+        let images = unsafe { self.swapchain_loader.get_swapchain_images(swapchain) }
+            .context("Failed to get swapchain images")?;
+
         if let Some(old_swapchain) = self.swapchain.take() {
             self.destroy_swapchain_resources(old_swapchain);
         }
 
-        let images = unsafe { self.swapchain_loader.get_swapchain_images(swapchain) }
-            .context("Failed to get swapchain images")?;
+        self.ensure_render_pass(format.format)
+            .context("Failed to create swapchain render pass")?;
 
         let image_views = Self::create_image_views(&self.context, &images, format.format)?;
+        let framebuffers = self.create_framebuffers(&image_views, extent)?;
 
         self.swapchain = Some(swapchain);
         self.images = images;
         self.image_views = image_views;
+        self.framebuffers = framebuffers;
         self.format = format;
         self.is_srgb = is_srgb;
         self.extent = extent;
@@ -504,8 +513,46 @@ impl Surface {
             .collect()
     }
 
+    fn ensure_render_pass(&mut self, format: vk::Format) -> Result<()> {
+        let recreate = self
+            .render_pass
+            .as_ref()
+            .is_none_or(|render_pass| render_pass.format() != format);
+
+        if recreate {
+            self.render_pass = Some(RenderPass::new_swapchain(
+                Rc::clone(&self.context),
+                c"swapchain_render_pass",
+                format,
+            )?);
+        }
+
+        Ok(())
+    }
+
+    fn create_framebuffers(
+        &self,
+        image_views: &[vk::ImageView],
+        extent: vk::Extent2D,
+    ) -> Result<Vec<vk::Framebuffer>> {
+        let render_pass = self.render_pass();
+
+        image_views
+            .iter()
+            .enumerate()
+            .map(|(i, &view)| {
+                let name = std::ffi::CString::new(format!("swapchain_framebuffer_{i}")).unwrap();
+                create_framebuffer(&self.context, &name, render_pass, view, extent)
+            })
+            .collect()
+    }
+
     /// Destroys swapchain resources (image views and swapchain).
     fn destroy_swapchain_resources(&mut self, swapchain: vk::SwapchainKHR) {
+        for framebuffer in self.framebuffers.drain(..) {
+            unsafe { self.context.device().destroy_framebuffer(framebuffer, None) };
+        }
+
         for view in self.image_views.drain(..) {
             unsafe { self.context.device().destroy_image_view(view, None) };
         }
@@ -533,10 +580,19 @@ impl Surface {
         &self.images
     }
 
-    /// Returns a reference to the swapchain image views.
+    /// Returns a reference to the swapchain framebuffers.
     #[inline]
-    pub(crate) fn image_views(&self) -> &[vk::ImageView] {
-        &self.image_views
+    pub(crate) fn framebuffers(&self) -> &[vk::Framebuffer] {
+        &self.framebuffers
+    }
+
+    /// Returns the swapchain render pass.
+    #[inline]
+    pub(crate) fn render_pass(&self) -> vk::RenderPass {
+        self.render_pass
+            .as_ref()
+            .expect("swapchain render pass not initialized")
+            .handle()
     }
 }
 

--- a/crates/graphics_engine/src/plumbing/sync.rs
+++ b/crates/graphics_engine/src/plumbing/sync.rs
@@ -37,7 +37,7 @@ impl Semaphore<Timeline> {
         name: &CStr,
         initial_value: u64,
     ) -> Result<Self, vk::Result> {
-        let mut type_create_info = vk::SemaphoreTypeCreateInfo::default()
+        let mut type_create_info = vk::SemaphoreTypeCreateInfoKHR::default()
             .semaphore_type(vk::SemaphoreType::TIMELINE)
             .initial_value(initial_value);
 
@@ -64,7 +64,7 @@ impl<T> Semaphore<T> {
     pub(crate) fn get_value(&self) -> Result<u64, vk::Result> {
         unsafe {
             self.context
-                .device()
+                .timeline_semaphore()
                 .get_semaphore_counter_value(self.handle)
         }
     }

--- a/crates/graphics_engine/src/resources.rs
+++ b/crates/graphics_engine/src/resources.rs
@@ -19,6 +19,7 @@ impl Resources {
     pub(crate) fn new(
         device: &Device,
         layout_transitioner: &mut LayoutTransitioner,
+        color_render_pass: vk::RenderPass,
         width: u32,
         height: u32,
     ) -> crate::Result<Self> {
@@ -28,6 +29,7 @@ impl Resources {
             Rc::clone(&context),
             c"color_target",
             layout_transitioner,
+            color_render_pass,
             vk::Format::R8G8B8A8_SRGB,
             width,
             height,
@@ -56,18 +58,20 @@ impl Resources {
         &mut self,
         device: &Device,
         layout_transitioner: &mut LayoutTransitioner,
+        color_render_pass: vk::RenderPass,
         width: u32,
         height: u32,
     ) {
         let context = Rc::clone(device.context());
 
         // Defer old color_target for cleanup.
-        let (old_handle, old_view, old_memory) = std::mem::replace(
+        let (old_handle, old_view, old_framebuffer, old_memory) = std::mem::replace(
             &mut self.color_target,
             ColorTargetImage::new(
                 Rc::clone(&context),
                 c"color_target",
                 layout_transitioner,
+                color_render_pass,
                 vk::Format::R8G8B8A8_SRGB,
                 width,
                 height,
@@ -79,6 +83,7 @@ impl Resources {
         device.defer_resource(DeferredResource::Image {
             handle: old_handle,
             view: Some(old_view),
+            framebuffer: Some(old_framebuffer),
             memory: old_memory,
         });
 


### PR DESCRIPTION
Even if it hurts maintainability, we drop to Vulkan 1.0 for best device support.

This also includes the scalar block layout, which is not needed anymore, since we moved the composition to the CPU.

VK_KHR_timeline_semaphore is required though, but even the v3dv driver under mesa support it.