### PR TITLE
feat: synchronous write-through for all disk image formats

### DIFF
--- a/crates/device/src/disk.rs
+++ b/crates/device/src/disk.rs
@@ -9,7 +9,15 @@ mod hdi;
 mod nhd;
 mod thd;
 
-use std::{error::Error, fmt, path::Path};
+use std::{
+    error::Error,
+    fmt,
+    path::{Path, PathBuf},
+};
+
+use common::error;
+
+use crate::disk_backend::DiskBackend;
 
 /// HDI header size (fixed at 32 bytes).
 const HDI_HEADER_SIZE: usize = 32;
@@ -119,22 +127,20 @@ pub struct HddImage {
     pub format: HddFormat,
     /// Raw sector data (geometry.total_sectors() * geometry.sector_size bytes).
     data: Vec<u8>,
-    /// Header size from the original image (needed for HDI/NHD serialization).
-    original_header_size: u32,
+    /// Verbatim copy of the source-image header. `to_bytes` emits
+    /// `header_bytes ++ data`.
+    pub(crate) header_bytes: Vec<u8>,
 }
 
 impl HddImage {
     /// Creates an HDD image from raw components (for testing and programmatic creation).
     pub fn from_raw(geometry: HddGeometry, format: HddFormat, data: Vec<u8>) -> Self {
+        let header_bytes = synthesize_default_header(format, geometry);
         Self {
             geometry,
             format,
             data,
-            original_header_size: match format {
-                HddFormat::Nhd => NHD_HEADER_SIZE as u32,
-                HddFormat::Hdi => HDI_HEADER_SIZE as u32,
-                HddFormat::Thd => THD_HEADER_SIZE as u32,
-            },
+            header_bytes,
         }
     }
 
@@ -201,12 +207,47 @@ impl HddImage {
         true
     }
 
-    /// Serializes the image back to its original format.
+    /// Serializes the image to bytes by emitting the preserved header
+    /// followed by the in-memory sector data.
     pub fn to_bytes(&self) -> Vec<u8> {
-        match self.format {
-            HddFormat::Nhd => self.serialize_nhd(),
-            HddFormat::Hdi => self.serialize_hdi(),
-            HddFormat::Thd => self.serialize_thd(),
+        let mut out = Vec::with_capacity(self.header_bytes.len() + self.data.len());
+        out.extend_from_slice(&self.header_bytes);
+        out.extend_from_slice(&self.data);
+        out
+    }
+}
+
+/// Synthesizes a default header for the given format and geometry, matching
+/// what the format-specific parsers would have produced for a freshly-built
+/// image.
+fn synthesize_default_header(format: HddFormat, geometry: HddGeometry) -> Vec<u8> {
+    match format {
+        HddFormat::Nhd => {
+            let mut header = vec![0u8; NHD_HEADER_SIZE];
+            header[..15].copy_from_slice(NHD_SIGNATURE);
+            header[0x110..0x114].copy_from_slice(&(NHD_HEADER_SIZE as u32).to_le_bytes());
+            header[0x114..0x118].copy_from_slice(&(geometry.cylinders as u32).to_le_bytes());
+            header[0x118..0x11A].copy_from_slice(&(geometry.heads as u16).to_le_bytes());
+            header[0x11A..0x11C]
+                .copy_from_slice(&(geometry.sectors_per_track as u16).to_le_bytes());
+            header[0x11C..0x11E].copy_from_slice(&geometry.sector_size.to_le_bytes());
+            header
+        }
+        HddFormat::Hdi => {
+            let mut header = vec![0u8; HDI_HEADER_SIZE];
+            let total_sectors = geometry.total_sectors();
+            header[8..12].copy_from_slice(&(HDI_HEADER_SIZE as u32).to_le_bytes());
+            header[12..16].copy_from_slice(&total_sectors.to_le_bytes());
+            header[16..20].copy_from_slice(&(geometry.sector_size as u32).to_le_bytes());
+            header[20..24].copy_from_slice(&(geometry.sectors_per_track as u32).to_le_bytes());
+            header[24..28].copy_from_slice(&(geometry.heads as u32).to_le_bytes());
+            header[28..32].copy_from_slice(&(geometry.cylinders as u32).to_le_bytes());
+            header
+        }
+        HddFormat::Thd => {
+            let mut header = vec![0u8; THD_HEADER_SIZE];
+            header[0..2].copy_from_slice(&geometry.cylinders.to_le_bytes());
+            header
         }
     }
 }
@@ -335,6 +376,130 @@ impl fmt::Display for HddError {
 }
 
 impl Error for HddError {}
+
+/// A hard disk image bound to its source file for synchronous write-through.
+#[derive(Debug)]
+pub struct MountedHdd {
+    image: HddImage,
+    backend: Option<DiskBackend>,
+    dirty: bool,
+}
+
+impl MountedHdd {
+    /// Constructs a new mount. If `path` is `None` or the file cannot be
+    /// opened for write, writes only land in memory.
+    pub fn new(image: HddImage, path: Option<PathBuf>) -> Self {
+        let backend = path.and_then(|p| match DiskBackend::open(p.clone()) {
+            Ok(b) => Some(b),
+            Err(err) => {
+                error!(
+                    "Failed to open HDD {} for write-through: {err}",
+                    p.display()
+                );
+                None
+            }
+        });
+        Self {
+            image,
+            backend,
+            dirty: false,
+        }
+    }
+
+    /// Returns a read-only reference to the parsed image.
+    pub fn image(&self) -> &HddImage {
+        &self.image
+    }
+
+    /// Returns the disk geometry.
+    pub fn geometry(&self) -> HddGeometry {
+        self.image.geometry
+    }
+
+    /// Returns whether the image has unwritten changes.
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Reads sector data at the given LBA.
+    pub fn read_sector(&self, lba: u32) -> Option<&[u8]> {
+        self.image.read_sector(lba)
+    }
+
+    /// Writes sector data at the given LBA.
+    pub fn write_sector(&mut self, lba: u32, data: &[u8]) -> bool {
+        if !self.image.write_sector(lba, data) {
+            return false;
+        }
+        if let Some(backend) = self.backend.as_mut() {
+            let offset = self.image.header_bytes.len() as u64
+                + lba as u64 * self.image.geometry.sector_size as u64;
+            if let Err(err) = backend.write_at(offset, data) {
+                self.dirty = true;
+                error!("HDD write-through failed at LBA {lba}: {err}");
+            }
+        } else {
+            self.dirty = true;
+        }
+        true
+    }
+
+    /// Formats the track containing `start_lba` by filling its sectors
+    /// with 0xE5.
+    pub fn format_track(&mut self, start_lba: u32) -> bool {
+        if !self.image.format_track(start_lba) {
+            return false;
+        }
+        if let Some(backend) = self.backend.as_mut() {
+            let sector_size = self.image.geometry.sector_size as usize;
+            let spt = self.image.geometry.sectors_per_track as usize;
+            let offset =
+                self.image.header_bytes.len() as u64 + start_lba as u64 * sector_size as u64;
+            let buf = vec![0xE5u8; spt * sector_size];
+            if let Err(err) = backend.write_at(offset, &buf) {
+                self.dirty = true;
+                error!("HDD format_track write-through failed: {err}");
+            }
+        } else {
+            self.dirty = true;
+        }
+        true
+    }
+
+    /// Re-emits the entire image if dirty. The dirty flag remains set
+    /// only when an earlier per-sector write-through reported an error,
+    /// so under normal use this is a no-op.
+    pub fn flush_if_dirty(&mut self) {
+        if !self.dirty {
+            return;
+        }
+        let Some(backend) = self.backend.as_mut() else {
+            return;
+        };
+        let bytes = self.image.to_bytes();
+        if let Err(err) = backend.replace_atomic(&bytes) {
+            error!("HDD eject-time flush failed: {err}");
+            return;
+        }
+        self.dirty = false;
+    }
+
+    /// Flushes dirty fallback data and any buffered successful writes.
+    pub fn flush(&mut self) {
+        self.flush_if_dirty();
+        if let Some(backend) = self.backend.as_mut()
+            && let Err(err) = backend.flush()
+        {
+            self.dirty = true;
+            error!("HDD flush failed: {err}");
+        }
+    }
+
+    /// Flushes pending writes and releases the backend.
+    pub fn eject(mut self) {
+        self.flush();
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -711,10 +876,140 @@ mod tests {
 
         let hdd = HddImage::from_hdi(&image).unwrap();
         assert_eq!(hdd.geometry.cylinders, 153);
-        assert_eq!(hdd.original_header_size, 4096);
+        assert_eq!(hdd.header_bytes.len(), 4096);
 
-        // Roundtrip preserves the larger header.
+        // Roundtrip preserves the larger header byte-for-byte.
         let serialized = hdd.to_bytes();
         assert_eq!(serialized.len(), image.len());
+        assert_eq!(&serialized[..4096], &image[..4096]);
+    }
+
+    fn tempfile_with(bytes: &[u8], suffix: &str) -> PathBuf {
+        let dir = std::env::temp_dir();
+        let unique = format!(
+            "neetan_hdd_test_{}_{}{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            suffix
+        );
+        let path = dir.join(unique);
+        std::fs::write(&path, bytes).expect("write temp file");
+        path
+    }
+
+    #[test]
+    fn mounted_hdd_nhd_sector_write_through() {
+        let image_bytes = build_nhd_image(50, 4, 17, 512);
+        let path = tempfile_with(&image_bytes, ".nhd");
+
+        let image = HddImage::from_nhd(&image_bytes).unwrap();
+        let mut mounted = MountedHdd::new(image, Some(path.clone()));
+
+        let pattern = vec![0xAAu8; 512];
+        assert!(mounted.write_sector(123, &pattern));
+
+        drop(mounted);
+        let raw = std::fs::read(&path).unwrap();
+        let offset = NHD_HEADER_SIZE + 123 * 512;
+        assert_eq!(&raw[offset..offset + 512], &pattern[..]);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn mounted_hdd_hdi_format_track_writes_e5() {
+        let image_bytes = build_hdi_image(20, 4, 17, 256);
+        let path = tempfile_with(&image_bytes, ".hdi");
+
+        let image = HddImage::from_hdi(&image_bytes).unwrap();
+        let mut mounted = MountedHdd::new(image, Some(path.clone()));
+
+        // Format the track containing LBA 17 (cylinder 0, head 1).
+        assert!(mounted.format_track(17));
+
+        drop(mounted);
+        let raw = std::fs::read(&path).unwrap();
+        let track_start = HDI_HEADER_SIZE + 17 * 256;
+        let track_end = track_start + 17 * 256;
+        assert!(
+            raw[track_start..track_end].iter().all(|&b| b == 0xE5),
+            "track region should be filled with 0xE5"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn mounted_hdd_thd_sector_write_through() {
+        let image_bytes = build_thd_image(50);
+        let path = tempfile_with(&image_bytes, ".thd");
+
+        let image = HddImage::from_thd(&image_bytes).unwrap();
+        let mut mounted = MountedHdd::new(image, Some(path.clone()));
+
+        let pattern = vec![0x77u8; THD_SECTOR_SIZE as usize];
+        assert!(mounted.write_sector(42, &pattern));
+
+        drop(mounted);
+        let raw = std::fs::read(&path).unwrap();
+        let offset = THD_HEADER_SIZE + 42 * THD_SECTOR_SIZE as usize;
+        assert_eq!(
+            &raw[offset..offset + THD_SECTOR_SIZE as usize],
+            &pattern[..]
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn mounted_hdd_write_sector_preserves_existing_dirty_bit() {
+        let image_bytes = build_nhd_image(50, 4, 17, 512);
+        let path = tempfile_with(&image_bytes, ".nhd");
+
+        let image = HddImage::from_nhd(&image_bytes).unwrap();
+        let mut mounted = MountedHdd::new(image, Some(path.clone()));
+
+        // Simulate a prior write-through error: in-memory ahead of disk.
+        mounted.image.write_sector(7, &[0x11u8; 512]);
+        mounted.dirty = true;
+
+        // A successful unrelated write must NOT clear dirty, otherwise the
+        // earlier in-memory-only mutation is silently lost on flush.
+        let pattern = vec![0xAAu8; 512];
+        assert!(mounted.write_sector(123, &pattern));
+        assert!(
+            mounted.is_dirty(),
+            "dirty must remain set after later successful write"
+        );
+
+        drop(mounted);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn mounted_hdd_format_track_preserves_existing_dirty_bit() {
+        let image_bytes = build_nhd_image(50, 4, 17, 512);
+        let path = tempfile_with(&image_bytes, ".nhd");
+
+        let image = HddImage::from_nhd(&image_bytes).unwrap();
+        let mut mounted = MountedHdd::new(image, Some(path.clone()));
+
+        // Simulate a prior write-through error: in-memory ahead of disk.
+        mounted.image.write_sector(7, &[0x11u8; 512]);
+        mounted.dirty = true;
+
+        // A successful format_track must NOT clear dirty, otherwise the
+        // earlier in-memory-only mutation is silently lost on flush.
+        assert!(mounted.format_track(34));
+        assert!(
+            mounted.is_dirty(),
+            "dirty must remain set after later successful format_track"
+        );
+
+        drop(mounted);
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/crates/device/src/disk/hdi.rs
+++ b/crates/device/src/disk/hdi.rs
@@ -39,24 +39,7 @@ impl HddImage {
             geometry,
             format: HddFormat::Hdi,
             data: data[data_start..data_start + expected_data_size].to_vec(),
-            original_header_size: header_size,
+            header_bytes: data[..data_start].to_vec(),
         })
-    }
-
-    pub(super) fn serialize_hdi(&self) -> Vec<u8> {
-        let header_size = self.original_header_size.max(HDI_HEADER_SIZE as u32);
-        let mut out = vec![0u8; header_size as usize];
-
-        // hddtype at offset 4 (leave as 0)
-        out[8..12].copy_from_slice(&header_size.to_le_bytes());
-        let hdd_size = self.geometry.total_sectors();
-        out[12..16].copy_from_slice(&hdd_size.to_le_bytes());
-        out[16..20].copy_from_slice(&(self.geometry.sector_size as u32).to_le_bytes());
-        out[20..24].copy_from_slice(&(self.geometry.sectors_per_track as u32).to_le_bytes());
-        out[24..28].copy_from_slice(&(self.geometry.heads as u32).to_le_bytes());
-        out[28..32].copy_from_slice(&(self.geometry.cylinders as u32).to_le_bytes());
-
-        out.extend_from_slice(&self.data);
-        out
     }
 }

--- a/crates/device/src/disk/nhd.rs
+++ b/crates/device/src/disk/nhd.rs
@@ -52,22 +52,7 @@ impl HddImage {
             geometry,
             format: HddFormat::Nhd,
             data: data[data_start..data_start + expected_data_size].to_vec(),
-            original_header_size: header_size,
+            header_bytes: data[..data_start].to_vec(),
         })
-    }
-
-    pub(super) fn serialize_nhd(&self) -> Vec<u8> {
-        let header_size = self.original_header_size.max(NHD_HEADER_SIZE as u32);
-        let mut out = vec![0u8; header_size as usize];
-
-        out[..15].copy_from_slice(NHD_SIGNATURE);
-        out[0x110..0x114].copy_from_slice(&header_size.to_le_bytes());
-        out[0x114..0x118].copy_from_slice(&(self.geometry.cylinders as u32).to_le_bytes());
-        out[0x118..0x11A].copy_from_slice(&(self.geometry.heads as u16).to_le_bytes());
-        out[0x11A..0x11C].copy_from_slice(&(self.geometry.sectors_per_track as u16).to_le_bytes());
-        out[0x11C..0x11E].copy_from_slice(&self.geometry.sector_size.to_le_bytes());
-
-        out.extend_from_slice(&self.data);
-        out
     }
 }

--- a/crates/device/src/disk/thd.rs
+++ b/crates/device/src/disk/thd.rs
@@ -42,14 +42,7 @@ impl HddImage {
             geometry,
             format: HddFormat::Thd,
             data: data[data_start..data_start + expected_data_size].to_vec(),
-            original_header_size: THD_HEADER_SIZE as u32,
+            header_bytes: data[..THD_HEADER_SIZE].to_vec(),
         })
-    }
-
-    pub(super) fn serialize_thd(&self) -> Vec<u8> {
-        let mut out = vec![0u8; THD_HEADER_SIZE];
-        out[0..2].copy_from_slice(&self.geometry.cylinders.to_le_bytes());
-        out.extend_from_slice(&self.data);
-        out
     }
 }

--- a/crates/device/src/disk_backend.rs
+++ b/crates/device/src/disk_backend.rs
@@ -1,0 +1,232 @@
+//! File-side backing for inserted floppy and HDD images.
+//!
+//! Holds an open `BufWriter<File>` for synchronous write-through and
+//! supports atomic full-image replacement.
+
+use std::{
+    ffi::{OsStr, OsString},
+    fs::{File, OpenOptions},
+    io::{BufWriter, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+};
+
+/// Path-paired writer that supports random-access seek+write and atomic
+/// whole-file replacement.
+pub struct DiskBackend {
+    path: PathBuf,
+    writer: Option<BufWriter<File>>,
+}
+
+impl DiskBackend {
+    /// Opens `path` for read+write and wraps it in a `BufWriter`.
+    pub fn open(path: PathBuf) -> std::io::Result<Self> {
+        let file = OpenOptions::new().read(true).write(true).open(&path)?;
+        Ok(Self {
+            path,
+            writer: Some(BufWriter::new(file)),
+        })
+    }
+
+    /// Returns the path the backend is bound to.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Seeks to `offset` and writes `data`.
+    pub fn write_at(&mut self, offset: u64, data: &[u8]) -> std::io::Result<()> {
+        let writer = self
+            .writer
+            .as_mut()
+            .ok_or_else(|| std::io::Error::other("disk backend closed"))?;
+        writer.seek(SeekFrom::Start(offset))?;
+        writer.write_all(data)
+    }
+
+    /// Replaces the entire file contents atomically (temp + rename) and
+    /// reopens the `BufWriter` against the new file.
+    pub fn replace_atomic(&mut self, bytes: &[u8]) -> std::io::Result<()> {
+        if let Some(mut w) = self.writer.take()
+            && let Err(err) = w.flush()
+        {
+            self.restore_writer();
+            return Err(err);
+        }
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+
+        for attempt in 0..16u32 {
+            let tmp_path = Self::replacement_tmp_path(&self.path, unique, attempt);
+            let mut tmp_file = match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&tmp_path)
+            {
+                Ok(file) => file,
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                    continue;
+                }
+                Err(err) => {
+                    self.restore_writer();
+                    return Err(err);
+                }
+            };
+
+            if let Err(err) = tmp_file.write_all(bytes) {
+                let _ = std::fs::remove_file(&tmp_path);
+                self.restore_writer();
+                return Err(err);
+            }
+            drop(tmp_file);
+
+            if let Err(err) = std::fs::rename(&tmp_path, &self.path) {
+                let _ = std::fs::remove_file(&tmp_path);
+                self.restore_writer();
+                return Err(err);
+            }
+
+            let file = OpenOptions::new().read(true).write(true).open(&self.path)?;
+            self.writer = Some(BufWriter::new(file));
+            return Ok(());
+        }
+
+        self.restore_writer();
+        Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            "could not create unique disk image replacement temp file",
+        ))
+    }
+
+    /// Flushes any buffered writes to the OS.
+    pub fn flush(&mut self) -> std::io::Result<()> {
+        if let Some(w) = self.writer.as_mut() {
+            w.flush()?;
+        }
+        Ok(())
+    }
+
+    fn replacement_tmp_path(path: &Path, unique: u128, attempt: u32) -> PathBuf {
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        let file_name = path.file_name().unwrap_or_else(|| OsStr::new("disk-image"));
+        let mut tmp_name = OsString::from(".");
+        tmp_name.push(file_name);
+        tmp_name.push(format!(
+            ".{}.{}.{}.tmp",
+            std::process::id(),
+            unique,
+            attempt
+        ));
+        parent.join(tmp_name)
+    }
+
+    fn restore_writer(&mut self) {
+        if self.writer.is_none()
+            && let Ok(file) = OpenOptions::new().read(true).write(true).open(&self.path)
+        {
+            self.writer = Some(BufWriter::new(file));
+        }
+    }
+}
+
+impl Drop for DiskBackend {
+    fn drop(&mut self) {
+        if let Some(mut w) = self.writer.take() {
+            let _ = w.flush();
+        }
+    }
+}
+
+impl std::fmt::Debug for DiskBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiskBackend")
+            .field("path", &self.path)
+            .field("open", &self.writer.is_some())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempfile_with(bytes: &[u8]) -> PathBuf {
+        let dir = std::env::temp_dir();
+        let unique = format!(
+            "neetan_disk_backend_test_{}_{}.tmp",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let path = dir.join(unique);
+        std::fs::write(&path, bytes).expect("write temp file");
+        path
+    }
+
+    #[test]
+    fn write_at_persists() {
+        let path = tempfile_with(&[0u8; 1024]);
+        let mut backend = DiskBackend::open(path.clone()).expect("open");
+        backend.write_at(256, &[0xAB, 0xCD, 0xEF]).expect("write");
+        backend.flush().expect("flush");
+        let raw = std::fs::read(&path).expect("read");
+        assert_eq!(&raw[256..259], &[0xAB, 0xCD, 0xEF]);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn replace_atomic_swaps_content() {
+        let path = tempfile_with(b"first content");
+        let mut backend = DiskBackend::open(path.clone()).expect("open");
+        backend
+            .replace_atomic(b"second content goes here")
+            .expect("replace");
+        let raw = std::fs::read(&path).expect("read");
+        assert_eq!(raw, b"second content goes here");
+        // Subsequent write_at lands on the new file.
+        backend.write_at(0, b"THIRD").expect("write");
+        backend.flush().expect("flush");
+        let raw = std::fs::read(&path).expect("read");
+        assert_eq!(&raw[..5], b"THIRD");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn replace_atomic_does_not_touch_existing_tmp_sibling() {
+        let tmp_seed = tempfile_with(b"seed");
+        let path = tmp_seed.with_extension("img");
+        std::fs::rename(&tmp_seed, &path).expect("rename seed to image path");
+
+        let tmp_sibling = path.with_extension("tmp");
+        std::fs::write(&tmp_sibling, b"keep me").expect("write sibling tmp");
+
+        let mut backend = DiskBackend::open(path.clone()).expect("open");
+        backend.replace_atomic(b"second content").expect("replace");
+        backend.flush().expect("flush");
+
+        let raw = std::fs::read(&path).expect("read replaced file");
+        assert_eq!(raw, b"second content");
+        let sibling = std::fs::read(&tmp_sibling).expect("read sibling tmp");
+        assert_eq!(sibling, b"keep me");
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(&tmp_sibling).ok();
+    }
+
+    #[test]
+    fn write_at_returns_error_on_seek_past_end_then_succeeds() {
+        // BufWriter+File: writing past current end extends the file.
+        let path = tempfile_with(&[0u8; 16]);
+        let mut backend = DiskBackend::open(path.clone()).expect("open");
+        backend.write_at(100, b"x").expect("write past end");
+        backend.flush().expect("flush");
+        let raw = std::fs::read(&path).expect("read");
+        assert!(raw.len() >= 101);
+        assert_eq!(raw[100], b'x');
+        std::fs::remove_file(&path).ok();
+    }
+}

--- a/crates/device/src/disk_hle.rs
+++ b/crates/device/src/disk_hle.rs
@@ -3,7 +3,7 @@
 //! Both SASI and IDE use the same INT 1Bh BIOS interface for disk I/O.
 //! This module provides the common HLE functions used by both controllers.
 
-use crate::disk::{HddGeometry, HddImage};
+use crate::disk::{HddGeometry, MountedHdd};
 
 /// Computes the sector position from register values.
 ///
@@ -48,7 +48,7 @@ pub fn execute_read(
     xfer_size: u32,
     sector_pos: u32,
     buf_addr: u32,
-    drives: &[Option<HddImage>; 2],
+    drives: &[Option<MountedHdd>; 2],
     mut write_byte: impl FnMut(u32, u8),
 ) -> u8 {
     let Some(drive) = &drives[drive_idx] else {
@@ -58,7 +58,7 @@ pub fn execute_read(
     let mut remaining = xfer_size;
     let mut pos = sector_pos;
     let mut addr = buf_addr;
-    let sector_size = drive.geometry.sector_size as u32;
+    let sector_size = drive.geometry().sector_size as u32;
 
     while remaining > 0 {
         let read_size = remaining.min(sector_size);
@@ -89,7 +89,7 @@ pub fn execute_write<const SECTOR_SIZE: usize>(
     xfer_size: u32,
     sector_pos: u32,
     buf_addr: u32,
-    drives: &mut [Option<HddImage>; 2],
+    drives: &mut [Option<MountedHdd>; 2],
     read_byte: impl Fn(u32) -> u8,
 ) -> u8 {
     let Some(drive) = &mut drives[drive_idx] else {
@@ -99,7 +99,7 @@ pub fn execute_write<const SECTOR_SIZE: usize>(
     let mut remaining = xfer_size;
     let mut pos = sector_pos;
     let mut addr = buf_addr;
-    let sector_size = drive.geometry.sector_size as usize;
+    let sector_size = drive.geometry().sector_size as usize;
 
     while remaining > 0 {
         let write_size = (remaining as usize).min(sector_size);
@@ -124,7 +124,7 @@ pub fn execute_write<const SECTOR_SIZE: usize>(
 /// Executes a BIOS init operation: returns the disk equipment word
 /// indicating which drives are present. Preserves non-disk bits from
 /// the current equipment word using mask 0xF0FF.
-pub fn execute_init(drives: &[Option<HddImage>; 2], current_equip: u16) -> u16 {
+pub fn execute_init(drives: &[Option<MountedHdd>; 2], current_equip: u16) -> u16 {
     let mut disk_equip = current_equip & 0xF0FF;
     for (i, drive) in drives.iter().enumerate() {
         if drive.is_some() {
@@ -135,7 +135,11 @@ pub fn execute_init(drives: &[Option<HddImage>; 2], current_equip: u16) -> u16 {
 }
 
 /// Executes a BIOS format operation on a track.
-pub fn execute_format(drive_idx: usize, sector_pos: u32, drives: &mut [Option<HddImage>; 2]) -> u8 {
+pub fn execute_format(
+    drive_idx: usize,
+    sector_pos: u32,
+    drives: &mut [Option<MountedHdd>; 2],
+) -> u8 {
     let Some(drive) = &mut drives[drive_idx] else {
         return 0x60;
     };
@@ -149,9 +153,9 @@ pub fn execute_format(drive_idx: usize, sector_pos: u32, drives: &mut [Option<Hd
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::disk::{HddFormat, HddGeometry};
+    use crate::disk::{HddFormat, HddGeometry, HddImage};
 
-    fn make_sasi_drive() -> HddImage {
+    fn make_sasi_drive() -> MountedHdd {
         let geometry = HddGeometry {
             cylinders: 153,
             heads: 4,
@@ -165,10 +169,10 @@ mod tests {
             data[offset] = (lba >> 8) as u8;
             data[offset + 1] = lba as u8;
         }
-        HddImage::from_raw(geometry, HddFormat::Thd, data)
+        MountedHdd::new(HddImage::from_raw(geometry, HddFormat::Thd, data), None)
     }
 
-    fn make_ide_drive() -> HddImage {
+    fn make_ide_drive() -> MountedHdd {
         let geometry = HddGeometry {
             cylinders: 20,
             heads: 4,
@@ -182,7 +186,7 @@ mod tests {
             data[offset] = (lba >> 8) as u8;
             data[offset + 1] = lba as u8;
         }
-        HddImage::from_raw(geometry, HddFormat::Hdi, data)
+        MountedHdd::new(HddImage::from_raw(geometry, HddFormat::Hdi, data), None)
     }
 
     fn sasi_geometry() -> HddGeometry {
@@ -252,7 +256,7 @@ mod tests {
 
     #[test]
     fn read_sasi_sector() {
-        let drives: [Option<HddImage>; 2] = [Some(make_sasi_drive()), None];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_sasi_drive()), None];
         let geometry = sasi_geometry();
         let pos = sector_position(0x80, 0x0000, 0x0005, &geometry);
         let addr = buffer_address(0x2000, 0x0000);
@@ -269,7 +273,7 @@ mod tests {
 
     #[test]
     fn read_ide_sector() {
-        let drives: [Option<HddImage>; 2] = [Some(make_ide_drive()), None];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_ide_drive()), None];
         let geometry = ide_geometry();
         let pos = sector_position(0x80, 0x0000, 0x0005, &geometry);
         let addr = buffer_address(0x2000, 0x0000);
@@ -286,14 +290,14 @@ mod tests {
 
     #[test]
     fn read_no_drive_returns_error() {
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
         let status = execute_read(0, 1, 0, 0x20000, &drives, |_, _| {});
         assert_eq!(status, 0x60);
     }
 
     #[test]
     fn write_sasi_sector() {
-        let mut drives: [Option<HddImage>; 2] = [Some(make_sasi_drive()), None];
+        let mut drives: [Option<MountedHdd>; 2] = [Some(make_sasi_drive()), None];
         let geometry = sasi_geometry();
         let pos = sector_position(0x80, 0x0000, 0x000A, &geometry);
         let addr = buffer_address(0x2000, 0x0000);
@@ -307,7 +311,7 @@ mod tests {
 
     #[test]
     fn write_ide_sector() {
-        let mut drives: [Option<HddImage>; 2] = [Some(make_ide_drive()), None];
+        let mut drives: [Option<MountedHdd>; 2] = [Some(make_ide_drive()), None];
         let geometry = ide_geometry();
         let pos = sector_position(0x80, 0x0000, 0x000A, &geometry);
         let addr = buffer_address(0x2000, 0x0000);
@@ -321,29 +325,29 @@ mod tests {
 
     #[test]
     fn init_detects_drives() {
-        let drives: [Option<HddImage>; 2] = [Some(make_sasi_drive()), None];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_sasi_drive()), None];
         let equip = execute_init(&drives, 0x0000);
         assert_eq!(equip, 0x0100);
 
-        let both: [Option<HddImage>; 2] = [Some(make_sasi_drive()), Some(make_sasi_drive())];
+        let both: [Option<MountedHdd>; 2] = [Some(make_sasi_drive()), Some(make_sasi_drive())];
         let equip = execute_init(&both, 0x0000);
         assert_eq!(equip, 0x0300);
 
-        let none: [Option<HddImage>; 2] = [None, None];
+        let none: [Option<MountedHdd>; 2] = [None, None];
         let equip = execute_init(&none, 0x0000);
         assert_eq!(equip, 0x0000);
     }
 
     #[test]
     fn init_preserves_non_disk_bits() {
-        let drives: [Option<HddImage>; 2] = [Some(make_sasi_drive()), None];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_sasi_drive()), None];
         let equip = execute_init(&drives, 0x8040);
         assert_eq!(equip, 0x8140);
     }
 
     #[test]
     fn format_fills_with_e5() {
-        let mut drives: [Option<HddImage>; 2] = [Some(make_sasi_drive()), None];
+        let mut drives: [Option<MountedHdd>; 2] = [Some(make_sasi_drive()), None];
         let status = execute_format(0, 0, &mut drives);
         assert_eq!(status, 0x00);
 

--- a/crates/device/src/floppy.rs
+++ b/crates/device/src/floppy.rs
@@ -13,10 +13,14 @@ use std::{
     error::Error,
     fmt,
     ops::{Deref, DerefMut},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
+use common::error;
 pub use d88::{D88Disk, D88Error, D88MediaType, D88Sector};
+pub use nfd::NfdRevision;
+
+use crate::disk_backend::DiskBackend;
 
 /// The original format of a loaded floppy image (used for serialization).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -25,8 +29,10 @@ pub enum FloppyFormat {
     D88,
     /// Headerless raw sector format (.hdm).
     Hdm,
-    /// T98Next floppy format (.nfd).
-    Nfd,
+    /// T98Next floppy format, R0 revision (.nfd, magic `T98FDDIMAGE.R0`).
+    NfdR0,
+    /// T98Next floppy format, R1 revision (.nfd, magic `T98FDDIMAGE.R1`).
+    NfdR1,
 }
 
 /// A parsed floppy disk image.
@@ -80,11 +86,12 @@ impl FloppyImage {
 
     /// Parses an NFD floppy image from raw bytes.
     pub fn from_nfd_bytes(data: &[u8]) -> Result<Self, FloppyError> {
-        let disk = nfd::from_bytes(data).map_err(FloppyError::Nfd)?;
-        Ok(Self {
-            disk,
-            format: FloppyFormat::Nfd,
-        })
+        let (disk, revision) = nfd::from_bytes(data).map_err(FloppyError::Nfd)?;
+        let format = match revision {
+            NfdRevision::R0 => FloppyFormat::NfdR0,
+            NfdRevision::R1 => FloppyFormat::NfdR1,
+        };
+        Ok(Self { disk, format })
     }
 
     /// Returns a human-readable format name.
@@ -92,19 +99,187 @@ impl FloppyImage {
         match self.format {
             FloppyFormat::D88 => "D88",
             FloppyFormat::Hdm => "HDM",
-            FloppyFormat::Nfd => "NFD",
+            FloppyFormat::NfdR0 => "NFD R0",
+            FloppyFormat::NfdR1 => "NFD R1",
         }
     }
 
-    /// Returns whether this image can be written back to disk.
-    /// Only D88 format supports lossless roundtrip serialization.
-    pub fn can_write_back(&self) -> bool {
-        matches!(self.format, FloppyFormat::D88)
+    /// Serializes the image back to its source on-disk format.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        match self.format {
+            FloppyFormat::D88 => self.disk.to_bytes(),
+            FloppyFormat::Hdm => hdm::to_bytes(&self.disk),
+            FloppyFormat::NfdR0 => nfd::to_bytes_r0(&self.disk),
+            FloppyFormat::NfdR1 => nfd::to_bytes_r1(&self.disk),
+        }
     }
 
-    /// Serializes the image back to D88 format.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.disk.to_bytes()
+    fn lossless_reemit_error(&self) -> Option<&'static str> {
+        match self.format {
+            FloppyFormat::D88 => None,
+            FloppyFormat::Hdm => {
+                if hdm::is_representable(&self.disk) {
+                    None
+                } else {
+                    Some("HDM cannot represent the current track layout")
+                }
+            }
+            FloppyFormat::NfdR0 | FloppyFormat::NfdR1 => {
+                Some("NFD full-image serialization does not preserve all source metadata")
+            }
+        }
+    }
+}
+
+/// A floppy image bound to its source file for synchronous write-through.
+#[derive(Debug)]
+pub struct MountedFloppy {
+    image: FloppyImage,
+    backend: Option<DiskBackend>,
+    dirty: bool,
+}
+
+impl MountedFloppy {
+    /// Constructs a new mount. If `path` is `None` or the file cannot be
+    /// opened for write, writes only land in memory.
+    pub fn new(image: FloppyImage, path: Option<PathBuf>) -> Self {
+        let backend = path.and_then(|p| match DiskBackend::open(p.clone()) {
+            Ok(b) => Some(b),
+            Err(err) => {
+                error!(
+                    "Failed to open floppy {} for write-through: {err}",
+                    p.display()
+                );
+                None
+            }
+        });
+        Self {
+            image,
+            backend,
+            dirty: false,
+        }
+    }
+
+    /// Returns a read-only reference to the parsed image.
+    pub fn image(&self) -> &FloppyImage {
+        &self.image
+    }
+
+    /// Returns whether the in-memory image has unwritten changes.
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Writes sector data identified by C/H/R/N near `track_index`.
+    /// Returns `true` if the sector was found.
+    #[allow(clippy::too_many_arguments)]
+    pub fn write_sector_data(
+        &mut self,
+        track_index: usize,
+        c: u8,
+        h: u8,
+        r: u8,
+        n: u8,
+        data: &[u8],
+    ) -> bool {
+        let Some(sector) = self
+            .image
+            .find_sector_near_track_index_mut(track_index, c, h, r, n)
+        else {
+            return false;
+        };
+        let copy_len = data.len().min(sector.data.len());
+        sector.data[..copy_len].copy_from_slice(&data[..copy_len]);
+        let source_offset = sector.source_offset;
+
+        if let (Some(backend), Some(offset)) = (self.backend.as_mut(), source_offset) {
+            if let Err(err) = backend.write_at(offset, &data[..copy_len]) {
+                self.dirty = true;
+                error!("Floppy write-through failed at offset {offset}: {err}");
+            }
+        } else {
+            self.dirty = true;
+        }
+        true
+    }
+
+    /// Formats a track and re-emits the image atomically. The image is
+    /// reparsed from the new bytes so per-sector source offsets stay
+    /// valid for subsequent write-through.
+    pub fn format_track(
+        &mut self,
+        track_index: usize,
+        chrn: &[(u8, u8, u8, u8)],
+        data_n: u8,
+        fill_byte: u8,
+    ) {
+        self.image
+            .format_track(track_index, chrn, data_n, fill_byte);
+        self.dirty = true;
+
+        let Some(backend) = self.backend.as_mut() else {
+            return;
+        };
+        if let Some(reason) = self.image.lossless_reemit_error() {
+            error!(
+                "Floppy FORMAT TRACK cannot be written back to {} without loss: {reason}",
+                self.image.format_name()
+            );
+            return;
+        }
+        let bytes = self.image.to_bytes();
+        if let Err(err) = backend.replace_atomic(&bytes) {
+            error!("Floppy FORMAT TRACK re-emit failed: {err}");
+            return;
+        }
+        match load_floppy_image(backend.path(), &bytes) {
+            Ok(reparsed) => {
+                self.image = reparsed;
+                self.dirty = false;
+            }
+            Err(err) => error!("Floppy reparse after FORMAT TRACK failed: {err}"),
+        }
+    }
+
+    /// Re-emits the entire image if dirty. The dirty flag remains set
+    /// only when an earlier per-sector write-through reported an error,
+    /// so under normal use this is a no-op.
+    pub fn flush_if_dirty(&mut self) {
+        if !self.dirty {
+            return;
+        }
+        let Some(backend) = self.backend.as_mut() else {
+            return;
+        };
+        if let Some(reason) = self.image.lossless_reemit_error() {
+            error!(
+                "Floppy dirty flush cannot write back {} without loss: {reason}",
+                self.image.format_name()
+            );
+            return;
+        }
+        let bytes = self.image.to_bytes();
+        if let Err(err) = backend.replace_atomic(&bytes) {
+            error!("Floppy eject-time flush failed: {err}");
+            return;
+        }
+        self.dirty = false;
+    }
+
+    /// Flushes dirty fallback data and any buffered successful writes.
+    pub fn flush(&mut self) {
+        self.flush_if_dirty();
+        if let Some(backend) = self.backend.as_mut()
+            && let Err(err) = backend.flush()
+        {
+            self.dirty = true;
+            error!("Floppy flush failed: {err}");
+        }
+    }
+
+    /// Flushes any pending writes and drops the backend handle.
+    pub fn eject(mut self) {
+        self.flush();
     }
 }
 
@@ -148,3 +323,229 @@ impl fmt::Display for FloppyError {
 }
 
 impl Error for FloppyError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempfile_with(bytes: &[u8], suffix: &str) -> PathBuf {
+        let dir = std::env::temp_dir();
+        let unique = format!(
+            "neetan_floppy_test_{}_{}{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            suffix
+        );
+        let path = dir.join(unique);
+        std::fs::write(&path, bytes).expect("write temp file");
+        path
+    }
+
+    fn build_minimal_d88(payload_byte: u8) -> Vec<u8> {
+        // One track, one 256-byte sector (N=1), C=0 H=0 R=1.
+        const HEADER_SIZE: usize = 0x2B0;
+        const SECTOR_HEADER_SIZE: usize = 16;
+        let mut image = vec![0u8; HEADER_SIZE];
+        image[0x1B] = 0x10; // 2DD
+        let track_offset = HEADER_SIZE as u32;
+        image[0x20..0x24].copy_from_slice(&track_offset.to_le_bytes());
+
+        let mut sector = vec![0u8; SECTOR_HEADER_SIZE];
+        sector[0] = 0; // C
+        sector[1] = 0; // H
+        sector[2] = 1; // R
+        sector[3] = 1; // N (256 bytes)
+        sector[4..6].copy_from_slice(&1u16.to_le_bytes()); // sector_count
+        sector[0x0E..0x10].copy_from_slice(&256u16.to_le_bytes());
+        let mut data = vec![payload_byte; 256];
+        sector.append(&mut data);
+        image.extend_from_slice(&sector);
+
+        let total = image.len() as u32;
+        image[0x1C..0x20].copy_from_slice(&total.to_le_bytes());
+        image
+    }
+
+    #[test]
+    fn mounted_floppy_d88_sector_write_through() {
+        let original = build_minimal_d88(0x00);
+        let path = tempfile_with(&original, ".d88");
+
+        let image = FloppyImage::from_d88_bytes(&original).unwrap();
+        let mut mounted = MountedFloppy::new(image, Some(path.clone()));
+
+        let pattern = [0x42u8; 256];
+        assert!(mounted.write_sector_data(0, 0, 0, 1, 1, &pattern));
+
+        // Drop the mount to flush the BufWriter, then re-read the file.
+        drop(mounted);
+        let raw = std::fs::read(&path).unwrap();
+        let reparsed = FloppyImage::from_d88_bytes(&raw).unwrap();
+        let s = reparsed.find_sector(0, 0, 1, 1).unwrap();
+        assert!(s.data.iter().all(|&b| b == 0x42));
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn mounted_floppy_d88_format_track_reemits_file() {
+        let original = build_minimal_d88(0x00);
+        let path = tempfile_with(&original, ".d88");
+
+        let image = FloppyImage::from_d88_bytes(&original).unwrap();
+        let mut mounted = MountedFloppy::new(image, Some(path.clone()));
+
+        // Re-format track 0 with two sectors instead of one.
+        mounted.format_track(0, &[(0, 0, 1, 1), (0, 0, 2, 1)], 1, 0xE5);
+
+        // After format_track + re-emit + reparse, source_offsets should be
+        // populated again, and a subsequent sector write reaches the file.
+        let pattern = [0x55u8; 256];
+        assert!(mounted.write_sector_data(0, 0, 0, 2, 1, &pattern));
+
+        drop(mounted);
+        let raw = std::fs::read(&path).unwrap();
+        let reparsed = FloppyImage::from_d88_bytes(&raw).unwrap();
+        assert_eq!(reparsed.sector_count(0), 2);
+        let s2 = reparsed.find_sector(0, 0, 2, 1).unwrap();
+        assert!(s2.data.iter().all(|&b| b == 0x55));
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn mounted_floppy_hdm_sector_write_through() {
+        // Build a 1.26MB HDM image with a known pattern.
+        let mut original = vec![0u8; 1_261_568];
+        for (i, byte) in original.iter_mut().enumerate() {
+            *byte = (i & 0xFF) as u8;
+        }
+        let path = tempfile_with(&original, ".hdm");
+
+        let image = FloppyImage::from_hdm_bytes(&original).unwrap();
+        let mut mounted = MountedFloppy::new(image, Some(path.clone()));
+
+        // Overwrite C=0 H=0 R=1.
+        let pattern = [0xCCu8; 1024];
+        assert!(mounted.write_sector_data(0, 0, 0, 1, 3, &pattern));
+
+        drop(mounted);
+        let raw = std::fs::read(&path).unwrap();
+        // First 1024 bytes should now be 0xCC.
+        assert!(raw[..1024].iter().all(|&b| b == 0xCC));
+        // Subsequent sectors unchanged.
+        assert_eq!(raw[1024], (1024 & 0xFF) as u8);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn mounted_floppy_hdm_incompatible_format_stays_dirty_and_leaves_file_unchanged() {
+        let mut original = vec![0u8; 1_261_568];
+        for (i, byte) in original.iter_mut().enumerate() {
+            *byte = (i & 0xFF) as u8;
+        }
+        let path = tempfile_with(&original, ".hdm");
+
+        let image = FloppyImage::from_hdm_bytes(&original).unwrap();
+        let mut mounted = MountedFloppy::new(image, Some(path.clone()));
+
+        // HDM can only represent 1024-byte sectors. Formatting a track as
+        // 256-byte sectors must not silently rewrite the file as zeroed HDM.
+        mounted.format_track(0, &[(0, 0, 1, 1)], 1, 0xE5);
+
+        assert!(mounted.is_dirty());
+        let raw = std::fs::read(&path).unwrap();
+        assert_eq!(raw, original);
+
+        drop(mounted);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn mounted_floppy_nfd_format_stays_dirty_and_leaves_file_unchanged() {
+        const COMMON_HEADER_SIZE: usize = 0x120;
+        const R1_TRACK_TABLE_SIZE: usize = 164 * 4;
+        const R1_TRACK_HEADER_SIZE: usize = 16;
+        const SECTOR_ENTRY_SIZE: usize = 16;
+
+        let track_metadata_size = R1_TRACK_HEADER_SIZE + SECTOR_ENTRY_SIZE;
+        let header_section_size = COMMON_HEADER_SIZE + R1_TRACK_TABLE_SIZE + track_metadata_size;
+        let mut original = vec![0u8; header_section_size + 256];
+        original[..15].copy_from_slice(b"T98FDDIMAGE.R1\0");
+        original[0x10..0x1A].copy_from_slice(b"KEEP-TITLE");
+        original[0x110..0x114].copy_from_slice(&(header_section_size as u32).to_le_bytes());
+
+        let track_meta_offset = COMMON_HEADER_SIZE + R1_TRACK_TABLE_SIZE;
+        original[COMMON_HEADER_SIZE..COMMON_HEADER_SIZE + 4]
+            .copy_from_slice(&(track_meta_offset as u32).to_le_bytes());
+        original[track_meta_offset..track_meta_offset + 2].copy_from_slice(&1u16.to_le_bytes());
+
+        let entry = track_meta_offset + R1_TRACK_HEADER_SIZE;
+        original[entry] = 0;
+        original[entry + 1] = 0;
+        original[entry + 2] = 1;
+        original[entry + 3] = 1;
+        original[entry + 11] = 0x90;
+        original[header_section_size..].fill(0xA5);
+
+        let path = tempfile_with(&original, ".nfd");
+        let image = FloppyImage::from_nfd_bytes(&original).unwrap();
+        let mut mounted = MountedFloppy::new(image, Some(path.clone()));
+
+        mounted.format_track(0, &[(0, 0, 1, 1)], 1, 0xE5);
+
+        assert!(mounted.is_dirty());
+        let raw = std::fs::read(&path).unwrap();
+        assert_eq!(raw, original);
+
+        drop(mounted);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn mounted_floppy_write_sector_preserves_existing_dirty_bit() {
+        let original = build_minimal_d88(0x00);
+        let path = tempfile_with(&original, ".d88");
+
+        let image = FloppyImage::from_d88_bytes(&original).unwrap();
+        let mut mounted = MountedFloppy::new(image, Some(path.clone()));
+
+        // Simulate a prior write-through error.
+        mounted.dirty = true;
+
+        let pattern = [0x42u8; 256];
+        assert!(mounted.write_sector_data(0, 0, 0, 1, 1, &pattern));
+        assert!(
+            mounted.is_dirty(),
+            "dirty must remain set after later successful write"
+        );
+
+        drop(mounted);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn mounted_floppy_format_track_clears_dirty_only_on_full_success() {
+        let original = build_minimal_d88(0x00);
+        let path = tempfile_with(&original, ".d88");
+
+        let image = FloppyImage::from_d88_bytes(&original).unwrap();
+        let mut mounted = MountedFloppy::new(image, Some(path.clone()));
+
+        // After a successful format_track + replace_atomic + reparse,
+        // dirty must be false. Pins down the success-path post-condition
+        // for the planned restructure of the assignment site.
+        mounted.format_track(0, &[(0, 0, 1, 1), (0, 0, 2, 1)], 1, 0xE5);
+        assert!(
+            !mounted.is_dirty(),
+            "successful format_track must clear dirty"
+        );
+
+        drop(mounted);
+        std::fs::remove_file(&path).ok();
+    }
+}

--- a/crates/device/src/floppy/d88.rs
+++ b/crates/device/src/floppy/d88.rs
@@ -94,6 +94,11 @@ pub struct D88Sector {
     pub reserved: [u8; 5],
     /// Sector data.
     pub data: Vec<u8>,
+    /// Byte offset of this sector's data within the on-disk image.
+    /// Populated by every parser (D88, HDM, NFD); used by `MountedFloppy`
+    /// to seek-and-overwrite the sector in the file. `None` for sectors
+    /// created by `D88Disk::format_track` until a re-emit + reparse runs.
+    pub source_offset: Option<u64>,
 }
 
 /// A parsed track containing its sectors.
@@ -229,6 +234,7 @@ impl D88Disk {
                     status,
                     reserved,
                     data: sector_data,
+                    source_offset: Some(data_start as u64),
                 });
 
                 pos = data_end;
@@ -435,6 +441,7 @@ impl D88Disk {
                 status: 0x00,
                 reserved: [0u8; 5],
                 data: vec![fill_byte; sector_size],
+                source_offset: None,
             })
             .collect();
         self.tracks[track_index] = Some(D88Track { sectors });
@@ -875,5 +882,37 @@ mod tests {
             let s = disk.find_sector(0, 0, r, 3).unwrap();
             assert_eq!(s.data[0], r);
         }
+    }
+
+    #[test]
+    fn parser_records_source_offsets() {
+        let image = build_test_d88(
+            0x10,
+            &[(0, 0, 1, 0, &[0xAA; 128]), (0, 0, 2, 0, &[0xBB; 128])],
+        );
+        let disk = D88Disk::from_bytes(&image).unwrap();
+
+        // First sector data starts at HEADER_SIZE + SECTOR_HEADER_SIZE.
+        let s1 = disk.find_sector(0, 0, 1, 0).unwrap();
+        assert_eq!(
+            s1.source_offset,
+            Some((HEADER_SIZE + SECTOR_HEADER_SIZE) as u64)
+        );
+        // Second sector follows the first sector's data plus its own header.
+        let s2 = disk.find_sector(0, 0, 2, 0).unwrap();
+        assert_eq!(
+            s2.source_offset,
+            Some((HEADER_SIZE + SECTOR_HEADER_SIZE + 128 + SECTOR_HEADER_SIZE) as u64),
+        );
+    }
+
+    #[test]
+    fn format_track_clears_source_offsets() {
+        let image = build_test_d88(0x10, &[(0, 0, 1, 0, &[0xAA; 128])]);
+        let mut disk = D88Disk::from_bytes(&image).unwrap();
+
+        disk.format_track(0, &[(0, 0, 1, 0)], 0, 0xE5);
+        let sector = disk.sector_at_index(0, 0).unwrap();
+        assert!(sector.source_offset.is_none());
     }
 }

--- a/crates/device/src/floppy/hdm.rs
+++ b/crates/device/src/floppy/hdm.rs
@@ -6,6 +6,8 @@
 
 use std::fmt;
 
+use common::warn;
+
 use super::d88::{D88Disk, D88MediaType, D88Sector};
 
 const HDM_FILE_SIZE: usize = 1_261_568;
@@ -54,6 +56,7 @@ pub fn from_bytes(data: &[u8]) -> Result<D88Disk, HdmError> {
 
             for record in 1..=SECTORS_PER_TRACK {
                 let sector_data = data[offset..offset + SECTOR_SIZE].to_vec();
+                let data_offset = offset;
                 offset += SECTOR_SIZE;
 
                 sectors.push(D88Sector {
@@ -67,6 +70,7 @@ pub fn from_bytes(data: &[u8]) -> Result<D88Disk, HdmError> {
                     status: 0x00,
                     reserved: [0u8; 5],
                     data: sector_data,
+                    source_offset: Some(data_offset as u64),
                 });
             }
 
@@ -80,6 +84,64 @@ pub fn from_bytes(data: &[u8]) -> Result<D88Disk, HdmError> {
         D88MediaType::Disk2HD,
         track_sectors,
     ))
+}
+
+/// Serializes a `D88Disk` back into the fixed HDM raw layout
+/// (77 cylinders x 2 heads x 8 sectors x 1024 bytes = 1,261,568 bytes).
+///
+/// Sectors are looked up by C/H/R in the fixed geometry. Missing sectors
+/// or sectors with non-1024-byte data are emitted as 1024 zero bytes;
+/// HDM cannot represent any other layout. This only happens when a
+/// guest's FORMAT TRACK has produced an HDM-incompatible layout.
+pub fn to_bytes(disk: &D88Disk) -> Vec<u8> {
+    let mut out = vec![0u8; HDM_FILE_SIZE];
+    let mut warned = false;
+
+    for cylinder in 0..CYLINDERS {
+        for head in 0..HEADS {
+            for record in 1..=SECTORS_PER_TRACK {
+                let slot_index = ((cylinder as usize) * (HEADS as usize) + (head as usize))
+                    * (SECTORS_PER_TRACK as usize)
+                    + ((record - 1) as usize);
+                let offset = slot_index * SECTOR_SIZE;
+
+                match disk.find_sector(cylinder, head, record, SIZE_CODE) {
+                    Some(sector) if sector.data.len() == SECTOR_SIZE => {
+                        out[offset..offset + SECTOR_SIZE].copy_from_slice(&sector.data);
+                    }
+                    _ => {
+                        if !warned {
+                            warn!(
+                                "HDM serializer: missing or non-1024-byte sector at \
+                                 C={cylinder} H={head} R={record}; emitting zeros. \
+                                 (HDM cannot represent non-standard geometry.)"
+                            );
+                            warned = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    out
+}
+
+/// Returns whether `disk` can be represented without data loss as HDM.
+pub(crate) fn is_representable(disk: &D88Disk) -> bool {
+    for cylinder in 0..CYLINDERS {
+        for head in 0..HEADS {
+            for record in 1..=SECTORS_PER_TRACK {
+                let Some(sector) = disk.find_sector(cylinder, head, record, SIZE_CODE) else {
+                    return false;
+                };
+                if sector.data.len() != SECTOR_SIZE {
+                    return false;
+                }
+            }
+        }
+    }
+    true
 }
 
 #[cfg(test)]
@@ -163,5 +225,51 @@ mod tests {
         let s0 = disk.sector_at_index(0, 0).unwrap();
         let s8 = disk.sector_at_index(0, 8).unwrap();
         assert_eq!(s0.record, s8.record);
+    }
+
+    fn build_pattern_image() -> Vec<u8> {
+        let mut data = vec![0u8; HDM_FILE_SIZE];
+        for (i, byte) in data.iter_mut().enumerate() {
+            *byte = (i & 0xFF) as u8;
+        }
+        data
+    }
+
+    #[test]
+    fn roundtrip_unchanged() {
+        let original = build_pattern_image();
+        let disk = from_bytes(&original).unwrap();
+        let serialized = to_bytes(&disk);
+        assert_eq!(serialized, original);
+    }
+
+    #[test]
+    fn roundtrip_after_sector_mutation() {
+        let original = build_pattern_image();
+        let mut disk = from_bytes(&original).unwrap();
+
+        let sector = disk
+            .find_sector_on_track_index_mut(2, 1, 0, 4, SIZE_CODE)
+            .unwrap();
+        sector.data.fill(0xCC);
+
+        let serialized = to_bytes(&disk);
+        let reparsed = from_bytes(&serialized).unwrap();
+        let s = reparsed.find_sector(1, 0, 4, SIZE_CODE).unwrap();
+        assert!(s.data.iter().all(|&b| b == 0xCC));
+    }
+
+    #[test]
+    fn parser_records_source_offsets() {
+        let data = build_pattern_image();
+        let disk = from_bytes(&data).unwrap();
+
+        // First sector (track 0, slot 0): cylinder 0, head 0, record 1.
+        let s = disk.find_sector(0, 0, 1, SIZE_CODE).unwrap();
+        assert_eq!(s.source_offset, Some(0));
+
+        // Sector at C=1 H=0 R=1 starts at offset 16384 (cylinder 1 = 2 tracks).
+        let s = disk.find_sector(1, 0, 1, SIZE_CODE).unwrap();
+        assert_eq!(s.source_offset, Some(2 * 8 * SECTOR_SIZE as u64));
     }
 }

--- a/crates/device/src/floppy/nfd.rs
+++ b/crates/device/src/floppy/nfd.rs
@@ -9,6 +9,8 @@
 
 use std::fmt;
 
+use common::warn;
+
 use super::d88::{D88Disk, D88MediaType, D88Sector};
 
 const NFD_R0_MAGIC: &[u8; 15] = b"T98FDDIMAGE.R0\0";
@@ -109,16 +111,27 @@ fn read_u32_le(data: &[u8], offset: usize) -> u32 {
     ])
 }
 
-/// Parses an NFD disk image (R0 or R1) from raw bytes.
-pub fn from_bytes(data: &[u8]) -> Result<D88Disk, NfdError> {
+/// Which NFD revision a parsed image came from. Used to select the
+/// matching serializer when re-emitting the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NfdRevision {
+    /// R0 revision (fixed 163 x 26 sector map).
+    R0,
+    /// R1 revision (per-track headers and offset table).
+    R1,
+}
+
+/// Parses an NFD disk image (R0 or R1) from raw bytes, returning the
+/// parsed disk and which revision the magic indicated.
+pub fn from_bytes(data: &[u8]) -> Result<(D88Disk, NfdRevision), NfdError> {
     if data.len() < COMMON_HEADER_SIZE {
         return Err(NfdError::TooSmall);
     }
 
     if &data[..15] == NFD_R0_MAGIC {
-        parse_r0(data)
+        parse_r0(data).map(|disk| (disk, NfdRevision::R0))
     } else if &data[..15] == NFD_R1_MAGIC {
-        parse_r1(data)
+        parse_r1(data).map(|disk| (disk, NfdRevision::R1))
     } else {
         Err(NfdError::InvalidMagic)
     }
@@ -210,6 +223,7 @@ fn parse_r0(data: &[u8]) -> Result<D88Disk, NfdError> {
             }
 
             let sector_data = data[data_offset..data_offset + sector_size].to_vec();
+            let sector_data_offset = data_offset;
             data_offset += sector_size;
 
             sectors.push(D88Sector {
@@ -223,6 +237,7 @@ fn parse_r0(data: &[u8]) -> Result<D88Disk, NfdError> {
                 status: by_status,
                 reserved: [0u8; 5],
                 data: sector_data,
+                source_offset: Some(sector_data_offset as u64),
             });
         }
 
@@ -328,6 +343,7 @@ fn parse_r1(data: &[u8]) -> Result<D88Disk, NfdError> {
             }
 
             let sector_data = data[data_offset..data_offset + sector_size].to_vec();
+            let sector_data_offset = data_offset;
             data_offset += total_size;
 
             sectors.push(D88Sector {
@@ -341,6 +357,7 @@ fn parse_r1(data: &[u8]) -> Result<D88Disk, NfdError> {
                 status: by_status,
                 reserved: [0u8; 5],
                 data: sector_data,
+                source_offset: Some(sector_data_offset as u64),
             });
         }
 
@@ -384,6 +401,200 @@ fn parse_r1(data: &[u8]) -> Result<D88Disk, NfdError> {
     ))
 }
 
+/// Maps a `D88MediaType` back to the canonical NFD PDA byte. Inverse of
+/// `media_type_from_pda`. The lossy direction `0x30 -> Disk2HD -> 0x90`
+/// is intentional; both PDAs decode to 2HD on the parse side.
+fn pda_from_media_type(media_type: D88MediaType) -> u8 {
+    match media_type {
+        D88MediaType::Disk2D | D88MediaType::Disk2DD => 0x10,
+        D88MediaType::Disk2HD => 0x90,
+    }
+}
+
+/// R0 header size: common header + flat sector map.
+const R0_HEADER_SIZE: usize =
+    COMMON_HEADER_SIZE + R0_TRACK_MAX * SECTORS_PER_TRACK * SECTOR_ENTRY_SIZE;
+
+/// R1 track-offset table size (164 tracks x 4 bytes each).
+const R1_TRACK_TABLE_SIZE: usize = R1_TRACK_MAX * 4;
+
+/// R1 per-track header size (u16 sector_count + u16 diag_count + 12 reserved bytes).
+const R1_TRACK_HEADER_SIZE: usize = 16;
+
+/// Serializes a `D88Disk` into NFD R0 bytes.
+///
+/// Title/comment bytes (offsets 0x10..0x110) are emitted as zeros; NFD
+/// header titles are not preserved across re-emit. Tracks with more than
+/// 26 sectors are truncated (R0 cannot represent them) and a warning is
+/// logged.
+pub fn to_bytes_r0(disk: &D88Disk) -> Vec<u8> {
+    let media_pda = pda_from_media_type(disk.media_type);
+    let mut warned_truncate = false;
+
+    // Compute total file size: header + sum of sector data sizes.
+    let mut data_size: usize = 0;
+    for track in 0..R0_TRACK_MAX {
+        let count = disk.sector_count(track);
+        let emit = count.min(SECTORS_PER_TRACK);
+        for slot in 0..emit {
+            let Some(sector) = disk.sector_at_index(track, slot) else {
+                continue;
+            };
+            data_size += sector.data.len();
+        }
+    }
+
+    let mut out = vec![0u8; R0_HEADER_SIZE + data_size];
+
+    // Common header.
+    out[..15].copy_from_slice(NFD_R0_MAGIC);
+    out[0x110..0x114].copy_from_slice(&(R0_HEADER_SIZE as u32).to_le_bytes());
+    out[0x114] = if disk.write_protected { 0x10 } else { 0x00 };
+
+    // Sector map and sector data.
+    let mut data_offset = R0_HEADER_SIZE;
+    for track in 0..R0_TRACK_MAX {
+        let count = disk.sector_count(track);
+        if count > SECTORS_PER_TRACK && !warned_truncate {
+            warn!(
+                "NFD R0 serializer: track {track} has {count} sectors; \
+                 R0 supports at most {SECTORS_PER_TRACK} per track, truncating."
+            );
+            warned_truncate = true;
+        }
+        let emit = count.min(SECTORS_PER_TRACK);
+
+        for slot in 0..SECTORS_PER_TRACK {
+            let entry_offset =
+                COMMON_HEADER_SIZE + (track * SECTORS_PER_TRACK + slot) * SECTOR_ENTRY_SIZE;
+
+            if slot < emit {
+                let Some(sector) = disk.sector_at_index(track, slot) else {
+                    out[entry_offset] = 0xFF;
+                    continue;
+                };
+                out[entry_offset] = sector.cylinder;
+                out[entry_offset + 1] = sector.head;
+                out[entry_offset + 2] = sector.record;
+                out[entry_offset + 3] = sector.size_code;
+                // fl_mfm: 0 means MFM (D88 has 0x40 set for MFM).
+                out[entry_offset + 4] = if sector.mfm_flag & 0x40 != 0 {
+                    0x00
+                } else {
+                    0xFF
+                };
+                out[entry_offset + 5] = sector.deleted;
+                out[entry_offset + 6] = sector.status;
+                out[entry_offset + 10] = media_pda;
+
+                let sector_data_size = sector.data.len();
+                out[data_offset..data_offset + sector_data_size].copy_from_slice(&sector.data);
+                data_offset += sector_data_size;
+            } else {
+                out[entry_offset] = 0xFF;
+            }
+        }
+    }
+
+    out
+}
+
+/// Serializes a `D88Disk` into NFD R1 bytes.
+///
+/// Title/comment bytes are emitted as zeros. Per-sector retry copies and
+/// diagnostic entries are dropped (count and retry fields are emitted as
+/// zero); the parser already discards them at load time, so this matches
+/// the lossy in-memory representation.
+pub fn to_bytes_r1(disk: &D88Disk) -> Vec<u8> {
+    let media_pda = pda_from_media_type(disk.media_type);
+
+    // Determine which tracks are non-empty and reserve their per-track
+    // metadata blocks. Layout: common header + track-offset table, then
+    // for each non-empty track a (header + sector entries) block, then
+    // sector data.
+    let mut track_metadata_size: [usize; R1_TRACK_MAX] = [0; R1_TRACK_MAX];
+    let mut header_section_size = COMMON_HEADER_SIZE + R1_TRACK_TABLE_SIZE;
+
+    for (track, slot) in track_metadata_size.iter_mut().enumerate() {
+        let count = disk.sector_count(track);
+        if count == 0 {
+            continue;
+        }
+        let block_size = R1_TRACK_HEADER_SIZE + count * SECTOR_ENTRY_SIZE;
+        *slot = block_size;
+        header_section_size += block_size;
+    }
+
+    // Compute sector-data total size.
+    let mut data_size: usize = 0;
+    for track in 0..R1_TRACK_MAX {
+        for slot in 0..disk.sector_count(track) {
+            if let Some(sector) = disk.sector_at_index(track, slot) {
+                data_size += sector.data.len();
+            }
+        }
+    }
+
+    let mut out = vec![0u8; header_section_size + data_size];
+
+    // Common header.
+    out[..15].copy_from_slice(NFD_R1_MAGIC);
+    out[0x110..0x114].copy_from_slice(&(header_section_size as u32).to_le_bytes());
+    out[0x114] = if disk.write_protected { 0x10 } else { 0x00 };
+
+    // Compute track absolute offsets and emit per-track metadata blocks.
+    let mut metadata_offset = COMMON_HEADER_SIZE + R1_TRACK_TABLE_SIZE;
+    let mut data_offset = header_section_size;
+
+    for (track, &block_size) in track_metadata_size.iter().enumerate() {
+        let count = disk.sector_count(track);
+        let table_entry = COMMON_HEADER_SIZE + track * 4;
+        if count == 0 {
+            // Track-offset entry stays zero.
+            continue;
+        }
+
+        out[table_entry..table_entry + 4].copy_from_slice(&(metadata_offset as u32).to_le_bytes());
+
+        // Per-track header: u16 sector_count, u16 diag_count = 0, 12 reserved.
+        out[metadata_offset..metadata_offset + 2].copy_from_slice(&(count as u16).to_le_bytes());
+        out[metadata_offset + 2..metadata_offset + 4].copy_from_slice(&0u16.to_le_bytes());
+        let mut entry_offset = metadata_offset + R1_TRACK_HEADER_SIZE;
+
+        for slot in 0..count {
+            let Some(sector) = disk.sector_at_index(track, slot) else {
+                entry_offset += SECTOR_ENTRY_SIZE;
+                continue;
+            };
+            out[entry_offset] = sector.cylinder;
+            out[entry_offset + 1] = sector.head;
+            out[entry_offset + 2] = sector.record;
+            out[entry_offset + 3] = sector.size_code;
+            out[entry_offset + 4] = if sector.mfm_flag & 0x40 != 0 {
+                0x00
+            } else {
+                0xFF
+            };
+            out[entry_offset + 5] = sector.deleted;
+            out[entry_offset + 6] = sector.status;
+            // bytes 7-9: zero
+            // byte 10: by_retry (always 0 - retries are not preserved)
+            out[entry_offset + 11] = media_pda;
+            // bytes 12-15: zero
+            entry_offset += SECTOR_ENTRY_SIZE;
+
+            // Append this sector's data after the metadata section.
+            let sector_data_size = sector.data.len();
+            out[data_offset..data_offset + sector_data_size].copy_from_slice(&sector.data);
+            data_offset += sector_data_size;
+        }
+
+        metadata_offset += block_size;
+    }
+
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -409,5 +620,142 @@ mod tests {
             from_bytes(&data),
             Err(NfdError::HeaderTruncated { .. })
         ));
+    }
+
+    /// Builds a minimal NFD R0 image with a single 256-byte sector at
+    /// track 0, slot 0 (C=0 H=0 R=1 N=1) carrying a fill pattern.
+    fn build_minimal_r0(fill: u8) -> Vec<u8> {
+        let header_size = R0_HEADER_SIZE;
+        let mut out = vec![0u8; header_size + 256];
+
+        out[..15].copy_from_slice(NFD_R0_MAGIC);
+        out[0x110..0x114].copy_from_slice(&(header_size as u32).to_le_bytes());
+
+        // Track 0, slot 0 entry.
+        let entry = COMMON_HEADER_SIZE;
+        out[entry] = 0; // C
+        out[entry + 1] = 0; // H
+        out[entry + 2] = 1; // R
+        out[entry + 3] = 1; // N (256 bytes)
+        // fl_mfm = 0 means MFM is on; matches D88 mfm_flag = 0x40.
+        out[entry + 4] = 0;
+        out[entry + 10] = 0x90; // PDA = 2HD
+
+        // Fill all other slots with 0xFF (empty).
+        for track in 0..R0_TRACK_MAX {
+            for slot in 0..SECTORS_PER_TRACK {
+                if track == 0 && slot == 0 {
+                    continue;
+                }
+                let off =
+                    COMMON_HEADER_SIZE + (track * SECTORS_PER_TRACK + slot) * SECTOR_ENTRY_SIZE;
+                out[off] = 0xFF;
+            }
+        }
+
+        // Sector data after header.
+        for byte in &mut out[header_size..] {
+            *byte = fill;
+        }
+
+        out
+    }
+
+    #[test]
+    fn r0_roundtrip_unchanged() {
+        let original = build_minimal_r0(0xAB);
+        let (disk, rev) = from_bytes(&original).unwrap();
+        assert_eq!(rev, NfdRevision::R0);
+        let serialized = to_bytes_r0(&disk);
+        assert_eq!(serialized.len(), original.len());
+        // Header (sector map + magic) and data should match for this minimal case.
+        assert_eq!(serialized, original);
+    }
+
+    #[test]
+    fn r0_after_sector_mutation() {
+        let original = build_minimal_r0(0xAB);
+        let (mut disk, _) = from_bytes(&original).unwrap();
+
+        let sector = disk.find_sector_on_track_index_mut(0, 0, 0, 1, 1).unwrap();
+        sector.data.fill(0x77);
+
+        let serialized = to_bytes_r0(&disk);
+        let (reparsed, _) = from_bytes(&serialized).unwrap();
+        let s = reparsed.find_sector(0, 0, 1, 1).unwrap();
+        assert!(s.data.iter().all(|&b| b == 0x77));
+    }
+
+    /// Builds a minimal NFD R1 image with two sectors on track 0
+    /// (C=0 H=0 R=1, R=2; both 256 bytes; no diag/retry).
+    fn build_minimal_r1(fill1: u8, fill2: u8) -> Vec<u8> {
+        let track_metadata_size = R1_TRACK_HEADER_SIZE + 2 * SECTOR_ENTRY_SIZE;
+        let header_section_size = COMMON_HEADER_SIZE + R1_TRACK_TABLE_SIZE + track_metadata_size;
+        let total = header_section_size + 2 * 256;
+        let mut out = vec![0u8; total];
+
+        out[..15].copy_from_slice(NFD_R1_MAGIC);
+        out[0x110..0x114].copy_from_slice(&(header_section_size as u32).to_le_bytes());
+
+        // Track-offset table: track 0 starts after the table.
+        let track_meta_offset = COMMON_HEADER_SIZE + R1_TRACK_TABLE_SIZE;
+        out[COMMON_HEADER_SIZE..COMMON_HEADER_SIZE + 4]
+            .copy_from_slice(&(track_meta_offset as u32).to_le_bytes());
+
+        // Track header: 2 sectors, 0 diag.
+        out[track_meta_offset..track_meta_offset + 2].copy_from_slice(&2u16.to_le_bytes());
+        // wDiag = 0 (already zero).
+
+        // Sector entries.
+        let entry0 = track_meta_offset + R1_TRACK_HEADER_SIZE;
+        out[entry0] = 0;
+        out[entry0 + 1] = 0;
+        out[entry0 + 2] = 1; // R
+        out[entry0 + 3] = 1; // N
+        out[entry0 + 11] = 0x90;
+        let entry1 = entry0 + SECTOR_ENTRY_SIZE;
+        out[entry1] = 0;
+        out[entry1 + 1] = 0;
+        out[entry1 + 2] = 2; // R
+        out[entry1 + 3] = 1;
+        out[entry1 + 11] = 0x90;
+
+        // Sector data.
+        let data1_offset = header_section_size;
+        for byte in &mut out[data1_offset..data1_offset + 256] {
+            *byte = fill1;
+        }
+        let data2_offset = data1_offset + 256;
+        for byte in &mut out[data2_offset..data2_offset + 256] {
+            *byte = fill2;
+        }
+
+        out
+    }
+
+    #[test]
+    fn r1_roundtrip_unchanged() {
+        let original = build_minimal_r1(0xAA, 0xBB);
+        let (disk, rev) = from_bytes(&original).unwrap();
+        assert_eq!(rev, NfdRevision::R1);
+        let serialized = to_bytes_r1(&disk);
+        assert_eq!(serialized, original);
+    }
+
+    #[test]
+    fn r1_after_sector_mutation() {
+        let original = build_minimal_r1(0xAA, 0xBB);
+        let (mut disk, _) = from_bytes(&original).unwrap();
+
+        let sector = disk.find_sector_on_track_index_mut(0, 0, 0, 2, 1).unwrap();
+        sector.data.fill(0x55);
+
+        let serialized = to_bytes_r1(&disk);
+        let (reparsed, _) = from_bytes(&serialized).unwrap();
+
+        let s1 = reparsed.find_sector(0, 0, 1, 1).unwrap();
+        assert!(s1.data.iter().all(|&b| b == 0xAA));
+        let s2 = reparsed.find_sector(0, 0, 2, 1).unwrap();
+        assert!(s2.data.iter().all(|&b| b == 0x55));
     }
 }

--- a/crates/device/src/ide.rs
+++ b/crates/device/src/ide.rs
@@ -15,14 +15,13 @@ mod lle;
 
 use std::{cell::Cell, path::PathBuf};
 
-use common::error;
 pub use lle::{IdeAction, IdePhase};
 
 pub use crate::disk_hle::{buffer_address, drive_index, sector_position, transfer_size};
 use crate::{
     cd_audio::CdAudioPlayer,
     cdrom::CdImage,
-    disk::{HddGeometry, HddImage},
+    disk::{HddGeometry, HddImage, MountedHdd},
 };
 
 /// Size of the expansion ROM window mapped at 0xD8000.
@@ -39,9 +38,7 @@ pub struct IdeController {
     yield_requested: Cell<bool>,
     rom: Option<Box<[u8; ROM_SIZE]>>,
     // Channel 0: HDD drives (master/slave).
-    drives: [Option<HddImage>; 2],
-    drive_paths: [Option<PathBuf>; 2],
-    drive_dirty: [bool; 2],
+    drives: [Option<MountedHdd>; 2],
     // Channel 1: ATAPI CD-ROM.
     cdrom: Option<CdImage>,
     atapi_state: atapi::AtapiState,
@@ -64,8 +61,6 @@ impl IdeController {
             yield_requested: Cell::new(false),
             rom: None,
             drives: [None, None],
-            drive_paths: [None, None],
-            drive_dirty: [false, false],
             cdrom: None,
             atapi_state: atapi::AtapiState::new(),
             cd_audio_player: CdAudioPlayer::new(output_sample_rate),
@@ -77,9 +72,10 @@ impl IdeController {
     /// Installs the expansion ROM on the first insertion.
     pub fn insert_drive(&mut self, drive: usize, image: HddImage, path: Option<PathBuf>) {
         let sector_size = image.geometry.sector_size as usize;
-        self.drives[drive] = Some(image);
-        self.drive_paths[drive] = path;
-        self.drive_dirty[drive] = false;
+        if let Some(mounted) = self.drives[drive].take() {
+            mounted.eject();
+        }
+        self.drives[drive] = Some(MountedHdd::new(image, path));
         self.lle_controller
             .set_drive_sector_size(0, drive, sector_size);
         self.install_rom();
@@ -167,34 +163,10 @@ impl IdeController {
         }
     }
 
-    /// Writes the HDD image back to its file if it has been modified.
+    /// Flushes the HDD image to its source file.
     pub fn flush_drive(&mut self, drive: usize) {
-        if !self.drive_dirty[drive] {
-            return;
-        }
-        if let (Some(image), Some(path)) = (&self.drives[drive], &self.drive_paths[drive]) {
-            let data = image.to_bytes();
-            let tmp_path = path.with_extension("tmp");
-            match std::fs::write(&tmp_path, &data) {
-                Ok(()) => match std::fs::rename(&tmp_path, path) {
-                    Ok(()) => {
-                        self.drive_dirty[drive] = false;
-                    }
-                    Err(err) => {
-                        error!(
-                            "Failed to rename temp HDD image for IDE drive {drive} to {}: {err}",
-                            path.display()
-                        );
-                        let _ = std::fs::remove_file(&tmp_path);
-                    }
-                },
-                Err(err) => {
-                    error!(
-                        "Failed to write HDD image for IDE drive {drive} to {}: {err}",
-                        path.display()
-                    );
-                }
-            }
+        if let Some(mounted) = self.drives[drive].as_mut() {
+            mounted.flush();
         }
     }
 
@@ -245,7 +217,6 @@ impl IdeController {
     }
 
     /// Executes a BIOS write: reads from memory via closure and writes sectors.
-    /// Marks the drive dirty on success.
     pub fn execute_write(
         &mut self,
         drive_idx: usize,
@@ -256,9 +227,9 @@ impl IdeController {
     ) -> u8 {
         let sector_size = self.drives[drive_idx]
             .as_ref()
-            .map(|d| d.geometry.sector_size)
+            .map(|d| d.geometry().sector_size)
             .unwrap_or(512);
-        let status = match sector_size {
+        match sector_size {
             256 => crate::disk_hle::execute_write::<256>(
                 drive_idx,
                 xfer_size,
@@ -275,11 +246,7 @@ impl IdeController {
                 &mut self.drives,
                 read_byte,
             ),
-        };
-        if status == 0x00 {
-            self.drive_dirty[drive_idx] = true;
         }
-        status
     }
 
     /// Executes a BIOS sense: returns the IDE media type.
@@ -310,13 +277,9 @@ impl IdeController {
         crate::disk_hle::execute_init(&self.drives, current_equip)
     }
 
-    /// Executes a BIOS format on a track. Marks the drive dirty on success.
+    /// Executes a BIOS format on a track.
     pub fn execute_format(&mut self, drive_idx: usize, sector_pos: u32) -> u8 {
-        let status = crate::disk_hle::execute_format(drive_idx, sector_pos, &mut self.drives);
-        if status == 0x00 {
-            self.drive_dirty[drive_idx] = true;
-        }
-        status
+        crate::disk_hle::execute_format(drive_idx, sector_pos, &mut self.drives)
     }
 
     /// Executes a BIOS mode set (function 0x0E): returns 0x00 if the drive
@@ -374,7 +337,7 @@ impl IdeController {
 
     /// Returns the geometry of the selected drive, if present.
     pub fn drive_geometry(&self, drive: usize) -> Option<HddGeometry> {
-        self.drives.get(drive)?.as_ref().map(|drive| drive.geometry)
+        self.drives.get(drive)?.as_ref().map(MountedHdd::geometry)
     }
 
     /// Reads a single sector by LBA, returning a copy of the data.
@@ -386,15 +349,12 @@ impl IdeController {
             .map(|data| data.to_vec())
     }
 
-    /// Writes a single sector by LBA. Returns true on success.
+    /// Writes a single sector by LBA.
     pub fn write_sector_raw(&mut self, drive: usize, lba: u32, data: &[u8]) -> bool {
-        if let Some(Some(image)) = self.drives.get_mut(drive)
-            && image.write_sector(lba, data)
-        {
-            self.drive_dirty[drive] = true;
-            return true;
+        match self.drives.get_mut(drive).and_then(Option::as_mut) {
+            Some(mounted) => mounted.write_sector(lba, data),
+            None => false,
         }
-        false
     }
 
     /// Returns the sector size for the given drive.
@@ -402,7 +362,7 @@ impl IdeController {
         self.drives
             .get(drive)?
             .as_ref()
-            .map(|image| image.geometry.sector_size)
+            .map(|m| m.geometry().sector_size)
     }
 
     /// Returns the total sector count for the given drive.
@@ -410,7 +370,7 @@ impl IdeController {
         self.drives
             .get(drive)?
             .as_ref()
-            .map(|image| image.geometry.total_sectors())
+            .map(|m| m.geometry().total_sectors())
     }
 
     /// Reads a byte from the expansion ROM at the given offset.
@@ -460,12 +420,7 @@ impl IdeController {
         if self.lle_controller.is_atapi_channel_active() {
             return self.atapi_write_data_word(value);
         }
-        let action = self.lle_controller.write_data_word(value, &mut self.drives);
-        if matches!(action, IdeAction::ScheduleCompletion) {
-            let selected = self.lle_controller.selected_hdd_drive();
-            self.drive_dirty[selected] = true;
-        }
-        action
+        self.lle_controller.write_data_word(value, &mut self.drives)
     }
 
     /// Reads the error register (port 0x0642). Clears ERR bit in status.

--- a/crates/device/src/ide/hle.rs
+++ b/crates/device/src/ide/hle.rs
@@ -4,16 +4,16 @@
 //! `crate::disk_hle`. This module contains IDE-specific functions:
 //! sense (returns 0x0F for IDE) and motor control extensions (D0h/E0h/F0h).
 
-use crate::disk::HddImage;
+use crate::disk::MountedHdd;
 
 /// Executes a BIOS sense operation: returns the media type.
 /// For SASI-compatible images (256-byte sectors with standard SASI geometry),
 /// returns the SASI media type code. Otherwise returns 0x0F (IDE).
-pub(super) fn execute_sense(drive_idx: usize, drives: &[Option<HddImage>; 2]) -> u8 {
+pub(super) fn execute_sense(drive_idx: usize, drives: &[Option<MountedHdd>; 2]) -> u8 {
     let Some(drive) = &drives[drive_idx] else {
         return 0x60;
     };
-    if let Some(sense_code) = drive.geometry.sasi_new_sense_type() {
+    if let Some(sense_code) = drive.geometry().sasi_new_sense_type() {
         return sense_code;
     }
     0x0F
@@ -21,7 +21,7 @@ pub(super) fn execute_sense(drive_idx: usize, drives: &[Option<HddImage>; 2]) ->
 
 /// Executes an IDE-specific Check Power Mode (function D0h).
 /// Returns 0x00 on success, 0x40 if drive absent.
-pub(super) fn execute_check_power_mode(drive_idx: usize, drives: &[Option<HddImage>; 2]) -> u8 {
+pub(super) fn execute_check_power_mode(drive_idx: usize, drives: &[Option<MountedHdd>; 2]) -> u8 {
     if drives[drive_idx].is_some() {
         0x00
     } else {
@@ -32,7 +32,7 @@ pub(super) fn execute_check_power_mode(drive_idx: usize, drives: &[Option<HddIma
 /// Executes an IDE-specific Motor ON (function E0h).
 /// Returns 0x00 on success, 0x40 if drive absent.
 /// No-op in emulation since virtual drives are always ready.
-pub(super) fn execute_motor_on(drive_idx: usize, drives: &[Option<HddImage>; 2]) -> u8 {
+pub(super) fn execute_motor_on(drive_idx: usize, drives: &[Option<MountedHdd>; 2]) -> u8 {
     if drives[drive_idx].is_some() {
         0x00
     } else {
@@ -43,7 +43,7 @@ pub(super) fn execute_motor_on(drive_idx: usize, drives: &[Option<HddImage>; 2])
 /// Executes an IDE-specific Motor OFF (function F0h).
 /// Returns 0x00 on success, 0x40 if drive absent.
 /// No-op in emulation since virtual drives are always ready.
-pub(super) fn execute_motor_off(drive_idx: usize, drives: &[Option<HddImage>; 2]) -> u8 {
+pub(super) fn execute_motor_off(drive_idx: usize, drives: &[Option<MountedHdd>; 2]) -> u8 {
     if drives[drive_idx].is_some() {
         0x00
     } else {
@@ -54,9 +54,9 @@ pub(super) fn execute_motor_off(drive_idx: usize, drives: &[Option<HddImage>; 2]
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::disk::{HddFormat, HddGeometry};
+    use crate::disk::{HddFormat, HddGeometry, HddImage};
 
-    fn make_test_drive() -> HddImage {
+    fn make_test_drive() -> MountedHdd {
         let geometry = HddGeometry {
             cylinders: 20,
             heads: 4,
@@ -64,10 +64,10 @@ mod tests {
             sector_size: 512,
         };
         let data = vec![0u8; geometry.total_bytes() as usize];
-        HddImage::from_raw(geometry, HddFormat::Hdi, data)
+        MountedHdd::new(HddImage::from_raw(geometry, HddFormat::Hdi, data), None)
     }
 
-    fn make_sasi_compat_drive() -> HddImage {
+    fn make_sasi_compat_drive() -> MountedHdd {
         let geometry = HddGeometry {
             cylinders: 153,
             heads: 4,
@@ -75,54 +75,54 @@ mod tests {
             sector_size: 256,
         };
         let data = vec![0u8; geometry.total_bytes() as usize];
-        HddImage::from_raw(geometry, HddFormat::Thd, data)
+        MountedHdd::new(HddImage::from_raw(geometry, HddFormat::Thd, data), None)
     }
 
     #[test]
     fn sense_returns_ide_type() {
-        let drives: [Option<HddImage>; 2] = [Some(make_test_drive()), None];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_test_drive()), None];
         assert_eq!(execute_sense(0, &drives), 0x0F);
     }
 
     #[test]
     fn sense_returns_sasi_type_for_sasi_compat_image() {
-        let drives: [Option<HddImage>; 2] = [Some(make_sasi_compat_drive()), None];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_sasi_compat_drive()), None];
         assert_eq!(execute_sense(0, &drives), 0x00);
     }
 
     #[test]
     fn check_power_mode_with_drive() {
-        let drives: [Option<HddImage>; 2] = [Some(make_test_drive()), None];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_test_drive()), None];
         assert_eq!(execute_check_power_mode(0, &drives), 0x00);
     }
 
     #[test]
     fn check_power_mode_without_drive() {
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
         assert_eq!(execute_check_power_mode(0, &drives), 0x40);
     }
 
     #[test]
     fn motor_on_with_drive() {
-        let drives: [Option<HddImage>; 2] = [Some(make_test_drive()), None];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_test_drive()), None];
         assert_eq!(execute_motor_on(0, &drives), 0x00);
     }
 
     #[test]
     fn motor_on_without_drive() {
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
         assert_eq!(execute_motor_on(0, &drives), 0x40);
     }
 
     #[test]
     fn motor_off_with_drive() {
-        let drives: [Option<HddImage>; 2] = [Some(make_test_drive()), None];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_test_drive()), None];
         assert_eq!(execute_motor_off(0, &drives), 0x00);
     }
 
     #[test]
     fn motor_off_without_drive() {
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
         assert_eq!(execute_motor_off(0, &drives), 0x40);
     }
 }

--- a/crates/device/src/ide/lle.rs
+++ b/crates/device/src/ide/lle.rs
@@ -13,7 +13,7 @@
 //! for completion interrupts.
 
 use super::atapi::{self, AtapiState};
-use crate::disk::{HddGeometry, HddImage};
+use crate::disk::{HddGeometry, MountedHdd};
 
 /// IDE controller phase (data transfer state).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -206,11 +206,6 @@ impl Controller {
         self.channels[self.active_channel].phase
     }
 
-    /// Returns the currently selected drive index (0 or 1) on channel 0.
-    pub(super) fn selected_hdd_drive(&self) -> usize {
-        self.channels[0].selected_drive
-    }
-
     /// Returns the currently active channel index (0 or 1).
     #[cfg(test)]
     pub(super) fn active_channel(&self) -> usize {
@@ -260,7 +255,7 @@ impl Controller {
     }
 
     /// Reads the 16-bit data register (port 0x0640).
-    pub(super) fn read_data_word(&mut self, drives: &[Option<HddImage>; 2]) -> (u16, IdeAction) {
+    pub(super) fn read_data_word(&mut self, drives: &[Option<MountedHdd>; 2]) -> (u16, IdeAction) {
         let ch = self.active_channel;
         if self.channels[ch].phase != IdePhase::DataIn {
             return (0xFFFF, IdeAction::None);
@@ -299,7 +294,7 @@ impl Controller {
     pub(super) fn write_data_word(
         &mut self,
         value: u16,
-        drives: &mut [Option<HddImage>; 2],
+        drives: &mut [Option<MountedHdd>; 2],
     ) -> IdeAction {
         let ch = self.active_channel;
         if self.channels[ch].phase != IdePhase::DataOut {
@@ -441,7 +436,7 @@ impl Controller {
     pub(super) fn write_command(
         &mut self,
         command: u8,
-        drives: &[Option<HddImage>; 2],
+        drives: &[Option<MountedHdd>; 2],
     ) -> IdeAction {
         // Channel 1 has no HDD drives attached - commands abort until ATAPI
         // support is wired in.
@@ -606,7 +601,7 @@ impl Controller {
                     return self.abort_command();
                 }
                 let sel = self.channels[self.active_channel].selected_drive;
-                let geometry = drives[sel].as_ref().unwrap().geometry;
+                let geometry = drives[sel].as_ref().unwrap().geometry();
                 self.build_identify_data(geometry);
                 let ch = self.channel_mut();
                 ch.phase = IdePhase::DataIn;
@@ -664,7 +659,7 @@ impl Controller {
     /// a slave device. The computed value is stored back into bank[0].
     pub(super) fn read_bank0_status(
         &mut self,
-        drives: &[Option<HddImage>; 2],
+        drives: &[Option<MountedHdd>; 2],
         has_cdrom: bool,
     ) -> u8 {
         // Compatibility mode: CD-ROM present only on channel 1 master.
@@ -710,7 +705,7 @@ impl Controller {
 
     /// Reads the additional status register (port 0x0435).
     /// Bit 1: 0 = IDE HDD present, 1 = no IDE HDD.
-    pub(super) fn read_additional_status(&self, drives: &[Option<HddImage>; 2]) -> u8 {
+    pub(super) fn read_additional_status(&self, drives: &[Option<MountedHdd>; 2]) -> u8 {
         let has_hdd = drives[0].is_some() || drives[1].is_some();
         if has_hdd { 0x00 } else { 0x02 }
     }
@@ -737,7 +732,7 @@ impl Controller {
         should_interrupt
     }
 
-    fn execute_diagnostic(&mut self, drives: &[Option<HddImage>; 2]) -> IdeAction {
+    fn execute_diagnostic(&mut self, drives: &[Option<MountedHdd>; 2]) -> IdeAction {
         let ch = &mut self.channels[self.active_channel];
         for (i, drive_image) in drives.iter().enumerate() {
             ch.drives[i].reset();
@@ -841,9 +836,9 @@ impl Controller {
         }
     }
 
-    fn start_read(&mut self, drives: &[Option<HddImage>; 2], multiple: bool) -> IdeAction {
+    fn start_read(&mut self, drives: &[Option<MountedHdd>; 2], multiple: bool) -> IdeAction {
         let sel = self.channels[self.active_channel].selected_drive;
-        let geometry = drives[sel].as_ref().unwrap().geometry;
+        let geometry = drives[sel].as_ref().unwrap().geometry();
         let lba = self.get_current_sector(&geometry);
         let sector_count = self.channel().drive().sector_count;
         let count = if sector_count == 0 {
@@ -879,7 +874,7 @@ impl Controller {
         IdeAction::ScheduleCompletion
     }
 
-    fn check_data_in_complete(&mut self, drives: &[Option<HddImage>; 2]) -> IdeAction {
+    fn check_data_in_complete(&mut self, drives: &[Option<MountedHdd>; 2]) -> IdeAction {
         let ch_idx = self.active_channel;
         let sel = self.channels[ch_idx].selected_drive;
         let drive = &self.channels[ch_idx].drives[sel];
@@ -890,7 +885,7 @@ impl Controller {
         if drive.sectors_pending == 0 {
             let data_in_updates_sector_registers = drive.data_in_updates_sector_registers;
             if data_in_updates_sector_registers && let Some(drive) = drives[sel].as_ref() {
-                let geometry = drive.geometry;
+                let geometry = drive.geometry();
                 self.advance_sector_address(&geometry);
             }
             let ch = &mut self.channels[ch_idx];
@@ -905,7 +900,7 @@ impl Controller {
             return IdeAction::ScheduleCompletion;
         }
 
-        let geometry = drives[sel].as_ref().unwrap().geometry;
+        let geometry = drives[sel].as_ref().unwrap().geometry();
         self.advance_sector_address(&geometry);
         let lba = self.get_current_sector(&geometry);
         let Some(sector_data) = drives[sel].as_ref().unwrap().read_sector(lba) else {
@@ -964,10 +959,10 @@ impl Controller {
         IdeAction::None
     }
 
-    fn handle_write_complete(&mut self, drives: &mut [Option<HddImage>; 2]) -> IdeAction {
+    fn handle_write_complete(&mut self, drives: &mut [Option<MountedHdd>; 2]) -> IdeAction {
         let ch_idx = self.active_channel;
         let sel = self.channels[ch_idx].selected_drive;
-        let geometry = drives[sel].as_ref().unwrap().geometry;
+        let geometry = drives[sel].as_ref().unwrap().geometry();
         let lba = self.get_current_sector(&geometry);
 
         let drive = &self.channels[ch_idx].drives[sel];
@@ -1226,7 +1221,7 @@ mod tests {
     use super::*;
     use crate::disk::{HddFormat, HddGeometry, HddImage};
 
-    fn make_test_drive() -> HddImage {
+    fn make_test_drive() -> MountedHdd {
         let geometry = HddGeometry {
             cylinders: 20,
             heads: 4,
@@ -1240,10 +1235,10 @@ mod tests {
             data[offset] = (lba >> 8) as u8;
             data[offset + 1] = lba as u8;
         }
-        HddImage::from_raw(geometry, HddFormat::Hdi, data)
+        MountedHdd::new(HddImage::from_raw(geometry, HddFormat::Hdi, data), None)
     }
 
-    fn make_drives(drive0: Option<HddImage>) -> [Option<HddImage>; 2] {
+    fn make_drives(drive0: Option<MountedHdd>) -> [Option<MountedHdd>; 2] {
         [drive0, None]
     }
 
@@ -1355,7 +1350,7 @@ mod tests {
     #[test]
     fn write_sector() {
         let mut controller = Controller::new();
-        let mut drives: [Option<HddImage>; 2] = [Some(make_test_drive()), None];
+        let mut drives: [Option<MountedHdd>; 2] = [Some(make_test_drive()), None];
 
         // LBA mode, sector 10
         controller.write_sector_number(10);
@@ -1479,7 +1474,7 @@ mod tests {
     #[test]
     fn no_drive_returns_error() {
         let mut controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
 
         let action = controller.write_command(0x20, &drives);
         assert_eq!(action, IdeAction::ScheduleCompletion);
@@ -1569,7 +1564,7 @@ mod tests {
     #[test]
     fn bank0_status_slave_sets_bit6() {
         let mut controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [Some(make_test_drive()), Some(make_test_drive())];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_test_drive()), Some(make_test_drive())];
         // Non-compmode with slave: returns 0x41 (bit 0 + bit 6).
         assert_eq!(controller.read_bank0_status(&drives, false), 0x41);
     }
@@ -1588,7 +1583,7 @@ mod tests {
     fn bank0_status_no_device_returns_raw_bank() {
         let mut controller = Controller::new();
         controller.write_bank(0, 0x31);
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
         // No device on channel 0: returns raw bank[0].
         assert_eq!(controller.read_bank0_status(&drives, false), 0x31);
     }
@@ -1596,7 +1591,7 @@ mod tests {
     #[test]
     fn reading_error_clears_err_status_bit() {
         let mut controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
 
         controller.write_command(0x20, &drives);
         assert_ne!(controller.read_alt_status() & STATUS_ERR, 0);
@@ -1608,7 +1603,7 @@ mod tests {
     #[test]
     fn reading_error_preserves_other_status_bits() {
         let mut controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
 
         controller.write_command(0x20, &drives);
         let status = controller.read_alt_status();
@@ -1626,7 +1621,7 @@ mod tests {
     #[test]
     fn additional_status_no_hdd() {
         let controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
         assert_eq!(controller.read_additional_status(&drives), 0x02);
     }
 
@@ -1723,7 +1718,7 @@ mod tests {
     #[test]
     fn identify_device_slave_word93() {
         let mut controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [Some(make_test_drive()), Some(make_test_drive())];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_test_drive()), Some(make_test_drive())];
 
         controller.write_device_head(0xF0);
         controller.write_command(0xEC, &drives);
@@ -1738,7 +1733,7 @@ mod tests {
     #[test]
     fn execute_diagnostic_with_both_drives() {
         let mut controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [Some(make_test_drive()), Some(make_test_drive())];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_test_drive()), Some(make_test_drive())];
 
         let action = controller.write_command(0x90, &drives);
         assert_eq!(action, IdeAction::ScheduleCompletion);
@@ -1761,7 +1756,7 @@ mod tests {
     #[test]
     fn execute_diagnostic_no_drives() {
         let mut controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
 
         controller.write_command(0x90, &drives);
         assert_eq!(controller.channels[0].drives[0].error, 0x80);
@@ -1792,7 +1787,7 @@ mod tests {
     #[test]
     fn seek_command_aborts_without_drive() {
         let mut controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
 
         let action = controller.write_command(0x70, &drives);
         assert_eq!(action, IdeAction::ScheduleCompletion);
@@ -1959,7 +1954,7 @@ mod tests {
     #[test]
     fn device_reset_both_drives_present() {
         let mut controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [Some(make_test_drive()), Some(make_test_drive())];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_test_drive()), Some(make_test_drive())];
 
         let action = controller.write_command(0x08, &drives);
         assert_eq!(action, IdeAction::ScheduleCompletion);
@@ -1970,7 +1965,7 @@ mod tests {
     #[test]
     fn device_reset_no_drives() {
         let mut controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
 
         let action = controller.write_command(0x08, &drives);
         assert_eq!(action, IdeAction::ScheduleCompletion);
@@ -2081,7 +2076,7 @@ mod tests {
     #[test]
     fn channel1_commands_abort_without_atapi() {
         let mut controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
 
         // Switch to channel 1.
         controller.write_bank(1, 0x01);

--- a/crates/device/src/lib.rs
+++ b/crates/device/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cd_audio;
 pub mod cdrom;
 pub mod cgrom;
 pub mod disk;
+pub mod disk_backend;
 pub mod disk_hle;
 pub mod display_control;
 pub mod egc;

--- a/crates/device/src/sasi.rs
+++ b/crates/device/src/sasi.rs
@@ -10,10 +10,9 @@ mod lle;
 
 use std::{cell::Cell, path::PathBuf};
 
-use common::error;
 pub use lle::{SasiAction, SasiPhase};
 
-use crate::disk::{HddGeometry, HddImage};
+use crate::disk::{HddGeometry, HddImage, MountedHdd};
 pub use crate::disk_hle::{buffer_address, drive_index, sector_position, transfer_size};
 
 /// Size of the expansion ROM window mapped at 0xD7000.
@@ -40,9 +39,7 @@ pub struct SasiController {
     hle_pending: bool,
     yield_requested: Cell<bool>,
     rom: Option<Box<[u8; ROM_SIZE]>>,
-    drives: [Option<HddImage>; 2],
-    drive_paths: [Option<PathBuf>; 2],
-    drive_dirty: [bool; 2],
+    drives: [Option<MountedHdd>; 2],
 }
 
 impl Default for SasiController {
@@ -60,51 +57,26 @@ impl SasiController {
             yield_requested: Cell::new(false),
             rom: None,
             drives: [None, None],
-            drive_paths: [None, None],
-            drive_dirty: [false, false],
         }
     }
 
     /// Inserts a hard disk image into the specified drive (0-1).
     /// Installs the expansion ROM on the first insertion.
     pub fn insert_drive(&mut self, drive: usize, image: HddImage, path: Option<PathBuf>) {
-        self.drives[drive] = Some(image);
-        self.drive_paths[drive] = path;
-        self.drive_dirty[drive] = false;
+        if let Some(mounted) = self.drives[drive].take() {
+            mounted.eject();
+        }
+        self.drives[drive] = Some(MountedHdd::new(image, path));
         if self.rom.is_none() {
             self.rom = Some(Box::new(*ROM_IMAGE));
         }
         self.refresh_parameter_tables(drive);
     }
 
-    /// Writes the HDD image back to its file if it has been modified.
+    /// Flushes the HDD image to its source file.
     pub fn flush_drive(&mut self, drive: usize) {
-        if !self.drive_dirty[drive] {
-            return;
-        }
-        if let (Some(image), Some(path)) = (&self.drives[drive], &self.drive_paths[drive]) {
-            let data = image.to_bytes();
-            let tmp_path = path.with_extension("tmp");
-            match std::fs::write(&tmp_path, &data) {
-                Ok(()) => match std::fs::rename(&tmp_path, path) {
-                    Ok(()) => {
-                        self.drive_dirty[drive] = false;
-                    }
-                    Err(err) => {
-                        error!(
-                            "Failed to rename temp HDD image for drive {drive} to {}: {err}",
-                            path.display()
-                        );
-                        let _ = std::fs::remove_file(&tmp_path);
-                    }
-                },
-                Err(err) => {
-                    error!(
-                        "Failed to write HDD image for drive {drive} to {}: {err}",
-                        path.display()
-                    );
-                }
-            }
+        if let Some(mounted) = self.drives[drive].as_mut() {
+            mounted.flush();
         }
     }
 
@@ -149,7 +121,6 @@ impl SasiController {
     }
 
     /// Executes a BIOS write: reads from memory via closure and writes sectors.
-    /// Marks the drive dirty on success.
     pub fn execute_write(
         &mut self,
         drive_idx: usize,
@@ -158,18 +129,14 @@ impl SasiController {
         buf_addr: u32,
         read_byte: impl Fn(u32) -> u8,
     ) -> u8 {
-        let status = crate::disk_hle::execute_write::<256>(
+        crate::disk_hle::execute_write::<256>(
             drive_idx,
             xfer_size,
             sector_pos,
             buf_addr,
             &mut self.drives,
             read_byte,
-        );
-        if status == 0x00 {
-            self.drive_dirty[drive_idx] = true;
-        }
-        status
+        )
     }
 
     /// Executes a BIOS sense: returns the SASI media type.
@@ -183,13 +150,9 @@ impl SasiController {
         crate::disk_hle::execute_init(&self.drives, current_equip)
     }
 
-    /// Executes a BIOS format on a track. Marks the drive dirty on success.
+    /// Executes a BIOS format on a track.
     pub fn execute_format(&mut self, drive_idx: usize, sector_pos: u32) -> u8 {
-        let status = crate::disk_hle::execute_format(drive_idx, sector_pos, &mut self.drives);
-        if status == 0x00 {
-            self.drive_dirty[drive_idx] = true;
-        }
-        status
+        crate::disk_hle::execute_format(drive_idx, sector_pos, &mut self.drives)
     }
 
     /// Executes a BIOS mode set (function 0x0E): selects drive mode
@@ -231,7 +194,7 @@ impl SasiController {
 
     /// Returns the geometry of the selected drive, if present.
     pub fn drive_geometry(&self, drive: usize) -> Option<HddGeometry> {
-        self.drives.get(drive)?.as_ref().map(|drive| drive.geometry)
+        self.drives.get(drive)?.as_ref().map(MountedHdd::geometry)
     }
 
     /// Reads a single sector by LBA, returning a copy of the data.
@@ -243,15 +206,12 @@ impl SasiController {
             .map(|data| data.to_vec())
     }
 
-    /// Writes a single sector by LBA. Returns true on success.
+    /// Writes a single sector by LBA.
     pub fn write_sector_raw(&mut self, drive: usize, lba: u32, data: &[u8]) -> bool {
-        if let Some(Some(image)) = self.drives.get_mut(drive)
-            && image.write_sector(lba, data)
-        {
-            self.drive_dirty[drive] = true;
-            return true;
+        match self.drives.get_mut(drive).and_then(Option::as_mut) {
+            Some(mounted) => mounted.write_sector(lba, data),
+            None => false,
         }
-        false
     }
 
     /// Returns the sector size for the given drive.
@@ -259,7 +219,7 @@ impl SasiController {
         self.drives
             .get(drive)?
             .as_ref()
-            .map(|image| image.geometry.sector_size)
+            .map(|m| m.geometry().sector_size)
     }
 
     /// Returns the total sector count for the given drive.
@@ -267,7 +227,7 @@ impl SasiController {
         self.drives
             .get(drive)?
             .as_ref()
-            .map(|image| image.geometry.total_sectors())
+            .map(|m| m.geometry().total_sectors())
     }
 
     /// Reads a byte from the expansion ROM at the given offset.
@@ -306,11 +266,10 @@ impl SasiController {
     /// Handles pending sector writes internally.
     pub fn write_data(&mut self, value: u8) -> SasiAction {
         let action = self.lle_controller.write_data(value, &self.drives);
-        if let Some((unit, sector, data)) = self.lle_controller.pending_write_data() {
-            if let Some(drive) = &mut self.drives[unit as usize] {
-                drive.write_sector(sector, data);
-            }
-            self.drive_dirty[unit as usize] = true;
+        if let Some((unit, sector, data)) = self.lle_controller.pending_write_data()
+            && let Some(drive) = &mut self.drives[unit as usize]
+        {
+            drive.write_sector(sector, data);
         }
         if action == SasiAction::FormatTrack {
             self.do_format_track();
@@ -325,7 +284,6 @@ impl SasiController {
         let sector = self.lle_controller.current_sector();
         if let Some(drive) = &mut self.drives[unit] {
             drive.format_track(sector);
-            self.drive_dirty[unit] = true;
         }
     }
 
@@ -360,13 +318,8 @@ impl SasiController {
     }
 
     /// DMA write: transfers one byte from host to disk.
-    /// Marks the drive dirty when a sector write completes.
     pub fn dma_write_byte(&mut self, value: u8) -> SasiAction {
-        let action = self.lle_controller.dma_write_byte(value, &mut self.drives);
-        if matches!(action, SasiAction::ScheduleCompletion) {
-            self.drive_dirty[self.lle_controller.current_unit() as usize] = true;
-        }
-        action
+        self.lle_controller.dma_write_byte(value, &mut self.drives)
     }
 
     /// Called when the scheduled completion event fires.
@@ -379,9 +332,10 @@ impl SasiController {
         let Some(rom) = self.rom.as_mut() else {
             return;
         };
-        let Some(image) = &self.drives[drive] else {
+        let Some(mounted) = &self.drives[drive] else {
             return;
         };
+        let geometry = mounted.geometry();
 
         let full_offset = match drive {
             0 => PARAM_TABLE_D0_FULL_OFFSET,
@@ -390,11 +344,11 @@ impl SasiController {
         };
         let half_offset = full_offset + PARAM_TABLE_SIZE;
 
-        Self::write_parameter_table(rom.as_mut_slice(), full_offset, image);
-        Self::write_parameter_table(rom.as_mut_slice(), half_offset, image);
+        Self::write_parameter_table(rom.as_mut_slice(), full_offset, geometry);
+        Self::write_parameter_table(rom.as_mut_slice(), half_offset, geometry);
     }
 
-    fn write_parameter_table(rom: &mut [u8], offset: usize, image: &HddImage) {
+    fn write_parameter_table(rom: &mut [u8], offset: usize, geometry: HddGeometry) {
         if offset + PARAM_TABLE_SIZE > rom.len() {
             return;
         }
@@ -402,7 +356,6 @@ impl SasiController {
         let table = &mut rom[offset..offset + PARAM_TABLE_SIZE];
         table.fill(0x00);
 
-        let geometry = image.geometry;
         let cylinders_minus_one = geometry.cylinders.saturating_sub(1);
         let max_head_address = geometry.heads.saturating_sub(1);
         let legacy_sense = geometry.sasi_legacy_sense_type().unwrap_or(0x0F);
@@ -426,6 +379,22 @@ impl SasiController {
 mod tests {
     use super::*;
     use crate::disk::{HddFormat, HddGeometry};
+
+    fn tempfile_with(bytes: &[u8], suffix: &str) -> PathBuf {
+        let dir = std::env::temp_dir();
+        let unique = format!(
+            "neetan_sasi_test_{}_{}{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            suffix
+        );
+        let path = dir.join(unique);
+        std::fs::write(&path, bytes).expect("write temp file");
+        path
+    }
 
     fn make_test_drive() -> HddImage {
         let geometry = HddGeometry {
@@ -462,5 +431,24 @@ mod tests {
         assert_eq!(sasi.read_rom_byte(10), 0xAA);
         // ROM size code: 2 (= 2 * 512 = 1024 bytes).
         assert_eq!(sasi.read_rom_byte(11), 0x02);
+    }
+
+    #[test]
+    fn flush_all_drives_persists_successful_write_before_drop() {
+        let image = make_test_drive();
+        let path = tempfile_with(&image.to_bytes(), ".thd");
+
+        let mut sasi = SasiController::new();
+        sasi.insert_drive(0, image, Some(path.clone()));
+
+        let pattern = vec![0x39u8; 256];
+        assert!(sasi.write_sector_raw(0, 12, &pattern));
+        sasi.flush_all_drives();
+
+        let raw = std::fs::read(&path).unwrap();
+        let offset = 256 + 12 * 256;
+        assert_eq!(&raw[offset..offset + 256], &pattern[..]);
+
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/crates/device/src/sasi/hle.rs
+++ b/crates/device/src/sasi/hle.rs
@@ -4,22 +4,22 @@
 //! `crate::disk_hle`. This module contains only the SASI-specific
 //! sense implementation.
 
-use crate::disk::HddImage;
+use crate::disk::MountedHdd;
 
 /// Executes a BIOS sense operation: returns the SASI media type.
-pub(super) fn execute_sense(drive_idx: usize, drives: &[Option<HddImage>; 2]) -> u8 {
+pub(super) fn execute_sense(drive_idx: usize, drives: &[Option<MountedHdd>; 2]) -> u8 {
     let Some(drive) = &drives[drive_idx] else {
         return 0x60;
     };
-    drive.geometry.sasi_media_type().unwrap_or(0x0F)
+    drive.geometry().sasi_media_type().unwrap_or(0x0F)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::disk::{HddFormat, HddGeometry};
+    use crate::disk::{HddFormat, HddGeometry, HddImage};
 
-    fn make_test_drive() -> HddImage {
+    fn make_test_drive() -> MountedHdd {
         let geometry = HddGeometry {
             cylinders: 153,
             heads: 4,
@@ -27,12 +27,12 @@ mod tests {
             sector_size: 256,
         };
         let data = vec![0u8; geometry.total_bytes() as usize];
-        HddImage::from_raw(geometry, HddFormat::Thd, data)
+        MountedHdd::new(HddImage::from_raw(geometry, HddFormat::Thd, data), None)
     }
 
     #[test]
     fn sense_returns_media_type() {
-        let drives: [Option<HddImage>; 2] = [Some(make_test_drive()), None];
+        let drives: [Option<MountedHdd>; 2] = [Some(make_test_drive()), None];
         let media_type = execute_sense(0, &drives);
         assert_eq!(media_type, 0); // 5 MB SASI = type 0
     }

--- a/crates/device/src/sasi/lle.rs
+++ b/crates/device/src/sasi/lle.rs
@@ -13,7 +13,7 @@
 //! protocol as a state machine: Free -> Command -> Read/Write -> Status ->
 //! Message -> Free.
 
-use crate::disk::HddImage;
+use crate::disk::MountedHdd;
 
 /// SASI controller phase (state machine).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -149,7 +149,7 @@ impl Controller {
     }
 
     /// Handles a write to port 0x80 (data register).
-    pub(super) fn write_data(&mut self, value: u8, drives: &[Option<HddImage>; 2]) -> SasiAction {
+    pub(super) fn write_data(&mut self, value: u8, drives: &[Option<MountedHdd>; 2]) -> SasiAction {
         match self.phase {
             SasiPhase::Free => {
                 if value == 1 {
@@ -190,7 +190,7 @@ impl Controller {
     }
 
     /// Handles a read from port 0x80 (data register).
-    pub(super) fn read_data(&mut self, drives: &[Option<HddImage>; 2]) -> u8 {
+    pub(super) fn read_data(&mut self, drives: &[Option<MountedHdd>; 2]) -> u8 {
         match self.phase {
             SasiPhase::Read => self.read_data_byte(drives),
             SasiPhase::Status => {
@@ -238,7 +238,7 @@ impl Controller {
     }
 
     /// Handles a read from port 0x82 (input status register).
-    pub(super) fn read_status(&mut self, drives: &[Option<HddImage>; 2]) -> u8 {
+    pub(super) fn read_status(&mut self, drives: &[Option<MountedHdd>; 2]) -> u8 {
         if self.output_control & OCR_NRDSW != 0 {
             self.read_bus_signals()
         } else {
@@ -257,7 +257,7 @@ impl Controller {
 
     /// Reads one byte from the sector buffer during DMA read.
     /// Called by the DMA controller for each byte transfer.
-    pub(super) fn dma_read_byte(&mut self, drives: &[Option<HddImage>; 2]) -> (u8, SasiAction) {
+    pub(super) fn dma_read_byte(&mut self, drives: &[Option<MountedHdd>; 2]) -> (u8, SasiAction) {
         if self.phase != SasiPhase::Read {
             return (0, SasiAction::None);
         }
@@ -276,7 +276,7 @@ impl Controller {
     pub(super) fn dma_write_byte(
         &mut self,
         value: u8,
-        drives: &mut [Option<HddImage>; 2],
+        drives: &mut [Option<MountedHdd>; 2],
     ) -> SasiAction {
         if self.phase != SasiPhase::Write {
             return SasiAction::None;
@@ -290,7 +290,7 @@ impl Controller {
         }
     }
 
-    fn execute_command(&mut self, drives: &[Option<HddImage>; 2]) -> SasiAction {
+    fn execute_command(&mut self, drives: &[Option<MountedHdd>; 2]) -> SasiAction {
         self.unit = (self.command[1] >> 5) & 1;
         let drive_present = drives[self.unit as usize].is_some();
 
@@ -342,7 +342,7 @@ impl Controller {
                 self.parse_sector_address();
                 self.status = 0;
                 if let Some(drive) = &drives[self.unit as usize]
-                    && self.sector < drive.geometry.total_sectors()
+                    && self.sector < drive.geometry().total_sectors()
                 {
                     self.set_completion(0x00);
                     return SasiAction::FormatTrack;
@@ -416,14 +416,14 @@ impl Controller {
         self.error_code = error_code;
     }
 
-    fn seek_read(&mut self, drives: &[Option<HddImage>; 2]) -> bool {
+    fn seek_read(&mut self, drives: &[Option<MountedHdd>; 2]) -> bool {
         self.data_position = 0;
         self.data_size = 0;
 
         let Some(drive) = &drives[self.unit as usize] else {
             return false;
         };
-        if drive.geometry.sector_size != 256 {
+        if drive.geometry().sector_size != 256 {
             return false;
         }
         let Some(sector_data) = drive.read_sector(self.sector) else {
@@ -434,7 +434,7 @@ impl Controller {
         true
     }
 
-    fn read_data_byte(&mut self, drives: &[Option<HddImage>; 2]) -> u8 {
+    fn read_data_byte(&mut self, drives: &[Option<MountedHdd>; 2]) -> u8 {
         if self.phase != SasiPhase::Read {
             return 0;
         }
@@ -458,7 +458,7 @@ impl Controller {
         ret
     }
 
-    fn handle_write_complete(&mut self, drives: &[Option<HddImage>; 2]) -> SasiAction {
+    fn handle_write_complete(&mut self, drives: &[Option<MountedHdd>; 2]) -> SasiAction {
         let drive_ok = drives[self.unit as usize].is_some();
         if !drive_ok {
             self.set_completion(0x0F);
@@ -478,7 +478,7 @@ impl Controller {
         }
     }
 
-    fn handle_write_complete_mut(&mut self, drives: &mut [Option<HddImage>; 2]) -> SasiAction {
+    fn handle_write_complete_mut(&mut self, drives: &mut [Option<MountedHdd>; 2]) -> SasiAction {
         let unit = self.unit as usize;
         let Some(drive) = &mut drives[unit] else {
             self.set_completion(0x0F);
@@ -534,19 +534,19 @@ impl Controller {
         ret
     }
 
-    fn read_capacity_indicators(&self, drives: &[Option<HddImage>; 2]) -> u8 {
+    fn read_capacity_indicators(&self, drives: &[Option<MountedHdd>; 2]) -> u8 {
         let mut ret = 0u8;
 
         // Drive 0 (SASI-1): bits 3-5
         if let Some(drive) = &drives[0] {
-            ret |= (drive.geometry.sasi_media_type().unwrap_or(7) & 7) << 3;
+            ret |= (drive.geometry().sasi_media_type().unwrap_or(7) & 7) << 3;
         } else {
             ret |= 7 << 3;
         }
 
         // Drive 1 (SASI-2): bits 0-2
         if let Some(drive) = &drives[1] {
-            ret |= drive.geometry.sasi_media_type().unwrap_or(7) & 7;
+            ret |= drive.geometry().sasi_media_type().unwrap_or(7) & 7;
         } else {
             ret |= 7;
         }
@@ -560,7 +560,7 @@ mod tests {
     use super::*;
     use crate::disk::{HddFormat, HddGeometry, HddImage};
 
-    fn make_test_drive() -> HddImage {
+    fn make_test_drive() -> MountedHdd {
         // 5 MB SASI: 153 cylinders, 4 heads, 33 sectors, 256 bytes/sector
         let geometry = HddGeometry {
             cylinders: 153,
@@ -576,10 +576,10 @@ mod tests {
             data[offset] = (lba >> 8) as u8;
             data[offset + 1] = lba as u8;
         }
-        HddImage::from_raw(geometry, HddFormat::Thd, data)
+        MountedHdd::new(HddImage::from_raw(geometry, HddFormat::Thd, data), None)
     }
 
-    fn make_drives(drive0: Option<HddImage>) -> [Option<HddImage>; 2] {
+    fn make_drives(drive0: Option<MountedHdd>) -> [Option<MountedHdd>; 2] {
         [drive0, None]
     }
 
@@ -771,7 +771,7 @@ mod tests {
     #[test]
     fn write_data_command() {
         let mut controller = Controller::new();
-        let mut drives: [Option<HddImage>; 2] = [Some(make_test_drive()), None];
+        let mut drives: [Option<MountedHdd>; 2] = [Some(make_test_drive()), None];
 
         controller.write_data(1, &drives);
         // Write 1 block at LBA 5.
@@ -828,7 +828,7 @@ mod tests {
     #[test]
     fn capacity_indicators_no_drives() {
         let controller = Controller::new();
-        let drives: [Option<HddImage>; 2] = [None, None];
+        let drives: [Option<MountedHdd>; 2] = [None, None];
 
         let mut ctrl = controller;
         ctrl.output_control = 0;

--- a/crates/device/src/upd765a_fdc.rs
+++ b/crates/device/src/upd765a_fdc.rs
@@ -12,9 +12,7 @@ use std::{
     path::PathBuf,
 };
 
-use common::error;
-
-use crate::floppy::{FloppyImage, d88::D88MediaType};
+use crate::floppy::{FloppyImage, MountedFloppy, d88::D88MediaType};
 
 /// FDC command processing phase.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -715,12 +713,10 @@ pub struct FloppyController {
     fdc_640k: Upd765aFdc,
     /// Which FDC (0=1MB, 1=640K) is currently executing a command.
     active_interface: u8,
-    /// Floppy disk images (up to 4 drives, shared between both FDCs).
-    drives: [Option<FloppyImage>; 4],
-    /// File paths for floppy disk images (for write-back).
-    drive_paths: [Option<PathBuf>; 4],
-    /// Dirty flags per drive (set when a write modifies sector data).
-    drive_dirty: [bool; 4],
+    /// Mounted floppy disks (up to 4 drives, shared between both FDCs).
+    /// Each `MountedFloppy` pairs the parsed image with its open file
+    /// handle for synchronous write-through.
+    drives: [Option<MountedFloppy>; 4],
     /// Dual-mode FDC interface control register (port 0xBE).
     fdc_media: u8,
 }
@@ -739,14 +735,15 @@ impl FloppyController {
             fdc_640k: Upd765aFdc::new(),
             active_interface: 0,
             drives: [None, None, None, None],
-            drive_paths: [None, None, None, None],
-            drive_dirty: [false, false, false, false],
             fdc_media: FDC_MEDIA_DEFAULT,
         }
     }
 
     /// Inserts a floppy disk image into the specified drive (0-3).
     pub fn insert_drive(&mut self, drive: usize, image: FloppyImage, path: Option<PathBuf>) {
+        if let Some(mounted) = self.drives[drive].take() {
+            mounted.eject();
+        }
         let mask = 1u8 << drive;
         if image.write_protected {
             self.fdc_1mb.state.drive_write_protected |= mask;
@@ -755,19 +752,16 @@ impl FloppyController {
             self.fdc_1mb.state.drive_write_protected &= !mask;
             self.fdc_640k.state.drive_write_protected &= !mask;
         }
-        self.drives[drive] = Some(image);
-        self.drive_paths[drive] = path;
-        self.drive_dirty[drive] = false;
+        self.drives[drive] = Some(MountedFloppy::new(image, path));
         self.fdc_1mb.state.drive_has_disk |= mask;
         self.fdc_640k.state.drive_has_disk |= mask;
     }
 
     /// Ejects the floppy disk from the specified drive, flushing if dirty.
     pub fn eject_drive(&mut self, drive: usize) {
-        self.flush_drive(drive);
-        self.drives[drive] = None;
-        self.drive_paths[drive] = None;
-        self.drive_dirty[drive] = false;
+        if let Some(mounted) = self.drives[drive].take() {
+            mounted.eject();
+        }
         let mask = 1u8 << drive;
         self.fdc_1mb.state.drive_has_disk &= !mask;
         self.fdc_640k.state.drive_has_disk &= !mask;
@@ -775,34 +769,10 @@ impl FloppyController {
         self.fdc_640k.state.drive_write_protected &= !mask;
     }
 
-    /// Writes the floppy image back to its file if it has been modified.
+    /// Flushes the floppy image to its source file.
     pub fn flush_drive(&mut self, drive: usize) {
-        if !self.drive_dirty[drive] {
-            return;
-        }
-        if let (Some(image), Some(path)) = (&self.drives[drive], &self.drive_paths[drive]) {
-            let data = image.to_bytes();
-            let tmp_path = path.with_extension("tmp");
-            match std::fs::write(&tmp_path, &data) {
-                Ok(()) => match std::fs::rename(&tmp_path, path) {
-                    Ok(()) => {
-                        self.drive_dirty[drive] = false;
-                    }
-                    Err(err) => {
-                        error!(
-                            "Failed to rename temp floppy image for drive {drive} to {}: {err}",
-                            path.display()
-                        );
-                        let _ = std::fs::remove_file(&tmp_path);
-                    }
-                },
-                Err(err) => {
-                    error!(
-                        "Failed to write floppy image for drive {drive} to {}: {err}",
-                        path.display()
-                    );
-                }
-            }
+        if let Some(mounted) = self.drives[drive].as_mut() {
+            mounted.flush();
         }
     }
 
@@ -815,17 +785,15 @@ impl FloppyController {
 
     /// Returns a reference to the disk image in the given drive, if present.
     pub fn drive(&self, index: usize) -> Option<&FloppyImage> {
-        self.drives[index].as_ref()
+        self.drives[index].as_ref().map(MountedFloppy::image)
     }
 
-    /// Returns whether the disk in the given drive has been modified.
+    /// Returns whether the disk in the given drive has been modified
+    /// since the last successful flush.
     pub fn is_drive_dirty(&self, index: usize) -> bool {
-        self.drive_dirty[index]
-    }
-
-    /// Marks a drive as dirty (modified).
-    pub fn mark_dirty(&mut self, drive: usize) {
-        self.drive_dirty[drive] = true;
+        self.drives[index]
+            .as_ref()
+            .is_some_and(MountedFloppy::is_dirty)
     }
 
     /// Returns a reference to the 1MB FDC.
@@ -902,8 +870,8 @@ impl FloppyController {
     /// and FDD EXC (bit 1) low, routing accesses to the 640KB FDC at 250 kbps.
     pub fn effective_fdc_media(&self) -> u8 {
         let mut value = self.fdc_media;
-        if let Some(image) = &self.drives[0]
-            && image.media_type != D88MediaType::Disk2HD
+        if let Some(mounted) = &self.drives[0]
+            && mounted.image().media_type != D88MediaType::Disk2HD
         {
             value &= !0x03;
         }
@@ -919,9 +887,10 @@ impl FloppyController {
     /// the disk in the specified drive.
     pub fn density_matches(&self, drive: usize) -> bool {
         let track_index = self.active_fdc().current_track_index();
-        let Some(image) = &self.drives[drive] else {
+        let Some(mounted) = &self.drives[drive] else {
             return true;
         };
+        let image = mounted.image();
         let Some(sector) = image.sector_at_index(track_index, 0) else {
             return true;
         };
@@ -946,14 +915,14 @@ impl FloppyController {
     pub fn is_write_protected(&self, drive: usize) -> bool {
         self.drives[drive]
             .as_ref()
-            .is_some_and(|d| d.write_protected)
+            .is_some_and(|m| m.image().write_protected)
     }
 
     /// Returns the size code (N) of the first sector on track 0 of the specified drive.
     pub fn boot_sector_size_code(&self, drive: usize) -> Option<u8> {
         self.drives[drive]
             .as_ref()
-            .and_then(|disk| disk.sector_at_index(0, 0))
+            .and_then(|mounted| mounted.image().sector_at_index(0, 0))
             .map(|s| s.size_code)
     }
 
@@ -969,12 +938,16 @@ impl FloppyController {
     ) -> Option<&[u8]> {
         self.drives[drive]
             .as_ref()
-            .and_then(|disk| disk.find_sector_near_track_index(track_index, c, h, r, n))
+            .and_then(|mounted| {
+                mounted
+                    .image()
+                    .find_sector_near_track_index(track_index, c, h, r, n)
+            })
             .map(|s| s.data.as_slice())
     }
 
     /// Writes sector data to the specified drive by C/H/R/N near the given track index.
-    /// Returns `true` if the sector was found and written. Marks the drive dirty on success.
+    /// Returns `true` if the sector was found and written.
     #[allow(clippy::too_many_arguments)]
     pub fn write_sector_data(
         &mut self,
@@ -986,15 +959,9 @@ impl FloppyController {
         n: u8,
         data: &[u8],
     ) -> bool {
-        if let Some(disk) = self.drives[drive].as_mut()
-            && let Some(sector) = disk.find_sector_near_track_index_mut(track_index, c, h, r, n)
-        {
-            let copy_len = data.len().min(sector.data.len());
-            sector.data[..copy_len].copy_from_slice(&data[..copy_len]);
-            self.drive_dirty[drive] = true;
-            true
-        } else {
-            false
+        match self.drives[drive].as_mut() {
+            Some(mounted) => mounted.write_sector_data(track_index, c, h, r, n, data),
+            None => false,
         }
     }
 
@@ -1008,9 +975,8 @@ impl FloppyController {
         data_n: u8,
         fill_byte: u8,
     ) {
-        if let Some(disk) = self.drives[drive].as_mut() {
-            disk.format_track(track_index, chrn, data_n, fill_byte);
-            self.drive_dirty[drive] = true;
+        if let Some(mounted) = self.drives[drive].as_mut() {
+            mounted.format_track(track_index, chrn, data_n, fill_byte);
         }
     }
 
@@ -1021,8 +987,10 @@ impl FloppyController {
         track_index: usize,
         sector_index: usize,
     ) -> Option<(u8, u8, u8, u8)> {
-        self.drives[drive].as_ref().and_then(|disk| {
-            disk.sector_at_index(track_index, sector_index)
+        self.drives[drive].as_ref().and_then(|mounted| {
+            mounted
+                .image()
+                .sector_at_index(track_index, sector_index)
                 .map(|s| (s.cylinder, s.head, s.record, s.size_code))
         })
     }
@@ -1031,7 +999,7 @@ impl FloppyController {
     pub fn sector_count(&self, drive: usize, track_index: usize) -> usize {
         self.drives[drive]
             .as_ref()
-            .map(|disk| disk.sector_count(track_index))
+            .map(|mounted| mounted.image().sector_count(track_index))
             .unwrap_or(0)
     }
 
@@ -1081,6 +1049,7 @@ impl FloppyController {
     pub fn sector_size_for_drive(&self, drive: usize) -> Option<u16> {
         let size_code = self.drives[drive]
             .as_ref()?
+            .image()
             .sector_at_index(0, 0)?
             .size_code;
         Some(128u16 << size_code)
@@ -1089,7 +1058,7 @@ impl FloppyController {
     /// Returns the total number of track slots in the floppy image for a drive.
     /// Each slot represents one side of one cylinder (track_index = cylinder * 2 + head).
     pub fn track_slot_count(&self, drive: usize) -> Option<usize> {
-        Some(self.drives[drive].as_ref()?.track_slot_count())
+        Some(self.drives[drive].as_ref()?.image().track_slot_count())
     }
 
     /// Sets all FDC state to match the PC-98 post-ITF boot state.
@@ -1123,6 +1092,45 @@ impl FloppyController {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn tempfile_with(bytes: &[u8], suffix: &str) -> PathBuf {
+        let dir = std::env::temp_dir();
+        let unique = format!(
+            "neetan_fdc_test_{}_{}{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            suffix
+        );
+        let path = dir.join(unique);
+        std::fs::write(&path, bytes).expect("write temp file");
+        path
+    }
+
+    fn single_sector_floppy_image(fill: u8) -> FloppyImage {
+        let sector = crate::floppy::D88Sector {
+            cylinder: 0,
+            head: 0,
+            record: 1,
+            size_code: 0,
+            sector_count: 1,
+            mfm_flag: 0x00,
+            deleted: 0x00,
+            status: 0x00,
+            reserved: [0; 5],
+            data: vec![fill; 128],
+            source_offset: None,
+        };
+        let disk = crate::floppy::D88Disk::from_tracks(
+            String::from("TEST"),
+            false,
+            D88MediaType::Disk2DD,
+            vec![Some(vec![sector])],
+        );
+        FloppyImage::from_d88(disk)
+    }
 
     #[test]
     fn initial_state() {
@@ -1390,5 +1398,51 @@ mod tests {
         fdc.state.drive_cylinder[2] = 10;
         fdc.state.hd_us = 0x06; // head=1, drive=2
         assert_eq!(fdc.current_track_index(), 10 * 2 + 1);
+    }
+
+    #[test]
+    fn flush_all_drives_persists_successful_write_before_drop() {
+        let first_image = single_sector_floppy_image(0x00);
+        let first_bytes = first_image.to_bytes();
+        let path = tempfile_with(&first_bytes, ".d88");
+        let parsed = FloppyImage::from_d88_bytes(&first_bytes).unwrap();
+
+        let mut controller = FloppyController::new();
+        controller.insert_drive(0, parsed, Some(path.clone()));
+
+        let pattern = [0x7Au8; 128];
+        assert!(controller.write_sector_data(0, 0, 0, 0, 1, 0, &pattern));
+        controller.flush_all_drives();
+
+        let raw = std::fs::read(&path).unwrap();
+        let reparsed = FloppyImage::from_d88_bytes(&raw).unwrap();
+        let sector = reparsed.find_sector(0, 0, 1, 0).unwrap();
+        assert_eq!(sector.data.as_slice(), &pattern);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn inserting_drive_flushes_dirty_previous_mount() {
+        let first_image = single_sector_floppy_image(0x00);
+        let first_path = tempfile_with(&first_image.to_bytes(), ".d88");
+
+        let mut controller = FloppyController::new();
+        controller.insert_drive(0, first_image, Some(first_path.clone()));
+
+        let pattern = [0x55u8; 128];
+        assert!(controller.write_sector_data(0, 0, 0, 0, 1, 0, &pattern));
+
+        let second_image = single_sector_floppy_image(0xAA);
+        let second_path = tempfile_with(&second_image.to_bytes(), ".d88");
+        controller.insert_drive(0, second_image, Some(second_path.clone()));
+
+        let raw = std::fs::read(&first_path).unwrap();
+        let reparsed = FloppyImage::from_d88_bytes(&raw).unwrap();
+        let sector = reparsed.find_sector(0, 0, 1, 0).unwrap();
+        assert_eq!(sector.data.as_slice(), &pattern);
+
+        std::fs::remove_file(&first_path).ok();
+        std::fs::remove_file(&second_path).ok();
     }
 }

--- a/crates/device/tests/nfd.rs
+++ b/crates/device/tests/nfd.rs
@@ -16,7 +16,9 @@ fn load_nfd_fixture(name: &str) -> D88Disk {
     let path = fixture_path(name);
     let data = std::fs::read(&path)
         .unwrap_or_else(|error| panic!("Failed to read {}: {error}", path.display()));
-    nfd::from_bytes(&data).unwrap_or_else(|error| panic!("Failed to parse {name}: {error}"))
+    nfd::from_bytes(&data)
+        .unwrap_or_else(|error| panic!("Failed to parse {name}: {error}"))
+        .0
 }
 
 fn load_d88_fixture(name: &str) -> D88Disk {

--- a/crates/machine/src/machine.rs
+++ b/crates/machine/src/machine.rs
@@ -219,12 +219,7 @@ fn insert_floppy_impl<T: Tracing>(
     let image = device::floppy::load_floppy_image(path, &data)
         .map_err(|error| format!("Failed to parse {}: {error}", path.display()))?;
     let description = format!("{} ({})", image.name, image.format_name());
-    let writeback = if image.can_write_back() {
-        Some(path.to_path_buf())
-    } else {
-        None
-    };
-    bus.insert_floppy(drive, image, writeback);
+    bus.insert_floppy(drive, image, Some(path.to_path_buf()));
     Ok(description)
 }
 

--- a/crates/os/tests/dos620/file_copy_harness.rs
+++ b/crates/os/tests/dos620/file_copy_harness.rs
@@ -170,6 +170,7 @@ pub fn create_random_file_floppy_with_name(fcb_name: &[u8; 11], file_data: &[u8]
                 status: 0,
                 reserved: [0; 5],
                 data: disk_data[offset..offset + sector_size].to_vec(),
+                source_offset: None,
             });
         }
         tracks.push(Some(sectors));
@@ -281,6 +282,7 @@ pub fn create_broken_chain_floppy_with_name(
                 status: 0,
                 reserved: [0; 5],
                 data: disk_data[offset..offset + sector_size].to_vec(),
+                source_offset: None,
             });
         }
         tracks.push(Some(sectors));

--- a/crates/os/tests/dos620/harness.rs
+++ b/crates/os/tests/dos620/harness.rs
@@ -206,6 +206,7 @@ fn build_d88_tracks(disk_data: &[u8], mfm_flag: u8) -> Vec<Option<Vec<D88Sector>
                 status: 0,
                 reserved: [0; 5],
                 data: disk_data[data_offset..data_offset + FLOPPY_SECTOR_SIZE].to_vec(),
+                source_offset: None,
             });
         }
         tracks.push(Some(sectors));

--- a/crates/os/tests/dos620/process_management.rs
+++ b/crates/os/tests/dos620/process_management.rs
@@ -101,6 +101,7 @@ fn create_test_floppy_with_two_programs(
                 status: 0,
                 reserved: [0; 5],
                 data: disk_data[data_offset..data_offset + SECTOR_SIZE].to_vec(),
+                source_offset: None,
             });
         }
         tracks.push(Some(sectors));

--- a/src/create.rs
+++ b/src/create.rs
@@ -39,6 +39,7 @@ pub fn create_fdd_image(path: &Path, fdd_type: FddType) -> crate::Result<()> {
                 status: 0x00,
                 reserved: [0u8; 5],
                 data: vec![0u8; sector_size],
+                source_offset: None,
             });
         }
 


### PR DESCRIPTION
- Add DiskBackend (BufWriter<File> + atomic replace).
- Add MountedFloppy and MountedHdd; controllers hold these instead of parallel image/path/dirty arrays.
- Add HDM, NFD R0, and NFD R1 serializers; split FloppyFormat::Nfd into NfdR0 and NfdR1.
- D88Sector gains source_offset for seek-and-overwrite.
- HddImage stores header_bytes verbatim instead of just a size.
- Drop FloppyImage::can_write_back.

Fixes #10 by using synchronous, buffered writes.