### PR TITLE
fix: Windows 3.1 properly starts now

### DIFF
--- a/crates/cpu/src/i386.rs
+++ b/crates/cpu/src/i386.rs
@@ -657,7 +657,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
     ) -> Option<SegmentDescriptor> {
         let addr = self.descriptor_addr_checked(selector)?;
-        Some(self.decode_descriptor_at(addr, bus))
+        let saved_supervisor_override = self.supervisor_override;
+        self.supervisor_override = true;
+        let descriptor = self.decode_descriptor_at(addr, bus);
+        self.supervisor_override = saved_supervisor_override;
+        Some(descriptor)
     }
 
     fn descriptor_dpl(rights: u8) -> u16 {
@@ -1420,12 +1424,15 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
     fn set_accessed_bit(&mut self, selector: u16, bus: &mut impl common::Bus) {
         if let Some(addr) = self.descriptor_addr_checked(selector) {
+            let saved_supervisor_override = self.supervisor_override;
+            self.supervisor_override = true;
             let linear = addr.wrapping_add(5);
             let phys = self.translate_linear(linear, true, bus).unwrap_or(0);
             let rights = bus.read_byte(phys);
             if rights & 0x01 == 0 {
                 bus.write_byte(phys, rights | 0x01);
             }
+            self.supervisor_override = saved_supervisor_override;
         }
     }
 

--- a/crates/cpu/src/i386.rs
+++ b/crates/cpu/src/i386.rs
@@ -666,11 +666,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
     ) -> Option<SegmentDescriptor> {
         let addr = self.descriptor_addr_checked(selector)?;
-        let saved_supervisor_override = self.supervisor_override;
-        self.supervisor_override = true;
-        let descriptor = self.decode_descriptor_at(addr, bus);
-        self.supervisor_override = saved_supervisor_override;
-        Some(descriptor)
+        Some(self.decode_descriptor_at(addr, bus))
     }
 
     fn descriptor_dpl(rights: u8) -> u16 {
@@ -2313,6 +2309,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             let phys = cpu.translate_linear(linear, false, bus).unwrap_or(0);
             bus.read_byte(phys)
         }
+        let saved_supervisor_override = self.supervisor_override;
+        self.supervisor_override = true;
         let b0 = translate_byte::<CPU_MODEL>(self, bus, addr);
         let b1 = translate_byte::<CPU_MODEL>(self, bus, addr.wrapping_add(1));
         let b2 = translate_byte::<CPU_MODEL>(self, bus, addr.wrapping_add(2));
@@ -2321,6 +2319,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let rights = translate_byte::<CPU_MODEL>(self, bus, addr.wrapping_add(5));
         let b6 = translate_byte::<CPU_MODEL>(self, bus, addr.wrapping_add(6));
         let b7 = translate_byte::<CPU_MODEL>(self, bus, addr.wrapping_add(7));
+        self.supervisor_override = saved_supervisor_override;
 
         let raw_limit = b0 as u32 | ((b1 as u32) << 8) | (((b6 & 0x0F) as u32) << 16);
         let base = b2 as u32 | ((b3 as u32) << 8) | ((b4 as u32) << 16) | ((b7 as u32) << 24);

--- a/crates/cpu/src/i386.rs
+++ b/crates/cpu/src/i386.rs
@@ -98,6 +98,7 @@ pub struct I386<const CPU_MODEL: u8 = { CPU_MODEL_386 }> {
     fetch_page_valid: bool,
     fetch_page_tag: u32,
     fetch_page_phys: u32,
+    fetch_page_user: bool,
 
     prefetch_valid: bool,
     prefetch_addr: u32,
@@ -107,6 +108,7 @@ pub struct I386<const CPU_MODEL: u8 = { CPU_MODEL_386 }> {
     tlb_tag: [u32; 64],
     tlb_phys: [u32; 64],
     tlb_writable: [bool; 64],
+    tlb_user: [bool; 64],
     tlb_dirty: [bool; 64],
 
     debug_trap_pending: bool,
@@ -171,6 +173,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             fetch_page_valid: false,
             fetch_page_tag: 0,
             fetch_page_phys: 0,
+            fetch_page_user: false,
             prefetch_valid: false,
             prefetch_addr: 0,
             prefetch_byte: 0,
@@ -178,6 +181,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             tlb_tag: [0; 64],
             tlb_phys: [0; 64],
             tlb_writable: [false; 64],
+            tlb_user: [false; 64],
             tlb_dirty: [false; 64],
             debug_trap_pending: false,
             trap_level: 0,
@@ -395,18 +399,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
         let eip = self.effective_eip();
         let linear = self.seg_bases[SegReg32::CS as usize].wrapping_add(eip);
-        let page = linear >> 12;
-        let addr = if self.fetch_page_valid && self.fetch_page_tag == page {
-            self.fetch_page_phys | (linear & 0xFFF)
-        } else {
-            let Some(addr) = self.translate_linear(linear, false, bus) else {
-                self.prefetch_valid = false;
-                return 0;
-            };
-            self.fetch_page_valid = true;
-            self.fetch_page_tag = page;
-            self.fetch_page_phys = addr & !0xFFF;
-            addr
+        let Some(addr) = self.fetch_physical_address(linear, bus) else {
+            self.prefetch_valid = false;
+            return 0;
         };
         let value = if self.prefetch_valid && self.prefetch_addr == addr {
             self.prefetch_valid = false;
@@ -430,22 +425,36 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     }
 
     #[inline(always)]
+    fn fetch_physical_address(&mut self, linear: u32, bus: &mut impl common::Bus) -> Option<u32> {
+        let page = linear >> 12;
+        if self.fetch_page_valid
+            && self.fetch_page_tag == page
+            && (!self.is_user_page_access() || self.fetch_page_user)
+        {
+            return Some(self.fetch_page_phys | (linear & 0xFFF));
+        }
+
+        let addr = self.translate_linear(linear, false, bus)?;
+        self.fetch_page_valid = true;
+        self.fetch_page_tag = page;
+        self.fetch_page_phys = addr & !0xFFF;
+        self.fetch_page_user = if self.is_paging_enabled() {
+            let slot = (page & 63) as usize;
+            self.tlb_valid[slot] && self.tlb_tag[slot] == page && self.tlb_user[slot]
+        } else {
+            true
+        };
+        Some(addr)
+    }
+
+    #[inline(always)]
     fn fetchword(&mut self, bus: &mut impl common::Bus) -> u16 {
         if !self.fault_pending {
             let eip = self.effective_eip();
             let linear = self.seg_bases[SegReg32::CS as usize].wrapping_add(eip);
             if (linear & 0xFFF) <= 0xFFE {
-                let page = linear >> 12;
-                let addr = if self.fetch_page_valid && self.fetch_page_tag == page {
-                    self.fetch_page_phys | (linear & 0xFFF)
-                } else {
-                    let Some(addr) = self.translate_linear(linear, false, bus) else {
-                        return 0;
-                    };
-                    self.fetch_page_valid = true;
-                    self.fetch_page_tag = page;
-                    self.fetch_page_phys = addr & !0xFFF;
-                    addr
+                let Some(addr) = self.fetch_physical_address(linear, bus) else {
+                    return 0;
                 };
                 let value = bus.read_word(addr);
                 self.advance_ip_by(2);
@@ -463,17 +472,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             let eip = self.effective_eip();
             let linear = self.seg_bases[SegReg32::CS as usize].wrapping_add(eip);
             if (linear & 0xFFF) <= 0xFFC {
-                let page = linear >> 12;
-                let addr = if self.fetch_page_valid && self.fetch_page_tag == page {
-                    self.fetch_page_phys | (linear & 0xFFF)
-                } else {
-                    let Some(addr) = self.translate_linear(linear, false, bus) else {
-                        return 0;
-                    };
-                    self.fetch_page_valid = true;
-                    self.fetch_page_tag = page;
-                    self.fetch_page_phys = addr & !0xFFF;
-                    addr
+                let Some(addr) = self.fetch_physical_address(linear, bus) else {
+                    return 0;
                 };
                 let value = bus.read_dword(addr);
                 self.advance_ip_by(4);
@@ -527,6 +527,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             return 0;
         }
         self.stored_cpl
+    }
+
+    #[inline(always)]
+    fn is_user_page_access(&self) -> bool {
+        self.cpl() == 3 && !self.supervisor_override
     }
 
     #[inline(always)]

--- a/crates/cpu/src/i386.rs
+++ b/crates/cpu/src/i386.rs
@@ -76,7 +76,9 @@ pub struct I386<const CPU_MODEL: u8 = { CPU_MODEL_386 }> {
     inhibit_all: u8,
 
     rep_ip: u16,
+    rep_ip_upper: u32,
     rep_restart_ip: u16,
+    rep_restart_ip_upper: u32,
     rep_seg_prefix: bool,
     rep_prefix_seg: SegReg32,
     rep_opcode: u8,
@@ -154,7 +156,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             no_interrupt: 0,
             inhibit_all: 0,
             rep_ip: 0,
+            rep_ip_upper: 0,
             rep_restart_ip: 0,
+            rep_restart_ip_upper: 0,
             rep_seg_prefix: false,
             rep_prefix_seg: SegReg32::DS,
             rep_opcode: 0,
@@ -2386,7 +2390,9 @@ impl<const CPU_MODEL: u8> common::Cpu for I386<CPU_MODEL> {
         self.inhibit_all = 0;
         self.rep_active = false;
         self.rep_completed = false;
+        self.rep_ip_upper = 0;
         self.rep_restart_ip = 0;
+        self.rep_restart_ip_upper = 0;
         self.rep_type = 0;
         self.rep_operand_size_override = false;
         self.rep_address_size_override = false;

--- a/crates/cpu/src/i386.rs
+++ b/crates/cpu/src/i386.rs
@@ -928,13 +928,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     }
 
     #[inline(always)]
-    fn seg_read_word_at(&mut self, bus: &mut impl common::Bus, delta: u32) -> u16 {
+    fn seg_read_word_at_with(
+        &mut self,
+        bus: &mut impl common::Bus,
+        delta: u32,
+        for_update: bool,
+    ) -> u16 {
         let offset = if self.address_size_override {
             self.eo32.wrapping_add(delta)
         } else {
             (self.eo32 as u16).wrapping_add(delta as u16) as u32
         };
-        if !self.check_segment_access(self.ea_seg, offset, 2, false, bus) {
+        if !self.check_segment_access(self.ea_seg, offset, 2, for_update, bus) {
             return 0;
         }
         let l0 = self.seg_addr(delta);
@@ -944,34 +949,49 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             l0 & 0xFFF <= 0xFFE && (offset as u16) <= 0xFFFE
         };
         if same_page {
-            let Some(a0) = self.translate_linear(l0, false, bus) else {
+            let Some(a0) = self.translate_linear(l0, for_update, bus) else {
                 return 0;
             };
             return bus.read_word(a0);
         }
         let l1 = self.seg_addr(delta.wrapping_add(1));
-        let Some(a0) = self.translate_linear(l0, false, bus) else {
+        let Some(a0) = self.translate_linear(l0, for_update, bus) else {
             return 0;
         };
-        let Some(a1) = self.translate_linear(l1, false, bus) else {
+        let Some(a1) = self.translate_linear(l1, for_update, bus) else {
             return 0;
         };
         bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8)
     }
 
     #[inline(always)]
-    fn seg_read_word(&mut self, bus: &mut impl common::Bus) -> u16 {
-        self.seg_read_word_at(bus, 0)
+    fn seg_read_word_at(&mut self, bus: &mut impl common::Bus, delta: u32) -> u16 {
+        self.seg_read_word_at_with(bus, delta, false)
     }
 
     #[inline(always)]
-    fn seg_read_dword_at(&mut self, bus: &mut impl common::Bus, delta: u32) -> u32 {
+    fn seg_read_word(&mut self, bus: &mut impl common::Bus) -> u16 {
+        self.seg_read_word_at_with(bus, 0, false)
+    }
+
+    #[inline(always)]
+    pub(super) fn seg_read_word_for_update(&mut self, bus: &mut impl common::Bus) -> u16 {
+        self.seg_read_word_at_with(bus, 0, true)
+    }
+
+    #[inline(always)]
+    fn seg_read_dword_at_with(
+        &mut self,
+        bus: &mut impl common::Bus,
+        delta: u32,
+        for_update: bool,
+    ) -> u32 {
         let offset = if self.address_size_override {
             self.eo32.wrapping_add(delta)
         } else {
             (self.eo32 as u16).wrapping_add(delta as u16) as u32
         };
-        if !self.check_segment_access(self.ea_seg, offset, 4, false, bus) {
+        if !self.check_segment_access(self.ea_seg, offset, 4, for_update, bus) {
             return 0;
         }
         let l0 = self.seg_addr(delta);
@@ -981,7 +1001,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             l0 & 0xFFF <= 0xFFC && (offset as u16) <= 0xFFFC
         };
         if same_page {
-            let Some(a0) = self.translate_linear(l0, false, bus) else {
+            let Some(a0) = self.translate_linear(l0, for_update, bus) else {
                 return 0;
             };
             return bus.read_dword(a0);
@@ -989,16 +1009,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let l1 = self.seg_addr(delta.wrapping_add(1));
         let l2 = self.seg_addr(delta.wrapping_add(2));
         let l3 = self.seg_addr(delta.wrapping_add(3));
-        let Some(a0) = self.translate_linear(l0, false, bus) else {
+        let Some(a0) = self.translate_linear(l0, for_update, bus) else {
             return 0;
         };
-        let Some(a1) = self.translate_linear(l1, false, bus) else {
+        let Some(a1) = self.translate_linear(l1, for_update, bus) else {
             return 0;
         };
-        let Some(a2) = self.translate_linear(l2, false, bus) else {
+        let Some(a2) = self.translate_linear(l2, for_update, bus) else {
             return 0;
         };
-        let Some(a3) = self.translate_linear(l3, false, bus) else {
+        let Some(a3) = self.translate_linear(l3, for_update, bus) else {
             return 0;
         };
         bus.read_byte(a0) as u32
@@ -1008,8 +1028,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     }
 
     #[inline(always)]
+    fn seg_read_dword_at(&mut self, bus: &mut impl common::Bus, delta: u32) -> u32 {
+        self.seg_read_dword_at_with(bus, delta, false)
+    }
+
+    #[inline(always)]
     fn seg_read_dword(&mut self, bus: &mut impl common::Bus) -> u32 {
-        self.seg_read_dword_at(bus, 0)
+        self.seg_read_dword_at_with(bus, 0, false)
+    }
+
+    #[inline(always)]
+    pub(super) fn seg_read_dword_for_update(&mut self, bus: &mut impl common::Bus) -> u32 {
+        self.seg_read_dword_at_with(bus, 0, true)
     }
 
     #[inline(always)]
@@ -1111,37 +1141,64 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     }
 
     #[inline(always)]
-    fn read_word_seg(&mut self, bus: &mut impl common::Bus, seg: SegReg32, offset: u32) -> u16 {
-        if !self.check_segment_access(seg, offset, 2, false, bus) {
+    fn read_word_seg_with(
+        &mut self,
+        bus: &mut impl common::Bus,
+        seg: SegReg32,
+        offset: u32,
+        for_update: bool,
+    ) -> u16 {
+        if !self.check_segment_access(seg, offset, 2, for_update, bus) {
             return 0;
         }
         let base = self.seg_base(seg);
         let l0 = base.wrapping_add(offset);
         if l0 & 0xFFF <= 0xFFE {
-            let Some(a0) = self.translate_linear(l0, false, bus) else {
+            let Some(a0) = self.translate_linear(l0, for_update, bus) else {
                 return 0;
             };
             return bus.read_word(a0);
         }
         let l1 = base.wrapping_add(offset.wrapping_add(1));
-        let Some(a0) = self.translate_linear(l0, false, bus) else {
+        let Some(a0) = self.translate_linear(l0, for_update, bus) else {
             return 0;
         };
-        let Some(a1) = self.translate_linear(l1, false, bus) else {
+        let Some(a1) = self.translate_linear(l1, for_update, bus) else {
             return 0;
         };
         bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8)
     }
 
     #[inline(always)]
-    fn read_dword_seg(&mut self, bus: &mut impl common::Bus, seg: SegReg32, offset: u32) -> u32 {
-        if !self.check_segment_access(seg, offset, 4, false, bus) {
+    fn read_word_seg(&mut self, bus: &mut impl common::Bus, seg: SegReg32, offset: u32) -> u16 {
+        self.read_word_seg_with(bus, seg, offset, false)
+    }
+
+    #[inline(always)]
+    pub(super) fn read_word_seg_for_update(
+        &mut self,
+        bus: &mut impl common::Bus,
+        seg: SegReg32,
+        offset: u32,
+    ) -> u16 {
+        self.read_word_seg_with(bus, seg, offset, true)
+    }
+
+    #[inline(always)]
+    fn read_dword_seg_with(
+        &mut self,
+        bus: &mut impl common::Bus,
+        seg: SegReg32,
+        offset: u32,
+        for_update: bool,
+    ) -> u32 {
+        if !self.check_segment_access(seg, offset, 4, for_update, bus) {
             return 0;
         }
         let base = self.seg_base(seg);
         let l0 = base.wrapping_add(offset);
         if l0 & 0xFFF <= 0xFFC {
-            let Some(a0) = self.translate_linear(l0, false, bus) else {
+            let Some(a0) = self.translate_linear(l0, for_update, bus) else {
                 return 0;
             };
             return bus.read_dword(a0);
@@ -1149,22 +1206,37 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let l1 = base.wrapping_add(offset.wrapping_add(1));
         let l2 = base.wrapping_add(offset.wrapping_add(2));
         let l3 = base.wrapping_add(offset.wrapping_add(3));
-        let Some(a0) = self.translate_linear(l0, false, bus) else {
+        let Some(a0) = self.translate_linear(l0, for_update, bus) else {
             return 0;
         };
-        let Some(a1) = self.translate_linear(l1, false, bus) else {
+        let Some(a1) = self.translate_linear(l1, for_update, bus) else {
             return 0;
         };
-        let Some(a2) = self.translate_linear(l2, false, bus) else {
+        let Some(a2) = self.translate_linear(l2, for_update, bus) else {
             return 0;
         };
-        let Some(a3) = self.translate_linear(l3, false, bus) else {
+        let Some(a3) = self.translate_linear(l3, for_update, bus) else {
             return 0;
         };
         bus.read_byte(a0) as u32
             | ((bus.read_byte(a1) as u32) << 8)
             | ((bus.read_byte(a2) as u32) << 16)
             | ((bus.read_byte(a3) as u32) << 24)
+    }
+
+    #[inline(always)]
+    fn read_dword_seg(&mut self, bus: &mut impl common::Bus, seg: SegReg32, offset: u32) -> u32 {
+        self.read_dword_seg_with(bus, seg, offset, false)
+    }
+
+    #[inline(always)]
+    pub(super) fn read_dword_seg_for_update(
+        &mut self,
+        bus: &mut impl common::Bus,
+        seg: SegReg32,
+        offset: u32,
+    ) -> u32 {
+        self.read_dword_seg_with(bus, seg, offset, true)
     }
 
     #[inline(always)]
@@ -1478,6 +1550,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8)
     }
 
+    pub(super) fn read_word_linear_for_update(
+        &mut self,
+        bus: &mut impl common::Bus,
+        addr: u32,
+    ) -> u16 {
+        if addr & 0xFFF <= 0xFFE {
+            let Some(a0) = self.translate_linear(addr, true, bus) else {
+                return 0;
+            };
+            return bus.read_word(a0);
+        }
+        let a0 = self.translate_linear(addr, true, bus).unwrap_or(0);
+        let a1 = self
+            .translate_linear(addr.wrapping_add(1), true, bus)
+            .unwrap_or(0);
+        bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8)
+    }
+
     fn write_word_linear(&mut self, bus: &mut impl common::Bus, addr: u32, value: u16) {
         if addr & 0xFFF <= 0xFFE {
             let Some(a0) = self.translate_linear(addr, true, bus) else {
@@ -1512,6 +1602,33 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             .unwrap_or(0);
         let a3 = self
             .translate_linear(addr.wrapping_add(3), false, bus)
+            .unwrap_or(0);
+        bus.read_byte(a0) as u32
+            | ((bus.read_byte(a1) as u32) << 8)
+            | ((bus.read_byte(a2) as u32) << 16)
+            | ((bus.read_byte(a3) as u32) << 24)
+    }
+
+    pub(super) fn read_dword_linear_for_update(
+        &mut self,
+        bus: &mut impl common::Bus,
+        addr: u32,
+    ) -> u32 {
+        if addr & 0xFFF <= 0xFFC {
+            let Some(a0) = self.translate_linear(addr, true, bus) else {
+                return 0;
+            };
+            return bus.read_dword(a0);
+        }
+        let a0 = self.translate_linear(addr, true, bus).unwrap_or(0);
+        let a1 = self
+            .translate_linear(addr.wrapping_add(1), true, bus)
+            .unwrap_or(0);
+        let a2 = self
+            .translate_linear(addr.wrapping_add(2), true, bus)
+            .unwrap_or(0);
+        let a3 = self
+            .translate_linear(addr.wrapping_add(3), true, bus)
             .unwrap_or(0);
         bus.read_byte(a0) as u32
             | ((bus.read_byte(a1) as u32) << 8)

--- a/crates/cpu/src/i386/execute.rs
+++ b/crates/cpu/src/i386/execute.rs
@@ -368,9 +368,15 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     fn add_br8(&mut self, bus: &mut impl common::Bus) {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let dst = self.get_rm_byte(modrm, bus);
+        let dst = self.get_rm_byte_for_update(modrm, bus);
+        if self.fault_pending {
+            return;
+        }
         let result = self.alu_add_byte(dst, src);
         self.putback_rm_byte(modrm, result, bus);
+        if self.fault_pending {
+            return;
+        }
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
     }
 
@@ -378,15 +384,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let dst = self.get_rm_dword(modrm, bus);
+            let dst = self.get_rm_dword_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_add_dword(dst, src);
             self.putback_rm_dword(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let dst = self.get_rm_word(modrm, bus);
+            let dst = self.get_rm_word_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_add_word(dst, src);
             self.putback_rm_word(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
     }
@@ -446,9 +464,15 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     fn or_br8(&mut self, bus: &mut impl common::Bus) {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let dst = self.get_rm_byte(modrm, bus);
+        let dst = self.get_rm_byte_for_update(modrm, bus);
+        if self.fault_pending {
+            return;
+        }
         let result = self.alu_or_byte(dst, src);
         self.putback_rm_byte(modrm, result, bus);
+        if self.fault_pending {
+            return;
+        }
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
     }
 
@@ -456,15 +480,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let dst = self.get_rm_dword(modrm, bus);
+            let dst = self.get_rm_dword_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_or_dword(dst, src);
             self.putback_rm_dword(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let dst = self.get_rm_word(modrm, bus);
+            let dst = self.get_rm_word_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_or_word(dst, src);
             self.putback_rm_word(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
     }
@@ -524,10 +560,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     fn adc_br8(&mut self, bus: &mut impl common::Bus) {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let dst = self.get_rm_byte(modrm, bus);
+        let dst = self.get_rm_byte_for_update(modrm, bus);
+        if self.fault_pending {
+            return;
+        }
         let cf = self.flags.cf_val();
         let result = self.alu_adc_byte(dst, src, cf);
         self.putback_rm_byte(modrm, result, bus);
+        if self.fault_pending {
+            return;
+        }
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
     }
 
@@ -536,15 +578,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let cf = self.flags.cf_val();
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let dst = self.get_rm_dword(modrm, bus);
+            let dst = self.get_rm_dword_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_adc_dword(dst, src, cf);
             self.putback_rm_dword(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let dst = self.get_rm_word(modrm, bus);
+            let dst = self.get_rm_word_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_adc_word(dst, src, cf);
             self.putback_rm_word(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
     }
@@ -608,10 +662,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     fn sbb_br8(&mut self, bus: &mut impl common::Bus) {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let dst = self.get_rm_byte(modrm, bus);
+        let dst = self.get_rm_byte_for_update(modrm, bus);
+        if self.fault_pending {
+            return;
+        }
         let cf = self.flags.cf_val();
         let result = self.alu_sbb_byte(dst, src, cf);
         self.putback_rm_byte(modrm, result, bus);
+        if self.fault_pending {
+            return;
+        }
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
     }
 
@@ -620,15 +680,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let cf = self.flags.cf_val();
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let dst = self.get_rm_dword(modrm, bus);
+            let dst = self.get_rm_dword_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_sbb_dword(dst, src, cf);
             self.putback_rm_dword(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let dst = self.get_rm_word(modrm, bus);
+            let dst = self.get_rm_word_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_sbb_word(dst, src, cf);
             self.putback_rm_word(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
     }
@@ -692,9 +764,15 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     fn and_br8(&mut self, bus: &mut impl common::Bus) {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let dst = self.get_rm_byte(modrm, bus);
+        let dst = self.get_rm_byte_for_update(modrm, bus);
+        if self.fault_pending {
+            return;
+        }
         let result = self.alu_and_byte(dst, src);
         self.putback_rm_byte(modrm, result, bus);
+        if self.fault_pending {
+            return;
+        }
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
     }
 
@@ -702,15 +780,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let dst = self.get_rm_dword(modrm, bus);
+            let dst = self.get_rm_dword_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_and_dword(dst, src);
             self.putback_rm_dword(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let dst = self.get_rm_word(modrm, bus);
+            let dst = self.get_rm_word_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_and_word(dst, src);
             self.putback_rm_word(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
     }
@@ -770,9 +860,15 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     fn sub_br8(&mut self, bus: &mut impl common::Bus) {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let dst = self.get_rm_byte(modrm, bus);
+        let dst = self.get_rm_byte_for_update(modrm, bus);
+        if self.fault_pending {
+            return;
+        }
         let result = self.alu_sub_byte(dst, src);
         self.putback_rm_byte(modrm, result, bus);
+        if self.fault_pending {
+            return;
+        }
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
     }
 
@@ -780,15 +876,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let dst = self.get_rm_dword(modrm, bus);
+            let dst = self.get_rm_dword_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_sub_dword(dst, src);
             self.putback_rm_dword(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let dst = self.get_rm_word(modrm, bus);
+            let dst = self.get_rm_word_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_sub_word(dst, src);
             self.putback_rm_word(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
     }
@@ -848,9 +956,15 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     fn xor_br8(&mut self, bus: &mut impl common::Bus) {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let dst = self.get_rm_byte(modrm, bus);
+        let dst = self.get_rm_byte_for_update(modrm, bus);
+        if self.fault_pending {
+            return;
+        }
         let result = self.alu_xor_byte(dst, src);
         self.putback_rm_byte(modrm, result, bus);
+        if self.fault_pending {
+            return;
+        }
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
     }
 
@@ -858,15 +972,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let dst = self.get_rm_dword(modrm, bus);
+            let dst = self.get_rm_dword_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_xor_dword(dst, src);
             self.putback_rm_dword(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let dst = self.get_rm_word(modrm, bus);
+            let dst = self.get_rm_word_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_xor_word(dst, src);
             self.putback_rm_word(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
     }
@@ -1449,9 +1575,15 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let modrm = self.fetch(bus);
         let reg = self.reg_byte(modrm);
         let reg_val = self.regs.byte(reg);
-        let rm_val = self.get_rm_byte(modrm, bus);
+        let rm_val = self.get_rm_byte_for_update(modrm, bus);
+        if self.fault_pending {
+            return;
+        }
         self.regs.set_byte(reg, rm_val);
         self.putback_rm_byte(modrm, reg_val, bus);
+        if self.fault_pending {
+            return;
+        }
         self.clk_modrm(modrm, Self::timing(3, 3), Self::timing(5, 5));
     }
 
@@ -1460,16 +1592,28 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         if self.operand_size_override {
             let reg = self.reg_dword(modrm);
             let reg_val = self.regs.dword(reg);
-            let rm_val = self.get_rm_dword(modrm, bus);
+            let rm_val = self.get_rm_dword_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             self.regs.set_dword(reg, rm_val);
             self.putback_rm_dword(modrm, reg_val, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(3, 3), Self::timing(5, 5), 4);
         } else {
             let reg = self.reg_word(modrm);
             let reg_val = self.regs.word(reg);
-            let rm_val = self.get_rm_word(modrm, bus);
+            let rm_val = self.get_rm_word_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             self.regs.set_word(reg, rm_val);
             self.putback_rm_word(modrm, reg_val, bus);
+            if self.fault_pending {
+                return;
+            }
             self.clk_modrm_word(modrm, Self::timing(3, 3), Self::timing(5, 5), 2);
         }
     }

--- a/crates/cpu/src/i386/execute.rs
+++ b/crates/cpu/src/i386/execute.rs
@@ -2782,13 +2782,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.invalidate_segment_if_needed(SegReg32::FS, new_cpl);
                 self.invalidate_segment_if_needed(SegReg32::GS, new_cpl);
             } else {
+                if !self.load_cs_for_return(new_cs, new_eip, bus) {
+                    return;
+                }
                 if self.use_esp() {
                     self.regs.set_dword(DwordReg::ESP, sp.wrapping_add(12));
                 } else {
                     self.regs.set_word(WordReg::SP, sp.wrapping_add(12) as u16);
-                }
-                if !self.load_cs_for_return(new_cs, new_eip, bus) {
-                    return;
                 }
                 self.ip = new_eip as u16;
                 self.ip_upper = new_eip & 0xFFFF_0000;
@@ -2834,13 +2834,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.invalidate_segment_if_needed(SegReg32::FS, new_cpl);
                 self.invalidate_segment_if_needed(SegReg32::GS, new_cpl);
             } else {
+                if !self.load_cs_for_return(new_cs, new_ip as u32, bus) {
+                    return;
+                }
                 if self.use_esp() {
                     self.regs.set_dword(DwordReg::ESP, sp.wrapping_add(6));
                 } else {
                     self.regs.set_word(WordReg::SP, sp.wrapping_add(6) as u16);
-                }
-                if !self.load_cs_for_return(new_cs, new_ip as u32, bus) {
-                    return;
                 }
                 self.ip = new_ip;
                 self.ip_upper = 0;

--- a/crates/cpu/src/i386/execute_0f.rs
+++ b/crates/cpu/src/i386/execute_0f.rs
@@ -275,7 +275,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             } else {
                 self.calc_ea(modrm, bus);
                 let (offset, bit_index) = self.bit_mem_effective_offset(bit_offset as i32, 32);
-                let mut value = self.read_dword_seg(bus, self.ea_seg, offset);
+                let mut value = self.read_dword_seg_for_update(bus, self.ea_seg, offset);
+                if self.fault_pending {
+                    return;
+                }
                 let bit = 1u32 << bit_index;
                 self.flags.carry_val = u32::from(value & bit != 0);
                 if clear {
@@ -312,7 +315,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.calc_ea(modrm, bus);
                 let signed_offset = bit_offset as i16 as i32;
                 let (offset, bit_index) = self.bit_mem_effective_offset(signed_offset, 16);
-                let mut value = self.read_word_seg(bus, self.ea_seg, offset);
+                let mut value = self.read_word_seg_for_update(bus, self.ea_seg, offset);
+                if self.fault_pending {
+                    return;
+                }
                 let bit = 1u16 << bit_index;
                 self.flags.carry_val = u32::from(value & bit != 0);
                 if clear {
@@ -369,7 +375,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 let bit_index = imm & 31;
                 if self.address_size_override {
                     let address = self.ea;
-                    let mut value = self.read_dword_linear(bus, address);
+                    let mut value = if write_back {
+                        self.read_dword_linear_for_update(bus, address)
+                    } else {
+                        self.read_dword_linear(bus, address)
+                    };
+                    if self.fault_pending {
+                        return;
+                    }
                     let bit = 1u32 << bit_index;
                     self.flags.carry_val = u32::from(value & bit != 0);
                     if clear {
@@ -386,7 +399,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                         self.write_dword_linear(bus, address, value);
                     }
                 } else {
-                    let mut value = self.seg_read_dword(bus);
+                    let mut value = if write_back {
+                        self.seg_read_dword_for_update(bus)
+                    } else {
+                        self.seg_read_dword(bus)
+                    };
+                    if self.fault_pending {
+                        return;
+                    }
                     let bit = 1u32 << bit_index;
                     self.flags.carry_val = u32::from(value & bit != 0);
                     if clear {
@@ -429,7 +449,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             let bit_index = imm & 15;
             if self.address_size_override {
                 let address = self.ea;
-                let mut value = self.read_word_linear(bus, address);
+                let mut value = if write_back {
+                    self.read_word_linear_for_update(bus, address)
+                } else {
+                    self.read_word_linear(bus, address)
+                };
+                if self.fault_pending {
+                    return;
+                }
                 let bit = 1u16 << bit_index;
                 self.flags.carry_val = u32::from(value & bit != 0);
                 if clear {
@@ -446,7 +473,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     self.write_word_linear(bus, address, value);
                 }
             } else {
-                let mut value = self.seg_read_word(bus);
+                let mut value = if write_back {
+                    self.seg_read_word_for_update(bus)
+                } else {
+                    self.seg_read_word(bus)
+                };
+                if self.fault_pending {
+                    return;
+                }
                 let bit = 1u16 << bit_index;
                 self.flags.carry_val = u32::from(value & bit != 0);
                 if clear {
@@ -1417,11 +1451,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         // CMPXCHG r/m8,r8 - compare AL with r/m8; if equal, load r8 into r/m8.
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let dst = self.get_rm_byte(modrm, bus);
+        let dst = self.get_rm_byte_for_update(modrm, bus);
+        if self.fault_pending {
+            return;
+        }
         let al = self.regs.byte(ByteReg::AL);
         self.alu_sub_byte(al, dst);
         if self.flags.zf() {
             self.putback_rm_byte(modrm, src, bus);
+            if self.fault_pending {
+                return;
+            }
         } else {
             self.regs.set_byte(ByteReg::AL, dst);
         }
@@ -1433,21 +1473,33 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let dst = self.get_rm_dword(modrm, bus);
+            let dst = self.get_rm_dword_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let eax = self.regs.dword(DwordReg::EAX);
             self.alu_sub_dword(eax, dst);
             if self.flags.zf() {
                 self.putback_rm_dword(modrm, src, bus);
+                if self.fault_pending {
+                    return;
+                }
             } else {
                 self.regs.set_dword(DwordReg::EAX, dst);
             }
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let dst = self.get_rm_word(modrm, bus);
+            let dst = self.get_rm_word_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let ax = self.regs.word(WordReg::AX);
             self.alu_sub_word(ax, dst);
             if self.flags.zf() {
                 self.putback_rm_word(modrm, src, bus);
+                if self.fault_pending {
+                    return;
+                }
             } else {
                 self.regs.set_word(WordReg::AX, dst);
             }
@@ -1460,10 +1512,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let modrm = self.fetch(bus);
         let src_reg = self.reg_byte(modrm);
         let src = self.regs.byte(src_reg);
-        let dst = self.get_rm_byte(modrm, bus);
+        let dst = self.get_rm_byte_for_update(modrm, bus);
+        if self.fault_pending {
+            return;
+        }
         let result = self.alu_add_byte(dst, src);
         self.regs.set_byte(src_reg, dst);
         self.putback_rm_byte(modrm, result, bus);
+        if self.fault_pending {
+            return;
+        }
         self.clk_modrm(modrm, 3, 4);
     }
 
@@ -1473,17 +1531,29 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         if self.operand_size_override {
             let src_reg = self.reg_dword(modrm);
             let src = self.regs.dword(src_reg);
-            let dst = self.get_rm_dword(modrm, bus);
+            let dst = self.get_rm_dword_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_add_dword(dst, src);
             self.regs.set_dword(src_reg, dst);
             self.putback_rm_dword(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
         } else {
             let src_reg = self.reg_word(modrm);
             let src = self.regs.word(src_reg);
-            let dst = self.get_rm_word(modrm, bus);
+            let dst = self.get_rm_word_for_update(modrm, bus);
+            if self.fault_pending {
+                return;
+            }
             let result = self.alu_add_word(dst, src);
             self.regs.set_word(src_reg, dst);
             self.putback_rm_word(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
         }
         self.clk_modrm(modrm, 3, 4);
     }

--- a/crates/cpu/src/i386/execute_0f.rs
+++ b/crates/cpu/src/i386/execute_0f.rs
@@ -341,6 +341,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         memory_cycles: i32,
     ) {
         let modrm = self.fetch(bus);
+        let write_back = clear || set || toggle;
 
         if self.operand_size_override {
             if modrm >= 0xC0 {
@@ -358,8 +359,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     value ^= bit;
                 }
                 self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
-                let reg = self.rm_dword(modrm);
-                self.regs.set_dword(reg, value);
+                if write_back {
+                    let reg = self.rm_dword(modrm);
+                    self.regs.set_dword(reg, value);
+                }
             } else {
                 self.calc_ea(modrm, bus);
                 let imm = self.fetch(bus) as u32;
@@ -379,7 +382,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                         value ^= bit;
                     }
                     self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
-                    self.write_dword_linear(bus, address, value);
+                    if write_back {
+                        self.write_dword_linear(bus, address, value);
+                    }
                 } else {
                     let mut value = self.seg_read_dword(bus);
                     let bit = 1u32 << bit_index;
@@ -394,7 +399,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                         value ^= bit;
                     }
                     self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
-                    self.seg_write_dword(bus, value);
+                    if write_back {
+                        self.seg_write_dword(bus, value);
+                    }
                 }
             }
         } else if modrm >= 0xC0 {
@@ -412,8 +419,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 value ^= bit;
             }
             self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
-            let reg = self.rm_word(modrm);
-            self.regs.set_word(reg, value);
+            if write_back {
+                let reg = self.rm_word(modrm);
+                self.regs.set_word(reg, value);
+            }
         } else {
             self.calc_ea(modrm, bus);
             let imm = self.fetch(bus) as u32;
@@ -433,7 +442,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     value ^= bit;
                 }
                 self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
-                self.write_word_linear(bus, address, value);
+                if write_back {
+                    self.write_word_linear(bus, address, value);
+                }
             } else {
                 let mut value = self.seg_read_word(bus);
                 let bit = 1u16 << bit_index;
@@ -448,7 +459,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     value ^= bit;
                 }
                 self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
-                self.seg_write_word(bus, value);
+                if write_back {
+                    self.seg_write_word(bus, value);
+                }
             }
         }
 

--- a/crates/cpu/src/i386/execute_group.rs
+++ b/crates/cpu/src/i386/execute_group.rs
@@ -31,13 +31,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     /// Group 0x80: ALU r/m8, imm8
     pub(super) fn group_80(&mut self, bus: &mut impl common::Bus) {
         let modrm = self.fetch(bus);
-        if self.lock_prefix && (modrm >> 3) & 7 == 7 {
+        let extension = (modrm >> 3) & 7;
+        if self.lock_prefix && extension == 7 {
             self.raise_fault(6, bus);
             return;
         }
-        let dst = self.get_rm_byte(modrm, bus);
+        let dst = if extension == 7 {
+            self.get_rm_byte(modrm, bus)
+        } else {
+            self.get_rm_byte_for_update(modrm, bus)
+        };
+        if self.fault_pending {
+            return;
+        }
         let src = self.fetch(bus);
-        let result = match (modrm >> 3) & 7 {
+        if self.fault_pending {
+            return;
+        }
+        let result = match extension {
             0 => self.alu_add_byte(dst, src),
             1 => self.alu_or_byte(dst, src),
             2 => {
@@ -58,8 +69,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
             _ => unreachable!(),
         };
-        if (modrm >> 3) & 7 != 7 {
+        if extension != 7 {
             self.putback_rm_byte(modrm, result, bus);
+            if self.fault_pending {
+                return;
+            }
         }
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
     }

--- a/crates/cpu/src/i386/execute_group.rs
+++ b/crates/cpu/src/i386/execute_group.rs
@@ -81,14 +81,25 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     /// Group 0x81: ALU r/m16, imm16
     pub(super) fn group_81(&mut self, bus: &mut impl common::Bus) {
         let modrm = self.fetch(bus);
-        if self.lock_prefix && (modrm >> 3) & 7 == 7 {
+        let extension = (modrm >> 3) & 7;
+        if self.lock_prefix && extension == 7 {
             self.raise_fault(6, bus);
             return;
         }
         if self.operand_size_override {
-            let dst = self.get_rm_dword(modrm, bus);
+            let dst = if extension == 7 {
+                self.get_rm_dword(modrm, bus)
+            } else {
+                self.get_rm_dword_for_update(modrm, bus)
+            };
+            if self.fault_pending {
+                return;
+            }
             let src = self.fetchdword(bus);
-            let result = match (modrm >> 3) & 7 {
+            if self.fault_pending {
+                return;
+            }
+            let result = match extension {
                 0 => self.alu_add_dword(dst, src),
                 1 => self.alu_or_dword(dst, src),
                 2 => {
@@ -109,14 +120,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
                 _ => unreachable!(),
             };
-            if (modrm >> 3) & 7 != 7 {
+            if extension != 7 {
                 self.putback_rm_dword(modrm, result, bus);
+                if self.fault_pending {
+                    return;
+                }
             }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
-            let dst = self.get_rm_word(modrm, bus);
+            let dst = if extension == 7 {
+                self.get_rm_word(modrm, bus)
+            } else {
+                self.get_rm_word_for_update(modrm, bus)
+            };
+            if self.fault_pending {
+                return;
+            }
             let src = self.fetchword(bus);
-            let result = match (modrm >> 3) & 7 {
+            if self.fault_pending {
+                return;
+            }
+            let result = match extension {
                 0 => self.alu_add_word(dst, src),
                 1 => self.alu_or_word(dst, src),
                 2 => {
@@ -137,8 +161,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
                 _ => unreachable!(),
             };
-            if (modrm >> 3) & 7 != 7 {
+            if extension != 7 {
                 self.putback_rm_word(modrm, result, bus);
+                if self.fault_pending {
+                    return;
+                }
             }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
@@ -152,14 +179,25 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     /// Group 0x83: ALU r/m16, sign-extended imm8
     pub(super) fn group_83(&mut self, bus: &mut impl common::Bus) {
         let modrm = self.fetch(bus);
-        if self.lock_prefix && (modrm >> 3) & 7 == 7 {
+        let extension = (modrm >> 3) & 7;
+        if self.lock_prefix && extension == 7 {
             self.raise_fault(6, bus);
             return;
         }
         if self.operand_size_override {
-            let dst = self.get_rm_dword(modrm, bus);
+            let dst = if extension == 7 {
+                self.get_rm_dword(modrm, bus)
+            } else {
+                self.get_rm_dword_for_update(modrm, bus)
+            };
+            if self.fault_pending {
+                return;
+            }
             let src = self.fetch(bus) as i8 as i32 as u32;
-            let result = match (modrm >> 3) & 7 {
+            if self.fault_pending {
+                return;
+            }
+            let result = match extension {
                 0 => self.alu_add_dword(dst, src),
                 1 => self.alu_or_dword(dst, src),
                 2 => {
@@ -180,14 +218,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
                 _ => unreachable!(),
             };
-            if (modrm >> 3) & 7 != 7 {
+            if extension != 7 {
                 self.putback_rm_dword(modrm, result, bus);
+                if self.fault_pending {
+                    return;
+                }
             }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
-            let dst = self.get_rm_word(modrm, bus);
+            let dst = if extension == 7 {
+                self.get_rm_word(modrm, bus)
+            } else {
+                self.get_rm_word_for_update(modrm, bus)
+            };
+            if self.fault_pending {
+                return;
+            }
             let src = self.fetch(bus) as i8 as u16;
-            let result = match (modrm >> 3) & 7 {
+            if self.fault_pending {
+                return;
+            }
+            let result = match extension {
                 0 => self.alu_add_word(dst, src),
                 1 => self.alu_or_word(dst, src),
                 2 => {
@@ -208,8 +259,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
                 _ => unreachable!(),
             };
-            if (modrm >> 3) & 7 != 7 {
+            if extension != 7 {
                 self.putback_rm_word(modrm, result, bus);
+                if self.fault_pending {
+                    return;
+                }
             }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
@@ -717,16 +771,28 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         match (modrm >> 3) & 7 {
             0 => {
                 // INC r/m8
-                let dst = self.get_rm_byte(modrm, bus);
+                let dst = self.get_rm_byte_for_update(modrm, bus);
+                if self.fault_pending {
+                    return;
+                }
                 let result = self.alu_inc_byte(dst);
                 self.putback_rm_byte(modrm, result, bus);
+                if self.fault_pending {
+                    return;
+                }
                 self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 3));
             }
             1 => {
                 // DEC r/m8
-                let dst = self.get_rm_byte(modrm, bus);
+                let dst = self.get_rm_byte_for_update(modrm, bus);
+                if self.fault_pending {
+                    return;
+                }
                 let result = self.alu_dec_byte(dst);
                 self.putback_rm_byte(modrm, result, bus);
+                if self.fault_pending {
+                    return;
+                }
                 self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 3));
             }
             _ => {
@@ -746,30 +812,54 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             0 => {
                 if self.operand_size_override {
                     // INC r/m32
-                    let dst = self.get_rm_dword(modrm, bus);
+                    let dst = self.get_rm_dword_for_update(modrm, bus);
+                    if self.fault_pending {
+                        return;
+                    }
                     let result = self.alu_inc_dword(dst);
                     self.putback_rm_dword(modrm, result, bus);
+                    if self.fault_pending {
+                        return;
+                    }
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 3), 4);
                 } else {
                     // INC r/m16
-                    let dst = self.get_rm_word(modrm, bus);
+                    let dst = self.get_rm_word_for_update(modrm, bus);
+                    if self.fault_pending {
+                        return;
+                    }
                     let result = self.alu_inc_word(dst);
                     self.putback_rm_word(modrm, result, bus);
+                    if self.fault_pending {
+                        return;
+                    }
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 3), 2);
                 }
             }
             1 => {
                 if self.operand_size_override {
                     // DEC r/m32
-                    let dst = self.get_rm_dword(modrm, bus);
+                    let dst = self.get_rm_dword_for_update(modrm, bus);
+                    if self.fault_pending {
+                        return;
+                    }
                     let result = self.alu_dec_dword(dst);
                     self.putback_rm_dword(modrm, result, bus);
+                    if self.fault_pending {
+                        return;
+                    }
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 3), 4);
                 } else {
                     // DEC r/m16
-                    let dst = self.get_rm_word(modrm, bus);
+                    let dst = self.get_rm_word_for_update(modrm, bus);
+                    if self.fault_pending {
+                        return;
+                    }
                     let result = self.alu_dec_word(dst);
                     self.putback_rm_word(modrm, result, bus);
+                    if self.fault_pending {
+                        return;
+                    }
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 3), 2);
                 }
             }

--- a/crates/cpu/src/i386/interrupt.rs
+++ b/crates/cpu/src/i386/interrupt.rs
@@ -504,7 +504,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
     pub(super) fn raise_interrupt(&mut self, vector: u8, bus: &mut impl common::Bus) {
         let return_eip = if self.rep_active {
-            self.ip_upper | self.rep_restart_ip as u32
+            self.rep_restart_ip_upper | self.rep_restart_ip as u32
         } else {
             self.ip_upper | self.ip as u32
         };
@@ -518,7 +518,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
     ) {
         let return_eip = if self.rep_active {
-            self.ip_upper | self.rep_restart_ip as u32
+            self.rep_restart_ip_upper | self.rep_restart_ip as u32
         } else {
             self.ip_upper | self.ip as u32
         };
@@ -533,7 +533,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
     pub(super) fn raise_trap(&mut self, vector: u8, bus: &mut impl common::Bus) {
         let return_eip = if self.rep_active {
-            self.ip_upper | self.rep_restart_ip as u32
+            self.rep_restart_ip_upper | self.rep_restart_ip as u32
         } else {
             self.ip_upper | self.ip as u32
         };

--- a/crates/cpu/src/i386/modrm.rs
+++ b/crates/cpu/src/i386/modrm.rs
@@ -292,12 +292,30 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
     }
 
+    pub(super) fn get_rm_word_for_update(&mut self, modrm: u8, bus: &mut impl common::Bus) -> u16 {
+        if modrm >= 0xC0 {
+            self.regs.word(self.rm_word(modrm))
+        } else {
+            self.calc_ea(modrm, bus);
+            self.seg_read_word_for_update(bus)
+        }
+    }
+
     pub(super) fn get_rm_dword(&mut self, modrm: u8, bus: &mut impl common::Bus) -> u32 {
         if modrm >= 0xC0 {
             self.regs.dword(self.rm_dword(modrm))
         } else {
             self.calc_ea(modrm, bus);
             self.seg_read_dword(bus)
+        }
+    }
+
+    pub(super) fn get_rm_dword_for_update(&mut self, modrm: u8, bus: &mut impl common::Bus) -> u32 {
+        if modrm >= 0xC0 {
+            self.regs.dword(self.rm_dword(modrm))
+        } else {
+            self.calc_ea(modrm, bus);
+            self.seg_read_dword_for_update(bus)
         }
     }
 

--- a/crates/cpu/src/i386/modrm.rs
+++ b/crates/cpu/src/i386/modrm.rs
@@ -258,7 +258,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.regs.byte(self.rm_byte(modrm))
         } else {
             self.calc_ea(modrm, bus);
-            let addr = self.translate_linear(self.ea, false, bus).unwrap_or(0);
+            if !self.check_segment_access(self.ea_seg, self.eo32, 1, false, bus) {
+                return 0;
+            }
+            let Some(addr) = self.translate_linear(self.ea, false, bus) else {
+                return 0;
+            };
+            bus.read_byte(addr)
+        }
+    }
+
+    pub(super) fn get_rm_byte_for_update(&mut self, modrm: u8, bus: &mut impl common::Bus) -> u8 {
+        if modrm >= 0xC0 {
+            self.regs.byte(self.rm_byte(modrm))
+        } else {
+            self.calc_ea(modrm, bus);
+            if !self.check_segment_access(self.ea_seg, self.eo32, 1, true, bus) {
+                return 0;
+            }
+            let Some(addr) = self.translate_linear(self.ea, true, bus) else {
+                return 0;
+            };
             bus.read_byte(addr)
         }
     }

--- a/crates/cpu/src/i386/paging.rs
+++ b/crates/cpu/src/i386/paging.rs
@@ -27,7 +27,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     pub(super) fn flush_tlb(&mut self) {
         self.tlb_valid = [false; TLB_SIZE];
         self.tlb_dirty = [false; TLB_SIZE];
+        self.tlb_user = [false; TLB_SIZE];
         self.fetch_page_valid = false;
+        self.fetch_page_user = false;
     }
 
     #[inline(always)]
@@ -45,7 +47,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let slot = (page & TLB_MASK) as usize;
 
         if self.tlb_valid[slot] && self.tlb_tag[slot] == page {
-            if write && (!self.tlb_writable[slot] || !self.tlb_dirty[slot]) {
+            let is_user = self.is_user_page_access();
+            if is_user && !self.tlb_user[slot] {
+                self.raise_page_fault(linear, write, true, bus);
+                return None;
+            }
+            let wp_enforced = CPU_MODEL == CPU_MODEL_486 && self.cr0 & 0x0001_0000 != 0;
+            if write && (is_user || wp_enforced) && !self.tlb_writable[slot] {
+                self.raise_page_fault(linear, write, true, bus);
+                return None;
+            }
+            if write && !self.tlb_dirty[slot] {
                 return self.page_table_walk(linear, write, bus);
             }
             return Some(self.tlb_phys[slot] | (linear & 0xFFF));
@@ -86,7 +98,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         // On 486, CR0.WP (bit 16) enforces R/W checks even in supervisor mode.
         // System table accesses (IDT, GDT, TSS) during interrupt delivery use
         // supervisor privilege regardless of current CPL.
-        let is_user = self.cpl() == 3 && !self.supervisor_override;
+        let is_user = self.is_user_page_access();
         if is_user {
             if pde & PTE_USER == 0 || pte & PTE_USER == 0 {
                 self.raise_page_fault(linear, write, true, bus);
@@ -129,13 +141,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.tlb_tag[slot] = page;
         self.tlb_phys[slot] = physical_page;
         self.tlb_dirty[slot] = write;
-        // Writable in TLB if both PDE and PTE allow writes (or supervisor without WP).
-        let wp_enforced = CPU_MODEL == CPU_MODEL_486 && self.cr0 & 0x0001_0000 != 0;
-        self.tlb_writable[slot] = if is_user || wp_enforced {
-            pde & PTE_WRITABLE != 0 && pte & PTE_WRITABLE != 0
-        } else {
-            true
-        };
+        self.tlb_writable[slot] = pde & PTE_WRITABLE != 0 && pte & PTE_WRITABLE != 0;
+        self.tlb_user[slot] = pde & PTE_USER != 0 && pte & PTE_USER != 0;
 
         Some(physical & PC98_PHYSICAL_ADDRESS_MASK)
     }
@@ -155,7 +162,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         if write {
             error_code |= 2; // W/R bit
         }
-        if self.cpl() == 3 {
+        if self.is_user_page_access() {
             error_code |= 4; // U/S bit
         }
         self.fault_pending = true;

--- a/crates/cpu/src/i386/rep.rs
+++ b/crates/cpu/src/i386/rep.rs
@@ -29,6 +29,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     fn start_rep(&mut self, rep_type: RepType, bus: &mut impl common::Bus) {
         self.clk(Self::timing(0, 1));
         self.rep_restart_ip = self.prev_ip;
+        self.rep_restart_ip_upper = self.prev_ip_upper;
         let mut next = self.fetch(bus);
 
         // Handle any number of prefixes between REP and opcode.
@@ -172,6 +173,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 // Save state for resume.
                 self.rep_active = true;
                 self.rep_ip = self.ip;
+                self.rep_ip_upper = self.ip_upper;
                 self.rep_seg_prefix = self.seg_prefix;
                 self.rep_prefix_seg = self.prefix_seg;
                 self.rep_opcode = next;
@@ -193,6 +195,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
     pub(super) fn continue_rep(&mut self, bus: &mut impl common::Bus) {
         self.ip = self.rep_ip;
+        self.ip_upper = self.rep_ip_upper;
+        self.prev_ip = self.rep_restart_ip;
+        self.prev_ip_upper = self.rep_restart_ip_upper;
         self.seg_prefix = self.rep_seg_prefix;
         self.prefix_seg = self.rep_prefix_seg;
         self.operand_size_override = self.rep_operand_size_override;

--- a/crates/cpu/src/i386/state.rs
+++ b/crates/cpu/src/i386/state.rs
@@ -264,7 +264,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.inhibit_all = 0;
         self.rep_active = false;
         self.rep_completed = false;
+        self.rep_ip_upper = 0;
         self.rep_restart_ip = 0;
+        self.rep_restart_ip_upper = 0;
         self.rep_type = 0;
         self.rep_operand_size_override = false;
         self.rep_address_size_override = false;

--- a/crates/cpu/tests/paging_i386.rs
+++ b/crates/cpu/tests/paging_i386.rs
@@ -815,6 +815,52 @@ fn paging_fault_user_writes_readonly_page() {
     assert_eq!(error_code, 0x0007, "error code: present, write, user");
 }
 
+#[test]
+fn paging_fault_user_read_modify_write_reports_write() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let mut state = setup_paged_protected_mode(&mut bus);
+    make_ring3(&mut state);
+    state.set_ebx(0);
+    cpu.load_state(&state);
+
+    let pde = read_dword_at(&bus, PG_PAGE_DIR);
+    write_dword_at(&mut bus, PG_PAGE_DIR, pde | PTE_US);
+
+    let code_pte_index = PG_RING3_CODE_BASE >> 12;
+    write_dword_at(
+        &mut bus,
+        PG_PAGE_TABLE_0 + code_pte_index * 4,
+        PG_RING3_CODE_BASE | PTE_P | PTE_RW | PTE_US,
+    );
+
+    let stack_pte_index = PG_RING3_STACK_BASE >> 12;
+    write_dword_at(
+        &mut bus,
+        PG_PAGE_TABLE_0 + stack_pte_index * 4,
+        PG_RING3_STACK_BASE | PTE_P | PTE_RW | PTE_US,
+    );
+
+    let data_pte_index = PG_DATA_BASE >> 12;
+    write_dword_at(&mut bus, PG_PAGE_TABLE_0 + data_pte_index * 4, 0);
+
+    place_at(&mut bus, PG_RING3_CODE_BASE, &[0x26, 0x80, 0x0F, 0x00]);
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert!(cpu.halted());
+    assert_eq!(cpu.ip(), PG_PF_HANDLER_IP as u32 + 1);
+    assert_eq!(cpu.cr2, PG_DATA_BASE);
+
+    let sp = cpu.esp();
+    let error_code = read_word_at(&bus, PG_STACK_BASE + sp);
+    assert_eq!(error_code, 0x0006, "error code: not present, write, user");
+
+    let return_eip = read_dword_at(&bus, PG_STACK_BASE + sp + 4);
+    assert_eq!(return_eip, 0, "fault should restart at the segment prefix");
+}
+
 /// On a 386, supervisor (CPL 0) can write to a page with R/W=0.
 #[test]
 fn paging_supervisor_writes_readonly_page() {

--- a/crates/cpu/tests/paging_i386.rs
+++ b/crates/cpu/tests/paging_i386.rs
@@ -861,6 +861,172 @@ fn paging_fault_user_read_modify_write_reports_write() {
     assert_eq!(return_eip, 0, "fault should restart at the segment prefix");
 }
 
+/// Helper for RMW page-fault tests: ring-3 user, ES segment override, [BX]
+/// addressing pointing at a not-present user data page; expect error 0x0006.
+fn assert_rmw_user_fault_writes_with_cpu<const CPU_MODEL: u8>(
+    cpu: &mut I386<{ CPU_MODEL }>,
+    instruction: &[u8],
+    expected_eip_after_fault: u32,
+) {
+    let mut bus = TestBus::new();
+
+    let mut state = setup_paged_protected_mode(&mut bus);
+    make_ring3(&mut state);
+    state.set_ebx(0);
+    state.set_edi(0);
+    cpu.load_state(&state);
+
+    let pde = read_dword_at(&bus, PG_PAGE_DIR);
+    write_dword_at(&mut bus, PG_PAGE_DIR, pde | PTE_US);
+
+    let code_pte_index = PG_RING3_CODE_BASE >> 12;
+    write_dword_at(
+        &mut bus,
+        PG_PAGE_TABLE_0 + code_pte_index * 4,
+        PG_RING3_CODE_BASE | PTE_P | PTE_RW | PTE_US,
+    );
+
+    let stack_pte_index = PG_RING3_STACK_BASE >> 12;
+    write_dword_at(
+        &mut bus,
+        PG_PAGE_TABLE_0 + stack_pte_index * 4,
+        PG_RING3_STACK_BASE | PTE_P | PTE_RW | PTE_US,
+    );
+
+    let data_pte_index = PG_DATA_BASE >> 12;
+    write_dword_at(&mut bus, PG_PAGE_TABLE_0 + data_pte_index * 4, 0);
+
+    place_at(&mut bus, PG_RING3_CODE_BASE, instruction);
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert!(cpu.halted());
+    assert_eq!(cpu.ip(), PG_PF_HANDLER_IP as u32 + 1);
+    assert_eq!(cpu.cr2, PG_DATA_BASE);
+
+    let sp = cpu.esp();
+    let error_code = read_word_at(&bus, PG_STACK_BASE + sp);
+    assert_eq!(error_code, 0x0006, "error code: not present, write, user");
+
+    let return_eip = read_dword_at(&bus, PG_STACK_BASE + sp + 4);
+    assert_eq!(
+        return_eip, expected_eip_after_fault,
+        "fault should restart at the segment prefix"
+    );
+}
+
+fn assert_rmw_user_fault_writes(instruction: &[u8], expected_eip_after_fault: u32) {
+    let mut cpu: I386 = I386::new();
+    assert_rmw_user_fault_writes_with_cpu(&mut cpu, instruction, expected_eip_after_fault);
+}
+
+fn assert_rmw_user_fault_writes_486(instruction: &[u8], expected_eip_after_fault: u32) {
+    let mut cpu: I386<{ cpu::CPU_MODEL_486 }> = I386::new();
+    assert_rmw_user_fault_writes_with_cpu(&mut cpu, instruction, expected_eip_after_fault);
+}
+
+#[test]
+fn paging_fault_user_inc_r_m8_reports_write() {
+    // ES: INC byte ptr [BX] -- 0x26 0xFE /0
+    assert_rmw_user_fault_writes(&[0x26, 0xFE, 0x07], 0);
+}
+
+#[test]
+fn paging_fault_user_inc_r_m16_reports_write() {
+    // ES: INC word ptr [BX] -- 0x26 0xFF /0
+    assert_rmw_user_fault_writes(&[0x26, 0xFF, 0x07], 0);
+}
+
+#[test]
+fn paging_fault_user_inc_r_m32_reports_write() {
+    // ES: INC dword ptr [BX] -- 0x26 0x66 0xFF /0
+    assert_rmw_user_fault_writes(&[0x26, 0x66, 0xFF, 0x07], 0);
+}
+
+#[test]
+fn paging_fault_user_dec_r_m8_reports_write() {
+    // ES: DEC byte ptr [BX] -- 0x26 0xFE /1
+    assert_rmw_user_fault_writes(&[0x26, 0xFE, 0x0F], 0);
+}
+
+#[test]
+fn paging_fault_user_or_r_m16_imm_reports_write() {
+    // ES: OR word ptr [BX], 0 -- 0x26 0x81 /1
+    assert_rmw_user_fault_writes(&[0x26, 0x81, 0x0F, 0x00, 0x00], 0);
+}
+
+#[test]
+fn paging_fault_user_or_r_m32_imm_reports_write() {
+    // ES: OR dword ptr [BX], 0 -- 0x26 0x66 0x81 /1
+    assert_rmw_user_fault_writes(&[0x26, 0x66, 0x81, 0x0F, 0x00, 0x00, 0x00, 0x00], 0);
+}
+
+#[test]
+fn paging_fault_user_or_r_m16_imm8_reports_write() {
+    // ES: OR word ptr [BX], 0 (sign-extended imm8) -- 0x26 0x83 /1
+    assert_rmw_user_fault_writes(&[0x26, 0x83, 0x0F, 0x00], 0);
+}
+
+#[test]
+fn paging_fault_user_add_mem_byte_reg_reports_write() {
+    // ES: ADD byte ptr [BX], CL -- 0x26 0x00 /CL
+    // ModRM 0x0F = mod=00 reg=001 (CL) rm=111 ([BX])
+    assert_rmw_user_fault_writes(&[0x26, 0x00, 0x0F], 0);
+}
+
+#[test]
+fn paging_fault_user_add_mem_word_reg_reports_write() {
+    // ES: ADD word ptr [BX], CX -- 0x26 0x01 /CX
+    assert_rmw_user_fault_writes(&[0x26, 0x01, 0x0F], 0);
+}
+
+#[test]
+fn paging_fault_user_xchg_mem_byte_reg_reports_write() {
+    // ES: XCHG byte ptr [BX], CL -- 0x26 0x86 /CL
+    assert_rmw_user_fault_writes(&[0x26, 0x86, 0x0F], 0);
+}
+
+#[test]
+fn paging_fault_user_xchg_mem_word_reg_reports_write() {
+    // ES: XCHG word ptr [BX], CX -- 0x26 0x87 /CX
+    assert_rmw_user_fault_writes(&[0x26, 0x87, 0x0F], 0);
+}
+
+#[test]
+fn paging_fault_user_cmpxchg_byte_reports_write() {
+    // ES: CMPXCHG byte ptr [BX], CL -- 0x26 0x0F 0xB0 /CL
+    // CMPXCHG always treated as a write because it conditionally writes; the
+    // architectural access is RMW so the W/R bit must be set on a fault.
+    // CMPXCHG is a 486+ instruction.
+    assert_rmw_user_fault_writes_486(&[0x26, 0x0F, 0xB0, 0x0F], 0);
+}
+
+#[test]
+fn paging_fault_user_xadd_byte_reports_write() {
+    // ES: XADD byte ptr [BX], CL -- 0x26 0x0F 0xC0 /CL
+    // XADD is a 486+ instruction.
+    assert_rmw_user_fault_writes_486(&[0x26, 0x0F, 0xC0, 0x0F], 0);
+}
+
+#[test]
+fn paging_fault_user_bts_imm_reports_write() {
+    // ES: BTS word ptr [BX], 0 -- 0x26 0x0F 0xBA /5 imm8
+    // ModRM 0x2F = mod=00 reg=101 (/5) rm=111 ([BX])
+    assert_rmw_user_fault_writes(&[0x26, 0x0F, 0xBA, 0x2F, 0x00], 0);
+}
+
+#[test]
+fn paging_fault_user_btr_imm_reports_write() {
+    // ES: BTR word ptr [BX], 0 -- 0x26 0x0F 0xBA /6 imm8
+    assert_rmw_user_fault_writes(&[0x26, 0x0F, 0xBA, 0x37, 0x00], 0);
+}
+
+#[test]
+fn paging_fault_user_btc_imm_reports_write() {
+    // ES: BTC word ptr [BX], 0 -- 0x26 0x0F 0xBA /7 imm8
+    assert_rmw_user_fault_writes(&[0x26, 0x0F, 0xBA, 0x3F, 0x00], 0);
+}
+
 /// On a 386, supervisor (CPL 0) can write to a page with R/W=0.
 #[test]
 fn paging_supervisor_writes_readonly_page() {

--- a/crates/cpu/tests/paging_i386.rs
+++ b/crates/cpu/tests/paging_i386.rs
@@ -586,11 +586,7 @@ fn paging_group_ba_bt_imm_sets_accessed_not_dirty() {
     let pde_after = read_dword_at(&bus, PG_PAGE_DIR);
     let pte_after = read_dword_at(&bus, PG_PAGE_TABLE_0 + pte_index * 4);
 
-    assert_ne!(
-        cpu.eflags() & 1,
-        0,
-        "BT must load the selected bit into CF"
-    );
+    assert_ne!(cpu.eflags() & 1, 0, "BT must load the selected bit into CF");
     assert_ne!(
         pde_after & PTE_A,
         0,

--- a/crates/cpu/tests/paging_i386.rs
+++ b/crates/cpu/tests/paging_i386.rs
@@ -554,6 +554,65 @@ fn paging_dirty_bit_on_write() {
     );
 }
 
+/// BT reads the memory operand but must not dirty the page.
+#[test]
+fn paging_group_ba_bt_imm_sets_accessed_not_dirty() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_paged_protected_mode(&mut bus);
+    cpu.load_state(&state);
+
+    let pte_index = PG_DATA_BASE >> 12;
+    let pde_before = read_dword_at(&bus, PG_PAGE_DIR);
+    let pte_before = read_dword_at(&bus, PG_PAGE_TABLE_0 + pte_index * 4);
+    write_dword_at(&mut bus, PG_PAGE_DIR, pde_before & !(PTE_A | PTE_D));
+    write_dword_at(
+        &mut bus,
+        PG_PAGE_TABLE_0 + pte_index * 4,
+        pte_before & !(PTE_A | PTE_D),
+    );
+
+    write_dword_at(&mut bus, PG_DATA_BASE + 0x80, 1 << 5);
+
+    // Operand-size override; BT dword [0x0080], 5.
+    place_at(
+        &mut bus,
+        PG_CODE_BASE,
+        &[0x66, 0x0F, 0xBA, 0x26, 0x80, 0x00, 0x05],
+    );
+    cpu.step(&mut bus);
+
+    let pde_after = read_dword_at(&bus, PG_PAGE_DIR);
+    let pte_after = read_dword_at(&bus, PG_PAGE_TABLE_0 + pte_index * 4);
+
+    assert_ne!(
+        cpu.eflags() & 1,
+        0,
+        "BT must load the selected bit into CF"
+    );
+    assert_ne!(
+        pde_after & PTE_A,
+        0,
+        "PDE Accessed bit must be set after BT memory read"
+    );
+    assert_ne!(
+        pte_after & PTE_A,
+        0,
+        "PTE Accessed bit must be set after BT memory read"
+    );
+    assert_eq!(
+        pte_after & PTE_D,
+        0,
+        "PTE Dirty bit must NOT be set after BT memory read"
+    );
+    assert_eq!(
+        read_dword_at(&bus, PG_DATA_BASE + 0x80),
+        1 << 5,
+        "BT must not modify the memory operand"
+    );
+}
+
 /// #PF on read from a not-present PDE. Error code = 0 (not present, read, supervisor).
 /// Uses PDE 1 (linear 0x400000+) for data so clearing it doesn't affect code/stack.
 #[test]

--- a/crates/cpu/tests/paging_i386.rs
+++ b/crates/cpu/tests/paging_i386.rs
@@ -1463,6 +1463,100 @@ fn paging_tlb_hit_read_write() {
 }
 
 #[test]
+fn paging_tlb_hit_preserves_user_read_permission() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_paged_protected_mode(&mut bus);
+    cpu.load_state(&state);
+
+    write_dword_at(
+        &mut bus,
+        PG_PAGE_DIR,
+        PG_PAGE_TABLE_0 | PTE_P | PTE_RW | PTE_US,
+    );
+    let code_pte_index = PG_RING3_CODE_BASE >> 12;
+    write_dword_at(
+        &mut bus,
+        PG_PAGE_TABLE_0 + code_pte_index * 4,
+        PG_RING3_CODE_BASE | PTE_P | PTE_RW | PTE_US,
+    );
+    let stack_pte_index = PG_RING3_STACK_BASE >> 12;
+    write_dword_at(
+        &mut bus,
+        PG_PAGE_TABLE_0 + stack_pte_index * 4,
+        PG_RING3_STACK_BASE | PTE_P | PTE_RW | PTE_US,
+    );
+    let data_pte_index = PG_DATA_BASE >> 12;
+    write_dword_at(
+        &mut bus,
+        PG_PAGE_TABLE_0 + data_pte_index * 4,
+        PG_DATA_BASE | PTE_P | PTE_RW,
+    );
+
+    bus.ram[PG_DATA_BASE as usize] = 0x5A;
+    place_at(&mut bus, PG_CODE_BASE, &[0xA0, 0x00, 0x00]);
+    cpu.step(&mut bus);
+    assert_eq!(cpu.al(), 0x5A);
+
+    make_ring3(&mut cpu.state);
+    cpu.state.stored_cpl = 3;
+    cpu.state.set_eip(0);
+    place_at(&mut bus, PG_RING3_CODE_BASE, &[0xA0, 0x00, 0x00]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert!(cpu.halted());
+    assert_eq!(cpu.ip(), PG_PF_HANDLER_IP as u32 + 1);
+    let error_code = read_word_at(&bus, PG_STACK_BASE + cpu.esp());
+    assert_eq!(error_code, 0x0005, "present + read + user");
+}
+
+#[test]
+fn paging_fetch_cache_preserves_user_read_permission() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let mut state = setup_paged_protected_mode(&mut bus);
+    state.seg_bases[cpu::SegReg32::CS as usize] = PG_RING3_CODE_BASE;
+    cpu.load_state(&state);
+
+    write_dword_at(
+        &mut bus,
+        PG_PAGE_DIR,
+        PG_PAGE_TABLE_0 | PTE_P | PTE_RW | PTE_US,
+    );
+    let code_pte_index = PG_RING3_CODE_BASE >> 12;
+    write_dword_at(
+        &mut bus,
+        PG_PAGE_TABLE_0 + code_pte_index * 4,
+        PG_RING3_CODE_BASE | PTE_P | PTE_RW,
+    );
+    let stack_pte_index = PG_RING3_STACK_BASE >> 12;
+    write_dword_at(
+        &mut bus,
+        PG_PAGE_TABLE_0 + stack_pte_index * 4,
+        PG_RING3_STACK_BASE | PTE_P | PTE_RW | PTE_US,
+    );
+
+    place_at(&mut bus, PG_RING3_CODE_BASE, &[0x90, 0xF4]);
+    cpu.step(&mut bus);
+
+    make_ring3(&mut cpu.state);
+    cpu.state.stored_cpl = 3;
+    cpu.state.set_eip(1);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert!(cpu.halted());
+    assert_eq!(cpu.ip(), PG_PF_HANDLER_IP as u32 + 1);
+    let error_code = read_word_at(&bus, PG_STACK_BASE + cpu.esp());
+    assert_eq!(error_code, 0x0005, "present + fetch + user");
+}
+
+#[test]
 fn paging_accessed_dirty_bits_already_set() {
     let mut cpu: I386 = I386::new();
     let mut bus = TestBus::new();

--- a/crates/cpu/tests/protected_mode_i386.rs
+++ b/crates/cpu/tests/protected_mode_i386.rs
@@ -6108,6 +6108,71 @@ fn i386_rep_movsd_source_page_fault_preserves_restart_state() {
 }
 
 #[test]
+fn i386_resumed_rep_movsd_source_page_fault_restarts_at_prefix() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+    let mut state = setup_protected_mode_with_exception_handlers(&mut bus);
+    enable_identity_paging(&mut bus, &mut state);
+
+    let source_offset = 0x0FFCu32;
+    let source_fault_linear = PM_DATA_BASE + 0x1000;
+    let destination_offset = 0x2000u32;
+    let destination_second_value = 0x5A5A_5A5A;
+
+    write_dword_at(&mut bus, PM_DATA_BASE + source_offset, 0xDEAD_BEEF);
+    write_dword_at(
+        &mut bus,
+        PM_DATA_BASE + destination_offset + 4,
+        destination_second_value,
+    );
+    unmap_identity_page(&mut bus, source_fault_linear);
+
+    cpu.load_state(&state);
+    cpu.state.set_esi(source_offset);
+    cpu.state.set_edi(destination_offset);
+    cpu.state.set_ecx(2);
+    cpu.state.flags.df = false;
+
+    // REP MOVSD with 32-bit address and operand size in a 16-bit code segment.
+    place_at(&mut bus, PM_CODE_BASE, &[0xF3, 0x67, 0x66, 0xA5, 0xF4]);
+
+    let _ = cpu.run_for(1, &mut bus);
+
+    assert_eq!(cpu.ip(), 0x0004);
+    assert_eq!(cpu.state.ecx(), 1);
+    assert_eq!(
+        read_dword_at(&bus, PM_DATA_BASE + destination_offset),
+        0xDEAD_BEEF
+    );
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert!(cpu.halted());
+    assert_eq!(cpu.ip(), PM_PAGE_FAULT_HANDLER_IP as u32 + 1);
+    assert_eq!(cpu.cr2, source_fault_linear);
+    assert_eq!(
+        read_dword_at(&bus, PM_DATA_BASE + destination_offset + 4),
+        destination_second_value
+    );
+    assert_eq!(cpu.state.ecx(), 1);
+    assert_eq!(cpu.state.esi(), 0x1000);
+    assert_eq!(cpu.state.edi(), destination_offset + 4);
+
+    let stack_pointer = cpu.esp();
+    assert_eq!(read_dword_at(&bus, PM_STACK_BASE + stack_pointer), 0);
+    assert_eq!(
+        read_dword_at(&bus, PM_STACK_BASE + stack_pointer + 4),
+        0,
+        "page fault should restart at the REP prefix"
+    );
+    assert_eq!(
+        read_dword_at(&bus, PM_STACK_BASE + stack_pointer + 8) as u16,
+        PM_CS_SEL
+    );
+}
+
+#[test]
 fn i386_stosb() {
     let mut cpu: I386 = I386::new();
     let mut bus = TestBus::new();

--- a/crates/cpu/tests/protected_mode_i386.rs
+++ b/crates/cpu/tests/protected_mode_i386.rs
@@ -446,6 +446,7 @@ fn write_dword_at(bus: &mut TestBus, addr: u32, value: u32) {
 const TEST_PAGE_DIRECTORY_BASE: u32 = 0xA0000;
 const TEST_PAGE_TABLE_BASE: u32 = 0xA1000;
 const TEST_PAGE_PRESENT_WRITABLE: u32 = 0x003;
+const TEST_PAGE_PRESENT_WRITABLE_USER: u32 = 0x007;
 
 fn enable_identity_paging(bus: &mut TestBus, state: &mut cpu::I386State) {
     write_dword_at(
@@ -469,6 +470,15 @@ fn enable_identity_paging(bus: &mut TestBus, state: &mut cpu::I386State) {
 fn unmap_identity_page(bus: &mut TestBus, linear_address: u32) {
     let page_index = (linear_address >> 12) & 0x3FF;
     write_dword_at(bus, TEST_PAGE_TABLE_BASE + page_index * 4, page_index << 12);
+}
+
+fn set_identity_page_flags(bus: &mut TestBus, linear_address: u32, flags: u32) {
+    let page_index = (linear_address >> 12) & 0x3FF;
+    write_dword_at(
+        bus,
+        TEST_PAGE_TABLE_BASE + page_index * 4,
+        (page_index << 12) | flags,
+    );
 }
 
 #[test]
@@ -1269,6 +1279,42 @@ fn make_ring3_state(state: &mut cpu::I386State) {
     state.set_es(PM_RING3_DS_SEL);
     state.seg_bases[cpu::SegReg32::ES as usize] = PM_DATA_BASE;
     state.seg_rights[cpu::SegReg32::ES as usize] = 0xF3;
+}
+
+#[test]
+fn i386_ring3_segment_load_reads_supervisor_descriptor_table_pages() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+    let mut state = setup_protected_mode_with_ring3(&mut bus);
+    make_ring3_state(&mut state);
+    enable_identity_paging(&mut bus, &mut state);
+
+    write_dword_at(
+        &mut bus,
+        TEST_PAGE_DIRECTORY_BASE,
+        TEST_PAGE_TABLE_BASE | TEST_PAGE_PRESENT_WRITABLE_USER,
+    );
+    set_identity_page_flags(&mut bus, PM_RING3_CODE_BASE, TEST_PAGE_PRESENT_WRITABLE_USER);
+    set_identity_page_flags(
+        &mut bus,
+        PM_RING3_STACK_BASE,
+        TEST_PAGE_PRESENT_WRITABLE_USER,
+    );
+    set_identity_page_flags(&mut bus, PM_DATA_BASE, TEST_PAGE_PRESENT_WRITABLE_USER);
+    set_identity_page_flags(&mut bus, PM_GDT_BASE, TEST_PAGE_PRESENT_WRITABLE);
+
+    cpu.load_state(&state);
+    place_at(
+        &mut bus,
+        PM_RING3_CODE_BASE,
+        &[0xB8, PM_RING3_DS_SEL as u8, 0x00, 0x8E, 0xD8, 0x90],
+    );
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_eq!(cpu.ds(), PM_RING3_DS_SEL);
+    assert_eq!(cpu.ip(), 5);
 }
 
 #[test]
@@ -2572,6 +2618,45 @@ fn i386_iret_32bit_protected_mode() {
         "EIP should be at target + 1 after HLT"
     );
     assert_eq!(cpu.cs(), PM_CS_SEL);
+}
+
+#[test]
+fn i386_iret_same_privilege_invalid_cs_preserves_source_frame() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let mut state = setup_protected_mode(&mut bus, 0xFFFF);
+    state.seg_granularity[cpu::SegReg32::SS as usize] = 0x40;
+    state.seg_limits[cpu::SegReg32::SS as usize] = 0xFFFF_FFFF;
+    cpu.load_state(&state);
+
+    let original_esp = cpu.esp().wrapping_sub(12);
+    write_dword_at(&mut bus, PM_STACK_BASE + original_esp, 0x2000);
+    write_dword_at(&mut bus, PM_STACK_BASE + original_esp + 4, 0x0040);
+    write_dword_at(&mut bus, PM_STACK_BASE + original_esp + 8, 0x0000_0202);
+    cpu.state.set_esp(original_esp);
+
+    place_at(&mut bus, PM_CODE_BASE, &[0x66, 0xCF]);
+
+    cpu.step(&mut bus);
+
+    assert_eq!(cpu.ip(), u32::from(PM_GP_HANDLER_IP));
+    assert_eq!(cpu.esp(), original_esp.wrapping_sub(16));
+    assert_eq!(
+        read_dword_at(&bus, PM_STACK_BASE + cpu.esp()),
+        0x0040,
+        "error code should contain the invalid return selector"
+    );
+    assert_eq!(
+        read_dword_at(&bus, PM_STACK_BASE + cpu.esp() + 4),
+        0x0000,
+        "fault frame should point back to the IRET instruction"
+    );
+    assert_eq!(
+        read_dword_at(&bus, PM_STACK_BASE + original_esp),
+        0x2000,
+        "the original IRET frame must remain in place"
+    );
 }
 
 /// RETF in protected mode with operand size override pops 32-bit EIP/CS.

--- a/crates/cpu/tests/protected_mode_i386.rs
+++ b/crates/cpu/tests/protected_mode_i386.rs
@@ -1322,6 +1322,153 @@ fn i386_ring3_segment_load_reads_supervisor_descriptor_table_pages() {
 }
 
 #[test]
+fn i386_ring3_call_gate_reads_supervisor_descriptor_table_pages() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+    let mut state = setup_protected_mode_with_ring3(&mut bus);
+    make_ring3_state(&mut state);
+
+    let gate_target_ip: u16 = 0x0100;
+    let target_selector: u16 = 0x1000;
+
+    write_gdt_gate(
+        &mut bus,
+        PM_GDT_BASE,
+        8,
+        gate_target_ip as u32,
+        target_selector,
+        0,
+        12,
+        3,
+    );
+
+    write_gdt_entry16(
+        &mut bus,
+        PM_GDT_BASE,
+        0x200,
+        PM_RING3_CODE_BASE,
+        0xFFFF,
+        0xFB,
+    );
+    state.gdt_limit = target_selector + 7;
+
+    bus.ram[(PM_RING3_CODE_BASE + gate_target_ip as u32) as usize] = 0xF4;
+
+    enable_identity_paging(&mut bus, &mut state);
+
+    write_dword_at(
+        &mut bus,
+        TEST_PAGE_DIRECTORY_BASE,
+        TEST_PAGE_TABLE_BASE | TEST_PAGE_PRESENT_WRITABLE_USER,
+    );
+    set_identity_page_flags(
+        &mut bus,
+        PM_RING3_CODE_BASE,
+        TEST_PAGE_PRESENT_WRITABLE_USER,
+    );
+    set_identity_page_flags(
+        &mut bus,
+        PM_RING3_STACK_BASE,
+        TEST_PAGE_PRESENT_WRITABLE_USER,
+    );
+    set_identity_page_flags(&mut bus, PM_DATA_BASE, TEST_PAGE_PRESENT_WRITABLE_USER);
+    set_identity_page_flags(&mut bus, PM_GDT_BASE, TEST_PAGE_PRESENT_WRITABLE_USER);
+    set_identity_page_flags(&mut bus, PM_GDT_BASE + 0x1000, TEST_PAGE_PRESENT_WRITABLE);
+
+    cpu.load_state(&state);
+    place_at(
+        &mut bus,
+        PM_RING3_CODE_BASE,
+        &[0x9A, 0x00, 0x00, 0x43, 0x00],
+    );
+
+    cpu.step(&mut bus);
+
+    assert_eq!(cpu.ip(), gate_target_ip as u32);
+    assert_eq!(cpu.cs() & !3, target_selector);
+    assert_eq!(cpu.cs() & 3, 3);
+}
+
+#[test]
+fn i386_ring3_task_switch_reads_supervisor_tss_descriptor() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+    let mut state = setup_protected_mode_with_ring3(&mut bus);
+    make_ring3_state(&mut state);
+
+    let task2_sel: u16 = 0x0048;
+    write_gdt_entry16(&mut bus, PM_GDT_BASE, 9, PM_TSS2_BASE, 103, 0xE9);
+    state.gdt_limit = 10 * 8 - 1;
+
+    let task2_ip: u32 = 0x0500;
+    write_tss386(
+        &mut bus,
+        PM_TSS2_BASE,
+        0,
+        0xFFF0,
+        PM_SS_SEL,
+        task2_ip,
+        0x0002,
+        0,
+        0,
+        0,
+        0,
+        0xFFF0,
+        0,
+        0,
+        0,
+        PM_DS_SEL,
+        PM_CS_SEL,
+        PM_SS_SEL,
+        PM_DS_SEL,
+        0,
+        0,
+        0,
+    );
+
+    bus.ram[(PM_CODE_BASE + task2_ip) as usize] = 0xF4;
+
+    enable_identity_paging(&mut bus, &mut state);
+
+    write_dword_at(
+        &mut bus,
+        TEST_PAGE_DIRECTORY_BASE,
+        TEST_PAGE_TABLE_BASE | TEST_PAGE_PRESENT_WRITABLE_USER,
+    );
+    set_identity_page_flags(
+        &mut bus,
+        PM_RING3_CODE_BASE,
+        TEST_PAGE_PRESENT_WRITABLE_USER,
+    );
+    set_identity_page_flags(
+        &mut bus,
+        PM_RING3_STACK_BASE,
+        TEST_PAGE_PRESENT_WRITABLE_USER,
+    );
+    set_identity_page_flags(&mut bus, PM_DATA_BASE, TEST_PAGE_PRESENT_WRITABLE_USER);
+    set_identity_page_flags(&mut bus, PM_TSS_BASE, TEST_PAGE_PRESENT_WRITABLE_USER);
+    set_identity_page_flags(&mut bus, PM_TSS2_BASE, TEST_PAGE_PRESENT_WRITABLE_USER);
+    set_identity_page_flags(&mut bus, PM_CODE_BASE, TEST_PAGE_PRESENT_WRITABLE_USER);
+    set_identity_page_flags(&mut bus, PM_STACK_BASE, TEST_PAGE_PRESENT_WRITABLE_USER);
+    set_identity_page_flags(&mut bus, PM_GDT_BASE, TEST_PAGE_PRESENT_WRITABLE);
+
+    cpu.load_state(&state);
+    place_at(
+        &mut bus,
+        PM_RING3_CODE_BASE,
+        &[0xEA, 0x00, 0x00, task2_sel as u8, (task2_sel >> 8) as u8],
+    );
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert!(cpu.halted());
+    assert_eq!(cpu.cs(), PM_CS_SEL);
+    assert_eq!(cpu.ip(), task2_ip + 1);
+    assert_eq!(cpu.cs() & 3, 0);
+}
+
+#[test]
 fn i386_ret_far_inter_privilege_ring0_to_ring3() {
     let mut cpu: I386 = I386::new();
     let mut bus = TestBus::new();

--- a/crates/cpu/tests/protected_mode_i386.rs
+++ b/crates/cpu/tests/protected_mode_i386.rs
@@ -6320,6 +6320,58 @@ fn i386_resumed_rep_movsd_source_page_fault_restarts_at_prefix() {
 }
 
 #[test]
+fn i386_resumed_rep_movsd_fault_preserves_high_eip() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+    let mut state = setup_protected_mode_with_exception_handlers(&mut bus);
+    enable_identity_paging(&mut bus, &mut state);
+
+    state.seg_granularity[cpu::SegReg32::CS as usize] = 0xC0;
+    state.seg_limits[cpu::SegReg32::CS as usize] = 0xFFFF_FFFF;
+
+    let code_offset: u32 = 0x0001_0000;
+    let source_offset: u32 = 0x0FFC;
+    let source_fault_linear = PM_DATA_BASE + 0x1000;
+    let destination_offset: u32 = 0x2000;
+
+    write_dword_at(&mut bus, PM_DATA_BASE + source_offset, 0xDEAD_BEEF);
+    unmap_identity_page(&mut bus, source_fault_linear);
+
+    place_at(&mut bus, PM_CODE_BASE + code_offset, &[0xF3, 0xA5, 0xF4]);
+
+    state.set_eip(code_offset);
+
+    cpu.load_state(&state);
+    cpu.state.set_esi(source_offset);
+    cpu.state.set_edi(destination_offset);
+    cpu.state.set_ecx(2);
+    cpu.state.flags.df = false;
+
+    let _ = cpu.run_for(1, &mut bus);
+    assert_eq!(cpu.state.ecx(), 1);
+    assert_eq!(cpu.ip(), code_offset + 2);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert!(cpu.halted());
+    assert_eq!(cpu.ip(), PM_PAGE_FAULT_HANDLER_IP as u32 + 1);
+    assert_eq!(cpu.cr2, source_fault_linear);
+
+    let stack_pointer = cpu.esp();
+    assert_eq!(read_dword_at(&bus, PM_STACK_BASE + stack_pointer), 0);
+    assert_eq!(
+        read_dword_at(&bus, PM_STACK_BASE + stack_pointer + 4),
+        code_offset,
+        "resumed REP fault must restart at the REP prefix with upper EIP bits preserved"
+    );
+    assert_eq!(
+        read_dword_at(&bus, PM_STACK_BASE + stack_pointer + 8) as u16,
+        PM_CS_SEL
+    );
+}
+
+#[test]
 fn i386_stosb() {
     let mut cpu: I386 = I386::new();
     let mut bus = TestBus::new();

--- a/crates/cpu/tests/protected_mode_i386.rs
+++ b/crates/cpu/tests/protected_mode_i386.rs
@@ -1294,7 +1294,11 @@ fn i386_ring3_segment_load_reads_supervisor_descriptor_table_pages() {
         TEST_PAGE_DIRECTORY_BASE,
         TEST_PAGE_TABLE_BASE | TEST_PAGE_PRESENT_WRITABLE_USER,
     );
-    set_identity_page_flags(&mut bus, PM_RING3_CODE_BASE, TEST_PAGE_PRESENT_WRITABLE_USER);
+    set_identity_page_flags(
+        &mut bus,
+        PM_RING3_CODE_BASE,
+        TEST_PAGE_PRESENT_WRITABLE_USER,
+    );
     set_identity_page_flags(
         &mut bus,
         PM_RING3_STACK_BASE,

--- a/crates/device/src/disk_hle.rs
+++ b/crates/device/src/disk_hle.rs
@@ -90,7 +90,7 @@ pub fn execute_write<const SECTOR_SIZE: usize>(
     sector_pos: u32,
     buf_addr: u32,
     drives: &mut [Option<MountedHdd>; 2],
-    read_byte: impl Fn(u32) -> u8,
+    mut read_byte: impl FnMut(u32) -> u8,
 ) -> u8 {
     let Some(drive) = &mut drives[drive_idx] else {
         return 0x60;

--- a/crates/device/src/ide.rs
+++ b/crates/device/src/ide.rs
@@ -223,7 +223,7 @@ impl IdeController {
         xfer_size: u32,
         sector_pos: u32,
         buf_addr: u32,
-        read_byte: impl Fn(u32) -> u8,
+        read_byte: impl FnMut(u32) -> u8,
     ) -> u8 {
         let sector_size = self.drives[drive_idx]
             .as_ref()

--- a/crates/device/src/sasi.rs
+++ b/crates/device/src/sasi.rs
@@ -127,7 +127,7 @@ impl SasiController {
         xfer_size: u32,
         sector_pos: u32,
         buf_addr: u32,
-        read_byte: impl Fn(u32) -> u8,
+        read_byte: impl FnMut(u32) -> u8,
     ) -> u8 {
         crate::disk_hle::execute_write::<256>(
             drive_idx,

--- a/crates/machine/src/bus.rs
+++ b/crates/machine/src/bus.rs
@@ -2416,7 +2416,13 @@ impl<T: Tracing> common::Bus for Pc9801Bus<T> {
 
     fn acknowledge_irq(&mut self) -> u8 {
         let vector = self.pic.acknowledge();
-        let irq = vector.wrapping_sub(self.pic.state.chips[0].icw[1]);
+        let master_base = self.pic.state.chips[0].icw[1] & 0xF8;
+        let slave_base = self.pic.state.chips[1].icw[1] & 0xF8;
+        let irq = if vector & 0xF8 == slave_base {
+            8 + vector.wrapping_sub(slave_base)
+        } else {
+            vector.wrapping_sub(master_base)
+        };
         self.tracer.set_cycle(self.current_cycle);
         self.tracer.trace_irq_acknowledge(irq, vector);
         vector

--- a/crates/machine/src/bus/bios.rs
+++ b/crates/machine/src/bus/bios.rs
@@ -777,4 +777,92 @@ mod tests {
         assert_eq!(bus.read_byte(0x0002_0001), 0x55);
         assert_eq!(bus.read_byte(0x0002_0002), 0x55);
     }
+
+    #[test]
+    fn int18h_multi_display_area_reads_paged_entry_table() {
+        let mut bus = test_bus();
+        setup_hle_page_tables(&mut bus);
+        let mut cpu = TestCpu::default();
+        cpu.set_ax(0x0F00);
+        cpu.set_bx(0x2000);
+        cpu.set_cx(0x0000);
+        cpu.set_dx(0x0001);
+
+        // Stale data at the linear address so we know the read came from the
+        // physical mapping.
+        write_bus_word(&mut bus, 0x0002_0000, 0xAAAA);
+        write_bus_word(&mut bus, 0x0002_0002, 0xBBBB);
+
+        // Real table at the physical address.
+        write_bus_word(&mut bus, 0x0003_0000, 0x0080);
+        write_bus_word(&mut bus, 0x0003_0002, 0x0001);
+
+        bus.hle_int18h(&mut cpu);
+
+        assert_eq!(bus.gdc_master.state.scroll[0].start_address, 0x0040);
+        assert_ne!(bus.gdc_master.state.scroll[0].line_count, 0);
+    }
+
+    #[test]
+    fn int19h_rx_count_reads_paged_buf_base() {
+        let mut bus = test_bus();
+        setup_hle_page_tables(&mut bus);
+        let mut cpu = TestCpu::default();
+
+        // BDA pointer at 0x0556/0x0558 points at linear 0x0002_0000.
+        bus.ram_write_u16(0x0556, 0x0000);
+        bus.ram_write_u16(0x0558, 0x2000);
+
+        // Mark the buffer as initialized at the physical address (R_FLAG bit 7).
+        bus.write_byte(0x0003_0002, 0x80);
+
+        // Stale R_CNT at linear, real R_CNT at physical.
+        write_bus_word(&mut bus, 0x0002_000E, 0xAAAA);
+        write_bus_word(&mut bus, 0x0003_000E, 0x1234);
+
+        // Mark linear as supervisor flag too so the bug-only path would see 0.
+        bus.write_byte(0x0002_0002, 0x00);
+
+        cpu.set_ax(0x0200);
+        bus.hle_int19h(&mut cpu);
+
+        assert_eq!(cpu.cx(), 0x1234);
+        assert_eq!(cpu.ah(), 0x00);
+    }
+
+    #[test]
+    fn int0ch_serial_irq_writes_paged_buf_base() {
+        let mut bus = test_bus();
+        setup_hle_page_tables(&mut bus);
+        let mut cpu = TestCpu::default();
+
+        // BDA pointer at 0x0556/0x0558 points at linear 0x0002_0000.
+        bus.ram_write_u16(0x0556, 0x0000);
+        bus.ram_write_u16(0x0558, 0x2000);
+
+        // Buffer ring config at the physical address. R_HEADP=R_PUTP=0x0014,
+        // R_TAILP=0x0024, R_GETP=0x0014, R_CNT=0, R_FLAG=0 (BFULL clear).
+        write_bus_word(&mut bus, 0x0003_000A, 0x0014); // R_HEADP
+        write_bus_word(&mut bus, 0x0003_000C, 0x0024); // R_TAILP
+        write_bus_word(&mut bus, 0x0003_000E, 0x0000); // R_CNT
+        write_bus_word(&mut bus, 0x0003_0010, 0x0014); // R_PUTP
+        write_bus_word(&mut bus, 0x0003_0012, 0x0014); // R_GETP
+        bus.write_byte(0x0003_0002, 0x00); // R_FLAG (no overflow)
+
+        // Stale conflicting data at linear: if the handler reads/writes
+        // through the linear path the test will see different values.
+        write_bus_word(&mut bus, 0x0002_000E, 0xAAAA);
+        bus.write_byte(0x0002_0002, 0xFF);
+
+        bus.hle_int0ch(&mut cpu);
+
+        // R_INT (offset 0x00) should be set with bit 7.
+        let r_int = bus.read_byte(0x0003_0000);
+        assert_ne!(r_int & 0x80, 0);
+        // R_CNT incremented to 1 at the physical address.
+        assert_eq!(read_bus_word(&mut bus, 0x0003_000E), 0x0001);
+        // Linear address must be untouched.
+        assert_eq!(read_bus_word(&mut bus, 0x0002_000E), 0xAAAA);
+        assert_eq!(bus.read_byte(0x0002_0002), 0xFF);
+    }
 }

--- a/crates/machine/src/bus/bios.rs
+++ b/crates/machine/src/bus/bios.rs
@@ -26,13 +26,36 @@ use super::{
 use crate::{Tracing, memory::Pc9801Memory};
 
 const PIT_CLOCK_8MHZ_LINEAGE: u32 = 1_996_800;
+const PAGE_PRESENT: u32 = 0x01;
+const PAGE_ACCESSED: u32 = 0x20;
+const PAGE_DIRTY: u32 = 0x40;
 
 fn iret_stack_base(cpu: &impl Cpu) -> u32 {
     cpu.segment_base(SegmentRegister::SS)
         .wrapping_add(u32::from(cpu.sp()))
 }
 
-pub(super) fn hle_page_translate(cr0: u32, cr3: u32, linear: u32, memory: &Pc9801Memory) -> u32 {
+fn hle_read_dword(memory: &Pc9801Memory, address: u32) -> u32 {
+    memory.read_byte(address) as u32
+        | ((memory.read_byte(address + 1) as u32) << 8)
+        | ((memory.read_byte(address + 2) as u32) << 16)
+        | ((memory.read_byte(address + 3) as u32) << 24)
+}
+
+fn hle_write_dword(memory: &mut Pc9801Memory, address: u32, value: u32) {
+    memory.write_byte(address, value as u8);
+    memory.write_byte(address + 1, (value >> 8) as u8);
+    memory.write_byte(address + 2, (value >> 16) as u8);
+    memory.write_byte(address + 3, (value >> 24) as u8);
+}
+
+fn hle_page_translate_access(
+    cr0: u32,
+    cr3: u32,
+    linear: u32,
+    write: bool,
+    memory: &mut Pc9801Memory,
+) -> u32 {
     if cr0 & 0x8000_0001 != 0x8000_0001 {
         return linear;
     }
@@ -40,22 +63,48 @@ pub(super) fn hle_page_translate(cr0: u32, cr3: u32, linear: u32, memory: &Pc980
     let tbl_idx = (linear >> 12) & 0x3FF;
     let offset = linear & 0xFFF;
     let pde_addr = (cr3 & 0xFFFFF000) + dir_idx * 4;
-    let pde = memory.read_byte(pde_addr) as u32
-        | ((memory.read_byte(pde_addr + 1) as u32) << 8)
-        | ((memory.read_byte(pde_addr + 2) as u32) << 16)
-        | ((memory.read_byte(pde_addr + 3) as u32) << 24);
-    if pde & 1 == 0 {
+    let pde = hle_read_dword(memory, pde_addr);
+    if pde & PAGE_PRESENT == 0 {
         return linear;
     }
     let pte_addr = (pde & 0xFFFFF000) + tbl_idx * 4;
-    let pte = memory.read_byte(pte_addr) as u32
-        | ((memory.read_byte(pte_addr + 1) as u32) << 8)
-        | ((memory.read_byte(pte_addr + 2) as u32) << 16)
-        | ((memory.read_byte(pte_addr + 3) as u32) << 24);
-    if pte & 1 == 0 {
+    let pte = hle_read_dword(memory, pte_addr);
+    if pte & PAGE_PRESENT == 0 {
         return linear;
     }
+
+    let accessed_pde = pde | PAGE_ACCESSED;
+    if accessed_pde != pde {
+        hle_write_dword(memory, pde_addr, accessed_pde);
+    }
+
+    let mut accessed_pte = pte | PAGE_ACCESSED;
+    if write {
+        accessed_pte |= PAGE_DIRTY;
+    }
+    if accessed_pte != pte {
+        hle_write_dword(memory, pte_addr, accessed_pte);
+    }
+
     (pte & 0xFFFFF000) | offset
+}
+
+pub(super) fn hle_page_translate_read(
+    cr0: u32,
+    cr3: u32,
+    linear: u32,
+    memory: &mut Pc9801Memory,
+) -> u32 {
+    hle_page_translate_access(cr0, cr3, linear, false, memory)
+}
+
+pub(super) fn hle_page_translate_write(
+    cr0: u32,
+    cr3: u32,
+    linear: u32,
+    memory: &mut Pc9801Memory,
+) -> u32 {
+    hle_page_translate_access(cr0, cr3, linear, true, memory)
 }
 
 fn boot_sector_has_signature(data: &[u8]) -> bool {
@@ -184,18 +233,24 @@ impl<T: Tracing> Pc9801Bus<T> {
         cpu.segment_base(seg).wrapping_add(off)
     }
 
-    fn hle_physical_address(&self, cpu: &impl Cpu, seg: SegmentRegister, off: u32) -> u32 {
+    fn hle_physical_address(
+        &mut self,
+        cpu: &impl Cpu,
+        seg: SegmentRegister,
+        off: u32,
+        write: bool,
+    ) -> u32 {
         let linear = self.hle_linear_address(cpu, seg, off);
-        hle_page_translate(self.hle_cr0, self.hle_cr3, linear, &self.memory)
+        hle_page_translate_access(self.hle_cr0, self.hle_cr3, linear, write, &mut self.memory)
     }
 
-    fn hle_read_byte(&self, cpu: &impl Cpu, seg: SegmentRegister, off: u32) -> u8 {
-        let phys = self.hle_physical_address(cpu, seg, off);
+    fn hle_read_byte(&mut self, cpu: &impl Cpu, seg: SegmentRegister, off: u32) -> u8 {
+        let phys = self.hle_physical_address(cpu, seg, off, false);
         self.read_byte_direct(phys)
     }
 
     fn hle_write_byte(&mut self, cpu: &impl Cpu, seg: SegmentRegister, off: u32, value: u8) {
-        let phys = self.hle_physical_address(cpu, seg, off);
+        let phys = self.hle_physical_address(cpu, seg, off, true);
         self.memory.write_byte(phys, value);
     }
 
@@ -244,5 +299,96 @@ impl<T: Tracing> Pc9801Bus<T> {
             count += 1;
         }
         count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::MachineModel;
+
+    use super::{
+        PAGE_ACCESSED, PAGE_DIRTY, hle_page_translate_read, hle_page_translate_write,
+        hle_read_dword, hle_write_dword,
+    };
+    use crate::memory::Pc9801Memory;
+
+    fn test_memory() -> Pc9801Memory {
+        Pc9801Memory::new(MachineModel::PC9801RA, 0x400000)
+    }
+
+    #[test]
+    fn hle_translate_read_sets_accessed_bits() {
+        let mut memory = test_memory();
+        let cr0 = 0x8000_0001;
+        let cr3 = 0x0000_1000;
+        let linear = 0x0040_1234;
+        let pde_addr = cr3 + 4;
+        let pte_addr = 0x0000_2004;
+
+        hle_write_dword(&mut memory, pde_addr, 0x0000_2003);
+        hle_write_dword(&mut memory, pte_addr, 0x0000_3003);
+
+        let physical = hle_page_translate_read(cr0, cr3, linear, &mut memory);
+
+        assert_eq!(physical, 0x0000_3234);
+        assert_eq!(
+            hle_read_dword(&memory, pde_addr),
+            0x0000_2003 | PAGE_ACCESSED
+        );
+        assert_eq!(
+            hle_read_dword(&memory, pte_addr),
+            0x0000_3003 | PAGE_ACCESSED
+        );
+    }
+
+    #[test]
+    fn hle_translate_write_sets_accessed_and_dirty_bits() {
+        let mut memory = test_memory();
+        let cr0 = 0x8000_0001;
+        let cr3 = 0x0000_1000;
+        let linear = 0x0040_1234;
+        let pde_addr = cr3 + 4;
+        let pte_addr = 0x0000_2004;
+
+        hle_write_dword(&mut memory, pde_addr, 0x0000_2003);
+        hle_write_dword(&mut memory, pte_addr, 0x0000_3003);
+
+        let physical = hle_page_translate_write(cr0, cr3, linear, &mut memory);
+
+        assert_eq!(physical, 0x0000_3234);
+        assert_eq!(
+            hle_read_dword(&memory, pde_addr),
+            0x0000_2003 | PAGE_ACCESSED
+        );
+        assert_eq!(
+            hle_read_dword(&memory, pte_addr),
+            0x0000_3003 | PAGE_ACCESSED | PAGE_DIRTY
+        );
+    }
+
+    #[test]
+    fn hle_translate_non_present_returns_linear_without_side_effects() {
+        let mut memory = test_memory();
+        let cr0 = 0x8000_0001;
+        let cr3 = 0x0000_1000;
+        let linear = 0x0040_1234;
+        let pde_addr = cr3 + 4;
+
+        hle_write_dword(&mut memory, pde_addr, 0x0000_2002);
+
+        let physical = hle_page_translate_write(cr0, cr3, linear, &mut memory);
+
+        assert_eq!(physical, linear);
+        assert_eq!(hle_read_dword(&memory, pde_addr), 0x0000_2002);
+    }
+
+    #[test]
+    fn hle_translate_paging_disabled_returns_linear() {
+        let mut memory = test_memory();
+        let linear = 0x0040_1234;
+
+        let physical = hle_page_translate_write(0, 0x0000_1000, linear, &mut memory);
+
+        assert_eq!(physical, linear);
     }
 }

--- a/crates/machine/src/bus/bios.rs
+++ b/crates/machine/src/bus/bios.rs
@@ -162,8 +162,8 @@ impl<T: Tracing> Pc9801Bus<T> {
         // values and adjust SP so the IRET frame sits at SS:SP+0.
         let sp = cpu.sp();
         let ss_base = cpu.segment_base(SegmentRegister::SS);
-        let saved_dx = self.read_word_direct(ss_base.wrapping_add(u32::from(sp)));
-        let saved_ax = self.read_word_direct(ss_base.wrapping_add(u32::from(sp.wrapping_add(2))));
+        let saved_dx = self.read_mem_word(ss_base.wrapping_add(u32::from(sp)));
+        let saved_ax = self.read_mem_word(ss_base.wrapping_add(u32::from(sp.wrapping_add(2))));
         cpu.set_dx(saved_dx);
         cpu.set_ax(saved_ax);
         cpu.set_sp(sp.wrapping_add(4));
@@ -257,14 +257,13 @@ impl<T: Tracing> Pc9801Bus<T> {
     fn set_iret_cf(&mut self, cpu: &impl Cpu, error: bool) {
         let base = iret_stack_base(cpu);
         let flags_addr = base + 0x04;
-        let mut flags = self.read_word_direct(flags_addr);
+        let mut flags = self.read_mem_word(flags_addr);
         if error {
             flags |= 0x0001;
         } else {
             flags &= !0x0001;
         }
-        self.memory.write_byte(flags_addr, flags as u8);
-        self.memory.write_byte(flags_addr + 1, (flags >> 8) as u8);
+        self.write_mem_word(flags_addr, flags);
     }
 
     fn write_result_ah_cf(&mut self, cpu: &mut impl Cpu, result_ah: u8) {
@@ -272,9 +271,23 @@ impl<T: Tracing> Pc9801Bus<T> {
         self.set_iret_cf(cpu, result_ah >= 0x20);
     }
 
+    fn read_mem_byte(&mut self, addr: u32) -> u8 {
+        let phys = hle_page_translate_read(self.hle_cr0, self.hle_cr3, addr, &mut self.memory);
+        self.memory.read_byte(phys)
+    }
+
+    fn read_mem_word(&mut self, addr: u32) -> u16 {
+        u16::from(self.read_mem_byte(addr)) | (u16::from(self.read_mem_byte(addr + 1)) << 8)
+    }
+
+    fn write_mem_byte(&mut self, addr: u32, value: u8) {
+        let phys = hle_page_translate_write(self.hle_cr0, self.hle_cr3, addr, &mut self.memory);
+        self.memory.write_byte(phys, value);
+    }
+
     fn write_mem_word(&mut self, addr: u32, value: u16) {
-        self.memory.write_byte(addr, value as u8);
-        self.memory.write_byte(addr + 1, (value >> 8) as u8);
+        self.write_mem_byte(addr, value as u8);
+        self.write_mem_byte(addr + 1, (value >> 8) as u8);
     }
 
     fn ram_read_u16(&self, addr: usize) -> u16 {
@@ -304,16 +317,237 @@ impl<T: Tracing> Pc9801Bus<T> {
 
 #[cfg(test)]
 mod tests {
-    use common::MachineModel;
+    use common::{Bus, Cpu, CpuMode, CpuType, MachineModel, NoTracing, SegmentRegister};
 
     use super::{
         PAGE_ACCESSED, PAGE_DIRTY, hle_page_translate_read, hle_page_translate_write,
         hle_read_dword, hle_write_dword,
     };
-    use crate::memory::Pc9801Memory;
+    use crate::{Pc9801Bus, memory::Pc9801Memory};
+
+    #[derive(Default)]
+    struct TestCpu {
+        ax: u16,
+        bx: u16,
+        cx: u16,
+        dx: u16,
+        sp: u16,
+        bp: u16,
+        si: u16,
+        di: u16,
+        es: u16,
+        cs: u16,
+        ss: u16,
+        ds: u16,
+        ip: u16,
+        flags: u16,
+        es_base: u32,
+        cs_base: u32,
+        ss_base: u32,
+        ds_base: u32,
+    }
+
+    impl TestCpu {
+        fn set_segment_base_for_test(&mut self, seg: SegmentRegister, base: u32) {
+            match seg {
+                SegmentRegister::ES => self.es_base = base,
+                SegmentRegister::CS => self.cs_base = base,
+                SegmentRegister::SS => self.ss_base = base,
+                SegmentRegister::DS => self.ds_base = base,
+            }
+        }
+    }
+
+    impl Cpu for TestCpu {
+        fn run_for(&mut self, _cycles_to_run: u64, _bus: &mut impl Bus) -> u64 {
+            0
+        }
+
+        fn reset(&mut self) {}
+
+        fn halted(&self) -> bool {
+            false
+        }
+
+        fn ax(&self) -> u16 {
+            self.ax
+        }
+
+        fn set_ax(&mut self, v: u16) {
+            self.ax = v;
+        }
+
+        fn bx(&self) -> u16 {
+            self.bx
+        }
+
+        fn set_bx(&mut self, v: u16) {
+            self.bx = v;
+        }
+
+        fn cx(&self) -> u16 {
+            self.cx
+        }
+
+        fn set_cx(&mut self, v: u16) {
+            self.cx = v;
+        }
+
+        fn dx(&self) -> u16 {
+            self.dx
+        }
+
+        fn set_dx(&mut self, v: u16) {
+            self.dx = v;
+        }
+
+        fn sp(&self) -> u16 {
+            self.sp
+        }
+
+        fn set_sp(&mut self, v: u16) {
+            self.sp = v;
+        }
+
+        fn bp(&self) -> u16 {
+            self.bp
+        }
+
+        fn set_bp(&mut self, v: u16) {
+            self.bp = v;
+        }
+
+        fn si(&self) -> u16 {
+            self.si
+        }
+
+        fn set_si(&mut self, v: u16) {
+            self.si = v;
+        }
+
+        fn di(&self) -> u16 {
+            self.di
+        }
+
+        fn set_di(&mut self, v: u16) {
+            self.di = v;
+        }
+
+        fn es(&self) -> u16 {
+            self.es
+        }
+
+        fn set_es(&mut self, v: u16) {
+            self.es = v;
+            self.es_base = u32::from(v) << 4;
+        }
+
+        fn cs(&self) -> u16 {
+            self.cs
+        }
+
+        fn set_cs(&mut self, v: u16) {
+            self.cs = v;
+            self.cs_base = u32::from(v) << 4;
+        }
+
+        fn ss(&self) -> u16 {
+            self.ss
+        }
+
+        fn set_ss(&mut self, v: u16) {
+            self.ss = v;
+            self.ss_base = u32::from(v) << 4;
+        }
+
+        fn ds(&self) -> u16 {
+            self.ds
+        }
+
+        fn set_ds(&mut self, v: u16) {
+            self.ds = v;
+            self.ds_base = u32::from(v) << 4;
+        }
+
+        fn ip(&self) -> u16 {
+            self.ip
+        }
+
+        fn set_ip(&mut self, v: u16) {
+            self.ip = v;
+        }
+
+        fn flags(&self) -> u16 {
+            self.flags
+        }
+
+        fn set_flags(&mut self, v: u16) {
+            self.flags = v;
+        }
+
+        fn cpu_type(&self) -> CpuType {
+            CpuType::I386
+        }
+
+        fn load_segment_real_mode(&mut self, seg: SegmentRegister, selector: u16) {
+            match seg {
+                SegmentRegister::ES => self.set_es(selector),
+                SegmentRegister::CS => self.set_cs(selector),
+                SegmentRegister::SS => self.set_ss(selector),
+                SegmentRegister::DS => self.set_ds(selector),
+            }
+        }
+
+        fn segment_base(&self, seg: SegmentRegister) -> u32 {
+            match seg {
+                SegmentRegister::ES => self.es_base,
+                SegmentRegister::CS => self.cs_base,
+                SegmentRegister::SS => self.ss_base,
+                SegmentRegister::DS => self.ds_base,
+            }
+        }
+    }
+
+    fn test_bus() -> Pc9801Bus<NoTracing> {
+        Pc9801Bus::new(MachineModel::PC9801RA, CpuMode::Low, 48000)
+    }
 
     fn test_memory() -> Pc9801Memory {
         Pc9801Memory::new(MachineModel::PC9801RA, 0x400000)
+    }
+
+    fn write_bus_dword(bus: &mut Pc9801Bus<NoTracing>, address: u32, value: u32) {
+        bus.write_byte(address, value as u8);
+        bus.write_byte(address + 1, (value >> 8) as u8);
+        bus.write_byte(address + 2, (value >> 16) as u8);
+        bus.write_byte(address + 3, (value >> 24) as u8);
+    }
+
+    fn setup_hle_page_tables(bus: &mut Pc9801Bus<NoTracing>) {
+        const PAGE_PRESENT_WRITE: u32 = 0x03;
+        let page_dir = 0x0008_0000;
+        let page_table = 0x0008_1000;
+
+        write_bus_dword(bus, page_dir, page_table | PAGE_PRESENT_WRITE);
+        for page in 0..256u32 {
+            write_bus_dword(
+                bus,
+                page_table + page * 4,
+                (page * 0x1000) | PAGE_PRESENT_WRITE,
+            );
+        }
+
+        write_bus_dword(bus, page_table + 0x20 * 4, 0x0003_0000 | PAGE_PRESENT_WRITE);
+        bus.set_hle_paging(0x8000_0001, page_dir);
+    }
+
+    fn write_bus_word(bus: &mut Pc9801Bus<NoTracing>, address: u32, value: u16) {
+        bus.write_byte(address, value as u8);
+        bus.write_byte(address + 1, (value >> 8) as u8);
+    }
+
+    fn read_bus_word(bus: &mut Pc9801Bus<NoTracing>, address: u32) -> u16 {
+        u16::from(bus.read_byte(address)) | (u16::from(bus.read_byte(address + 1)) << 8)
     }
 
     #[test]
@@ -390,5 +624,157 @@ mod tests {
         let physical = hle_page_translate_write(0, 0x0000_1000, linear, &mut memory);
 
         assert_eq!(physical, linear);
+    }
+
+    #[test]
+    fn execute_bios_hle_restores_saved_registers_from_paged_stack() {
+        let mut bus = test_bus();
+        setup_hle_page_tables(&mut bus);
+        let mut cpu = TestCpu::default();
+        cpu.set_sp(0);
+        cpu.set_segment_base_for_test(SegmentRegister::SS, 0x0002_0000);
+
+        write_bus_word(&mut bus, 0x0002_0000, 0xAAAA);
+        write_bus_word(&mut bus, 0x0002_0002, 0xBBBB);
+        write_bus_word(&mut bus, 0x0003_0000, 0x5678);
+        write_bus_word(&mut bus, 0x0003_0002, 0x0200);
+        bus.bios.write_trap_port(0x18);
+
+        bus.execute_bios_hle(&mut cpu);
+
+        assert_eq!(cpu.dx(), 0x5678);
+        assert_eq!(cpu.ax(), 0x0200);
+        assert_eq!(cpu.sp(), 0x0004);
+        assert_eq!(read_bus_word(&mut bus, 0x0002_0000), 0xAAAA);
+        assert_eq!(read_bus_word(&mut bus, 0x0002_0002), 0xBBBB);
+    }
+
+    #[test]
+    fn set_iret_cf_uses_paged_stack_frame() {
+        let mut bus = test_bus();
+        setup_hle_page_tables(&mut bus);
+        let mut cpu = TestCpu::default();
+        cpu.set_sp(0);
+        cpu.set_segment_base_for_test(SegmentRegister::SS, 0x0002_0000);
+
+        write_bus_word(&mut bus, 0x0002_0004, 0x5555);
+        write_bus_word(&mut bus, 0x0003_0004, 0x0200);
+
+        bus.set_iret_cf(&cpu, true);
+
+        assert_eq!(read_bus_word(&mut bus, 0x0003_0004), 0x0201);
+        assert_eq!(read_bus_word(&mut bus, 0x0002_0004), 0x5555);
+
+        bus.set_iret_cf(&cpu, false);
+
+        assert_eq!(read_bus_word(&mut bus, 0x0003_0004), 0x0200);
+        assert_eq!(read_bus_word(&mut bus, 0x0002_0004), 0x5555);
+    }
+
+    #[test]
+    fn int18h_key_read_rewinds_paged_iret_frame() {
+        let mut bus = test_bus();
+        setup_hle_page_tables(&mut bus);
+        let mut cpu = TestCpu::default();
+        cpu.set_sp(0x0100);
+        cpu.set_segment_base_for_test(SegmentRegister::SS, 0x0002_0000);
+
+        write_bus_word(&mut bus, 0x0002_0100, 0xAAAA);
+        write_bus_word(&mut bus, 0x0002_0104, 0xBBBB);
+        write_bus_word(&mut bus, 0x0003_0100, 0x1234);
+        write_bus_word(&mut bus, 0x0003_0104, 0x0000);
+
+        bus.int18h_key_read(&mut cpu);
+
+        assert_eq!(read_bus_word(&mut bus, 0x0003_0100), 0x1232);
+        assert_eq!(read_bus_word(&mut bus, 0x0003_0104), 0x0200);
+        assert_eq!(read_bus_word(&mut bus, 0x0002_0100), 0xAAAA);
+        assert_eq!(read_bus_word(&mut bus, 0x0002_0104), 0xBBBB);
+    }
+
+    #[test]
+    fn hle_int08h_chains_callback_on_paged_stack() {
+        let mut bus = test_bus();
+        setup_hle_page_tables(&mut bus);
+        let mut cpu = TestCpu::default();
+        cpu.set_sp(0x0100);
+        cpu.set_segment_base_for_test(SegmentRegister::SS, 0x0002_0000);
+
+        bus.bios_interval_timer_active = true;
+        bus.ram_write_u16(0x058A, 1);
+        bus.ram_write_u16(0x001C, 0x2222);
+        bus.ram_write_u16(0x001E, 0x3333);
+
+        write_bus_word(&mut bus, 0x0002_00FA, 0xAAAA);
+        write_bus_word(&mut bus, 0x0002_00FC, 0xBBBB);
+        write_bus_word(&mut bus, 0x0002_00FE, 0xCCCC);
+        write_bus_word(&mut bus, 0x0003_0104, 0x0202);
+
+        bus.hle_int08h(&mut cpu);
+
+        assert_eq!(cpu.sp(), 0x00FA);
+        assert_eq!(read_bus_word(&mut bus, 0x0003_00FA), 0x2222);
+        assert_eq!(read_bus_word(&mut bus, 0x0003_00FC), 0x3333);
+        assert_eq!(read_bus_word(&mut bus, 0x0003_00FE), 0x0002);
+        assert_eq!(read_bus_word(&mut bus, 0x0002_00FA), 0xAAAA);
+        assert_eq!(read_bus_word(&mut bus, 0x0002_00FC), 0xBBBB);
+        assert_eq!(read_bus_word(&mut bus, 0x0002_00FE), 0xCCCC);
+    }
+
+    #[test]
+    fn hle_int09h_chains_copy_vector_on_paged_stack() {
+        let mut bus = test_bus();
+        setup_hle_page_tables(&mut bus);
+        let mut cpu = TestCpu::default();
+        cpu.set_sp(0);
+        cpu.set_segment_base_for_test(SegmentRegister::SS, 0x0002_0000);
+
+        bus.keyboard_chained_raw_code = Some(0x60);
+        bus.ram_write_u16(0x0018, 0x4321);
+        bus.ram_write_u16(0x001A, 0x8765);
+
+        write_bus_word(&mut bus, 0x0002_0000, 0xAAAA);
+        write_bus_word(&mut bus, 0x0002_0002, 0xBBBB);
+        write_bus_word(&mut bus, 0x0002_0004, 0xCCCC);
+        write_bus_word(&mut bus, 0x0003_0000, 0x1111);
+        write_bus_word(&mut bus, 0x0003_0002, 0x2222);
+        write_bus_word(&mut bus, 0x0003_0004, 0x0202);
+
+        bus.hle_int09h(&mut cpu);
+
+        assert_eq!(read_bus_word(&mut bus, 0x0003_0000), 0x4321);
+        assert_eq!(read_bus_word(&mut bus, 0x0003_0002), 0x8765);
+        assert_eq!(read_bus_word(&mut bus, 0x0003_0004), 0x0002);
+        assert_eq!(read_bus_word(&mut bus, 0x0003_0006), 0x1111);
+        assert_eq!(read_bus_word(&mut bus, 0x0003_0008), 0x2222);
+        assert_eq!(read_bus_word(&mut bus, 0x0003_000A), 0x0202);
+        assert_eq!(read_bus_word(&mut bus, 0x0002_0000), 0xAAAA);
+        assert_eq!(read_bus_word(&mut bus, 0x0002_0002), 0xBBBB);
+        assert_eq!(read_bus_word(&mut bus, 0x0002_0004), 0xCCCC);
+    }
+
+    #[test]
+    fn int18h_font_pattern_read_writes_paged_output_buffer() {
+        let mut bus = test_bus();
+        setup_hle_page_tables(&mut bus);
+        let mut cpu = TestCpu::default();
+        cpu.set_ax(0x1400);
+        cpu.set_bx(0x2000);
+        cpu.set_cx(0x0000);
+        cpu.set_dx(0x8000);
+        bus.memory.font_write(0x80000, 0xA5);
+
+        for i in 0..18u32 {
+            bus.write_byte(0x0002_0000 + i, 0x55);
+            bus.write_byte(0x0003_0000 + i, 0x77);
+        }
+
+        bus.hle_int18h(&mut cpu);
+
+        assert_eq!(read_bus_word(&mut bus, 0x0003_0000), 0x0102);
+        assert_eq!(bus.read_byte(0x0003_0002), 0xA5);
+        assert_eq!(bus.read_byte(0x0002_0000), 0x55);
+        assert_eq!(bus.read_byte(0x0002_0001), 0x55);
+        assert_eq!(bus.read_byte(0x0002_0002), 0x55);
     }
 }

--- a/crates/machine/src/bus/bios/cmt_printer.rs
+++ b/crates/machine/src/bus/bios/cmt_printer.rs
@@ -53,7 +53,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                             cpu.set_bx(src_off);
                             return;
                         }
-                        let byte = self.read_byte_direct(src_base + u32::from(i));
+                        let byte = self.read_mem_byte(src_base + u32::from(i));
                         self.printer.write_data(byte);
                         let old_c = self.printer.read_port_c();
                         self.printer.write_port_c(old_c | 0x80);

--- a/crates/machine/src/bus/bios/comed.rs
+++ b/crates/machine/src/bus/bios/comed.rs
@@ -35,9 +35,9 @@ impl<T: Tracing> Pc9801Bus<T> {
                 // BOVF check at function exit: if buffer overflow occurred,
                 // clear the flag and return AH=2.
                 let buf_base = self.int19h_get_buf_base();
-                let flag = self.read_byte_direct(buf_base + 0x02);
+                let flag = self.read_mem_byte(buf_base + 0x02);
                 if flag & 0x20 != 0 {
-                    self.memory.write_byte(buf_base + 0x02, flag & !0x20);
+                    self.write_mem_byte(buf_base + 0x02, flag & !0x20);
                     cpu.set_ah(0x02);
                 }
             }
@@ -51,12 +51,12 @@ impl<T: Tracing> Pc9801Bus<T> {
         (u32::from(segment) << 4).wrapping_add(u32::from(offset))
     }
 
-    fn int19h_is_initialized(&self) -> bool {
+    fn int19h_is_initialized(&mut self) -> bool {
         let buf_base = self.int19h_get_buf_base();
         if buf_base == 0 {
             return false;
         }
-        let flag = self.read_byte_direct(buf_base + 0x02);
+        let flag = self.read_mem_byte(buf_base + 0x02);
         flag & 0x80 != 0
     }
 
@@ -107,8 +107,8 @@ impl<T: Tracing> Pc9801Bus<T> {
         let data_end = data_start + buf_size;
 
         // R_INT (offset 0x00) and R_BFLG (offset 0x01): clear stale state.
-        self.memory.write_byte(buf_base, 0x00);
-        self.memory.write_byte(buf_base + 0x01, 0x00);
+        self.write_mem_byte(buf_base, 0x00);
+        self.write_mem_byte(buf_base + 0x01, 0x00);
 
         // R_FLAG (offset 0x02): set AH<<4, only add RFLAG_INIT if IR bit clear.
         let cmd = cpu.cl();
@@ -125,49 +125,38 @@ impl<T: Tracing> Pc9801Bus<T> {
                 self.pic.invalidate_irq_cache();
             }
         }
-        self.memory.write_byte(buf_base + 0x02, flag);
+        self.write_mem_byte(buf_base + 0x02, flag);
 
         // R_CMD (offset 0x03).
-        self.memory.write_byte(buf_base + 0x03, cmd);
+        self.write_mem_byte(buf_base + 0x03, cmd);
         // R_STIME (offset 0x04) = BH, default 0x04 if zero.
         let stime = if cpu.bh() == 0 { 0x04 } else { cpu.bh() };
-        self.memory.write_byte(buf_base + 0x04, stime);
+        self.write_mem_byte(buf_base + 0x04, stime);
         // R_RTIME (offset 0x05) = BL, default 0x40 if zero.
         let rtime = if cpu.bx() as u8 == 0 {
             0x40
         } else {
             cpu.bx() as u8
         };
-        self.memory.write_byte(buf_base + 0x05, rtime);
+        self.write_mem_byte(buf_base + 0x05, rtime);
 
         // R_XOFF (offset 0x06) = buf_size / 8.
         let xoff = buf_size / 8;
-        self.memory.write_byte(buf_base + 0x06, xoff as u8);
-        self.memory.write_byte(buf_base + 0x07, (xoff >> 8) as u8);
+        self.write_mem_word(buf_base + 0x06, xoff);
         // R_XON (offset 0x08) = XOFF + buf_size / 4.
         let xon = xoff + buf_size / 4;
-        self.memory.write_byte(buf_base + 0x08, xon as u8);
-        self.memory.write_byte(buf_base + 0x09, (xon >> 8) as u8);
+        self.write_mem_word(buf_base + 0x08, xon);
 
         // R_HEADP (offset 0x0A).
-        self.memory.write_byte(buf_base + 0x0A, data_start as u8);
-        self.memory
-            .write_byte(buf_base + 0x0B, (data_start >> 8) as u8);
+        self.write_mem_word(buf_base + 0x0A, data_start);
         // R_TAILP (offset 0x0C).
-        self.memory.write_byte(buf_base + 0x0C, data_end as u8);
-        self.memory
-            .write_byte(buf_base + 0x0D, (data_end >> 8) as u8);
+        self.write_mem_word(buf_base + 0x0C, data_end);
         // R_CNT (offset 0x0E).
-        self.memory.write_byte(buf_base + 0x0E, 0x00);
-        self.memory.write_byte(buf_base + 0x0F, 0x00);
+        self.write_mem_word(buf_base + 0x0E, 0x0000);
         // R_PUTP (offset 0x10).
-        self.memory.write_byte(buf_base + 0x10, data_start as u8);
-        self.memory
-            .write_byte(buf_base + 0x11, (data_start >> 8) as u8);
+        self.write_mem_word(buf_base + 0x10, data_start);
         // R_GETP (offset 0x12).
-        self.memory.write_byte(buf_base + 0x12, data_start as u8);
-        self.memory
-            .write_byte(buf_base + 0x13, (data_start >> 8) as u8);
+        self.write_mem_word(buf_base + 0x12, data_start);
 
         // Program the serial UART command register.
         self.serial.write_command(cmd);
@@ -181,13 +170,13 @@ impl<T: Tracing> Pc9801Bus<T> {
 
         let buf_base = self.int19h_get_buf_base();
         // Set RFLAG_XON bit (bit 4).
-        let flag = self.read_byte_direct(buf_base + 0x02);
-        self.memory.write_byte(buf_base + 0x02, flag | 0x10);
+        let flag = self.read_mem_byte(buf_base + 0x02);
+        self.write_mem_byte(buf_base + 0x02, flag | 0x10);
     }
 
     fn int19h_rx_count(&mut self, cpu: &mut impl Cpu) {
         let buf_base = self.int19h_get_buf_base();
-        let count = self.read_word_direct(buf_base + 0x0E);
+        let count = self.read_mem_word(buf_base + 0x0E);
         cpu.set_cx(count);
         cpu.set_ah(0x00);
     }
@@ -201,41 +190,36 @@ impl<T: Tracing> Pc9801Bus<T> {
     fn int19h_receive(&mut self, cpu: &mut impl Cpu) -> bool {
         let buf_base = self.int19h_get_buf_base();
         let buf_seg = self.ram_read_u16(0x0558);
-        let count = self.read_word_direct(buf_base + 0x0E);
+        let count = self.read_mem_word(buf_base + 0x0E);
 
         if count == 0 {
             cpu.set_ah(0x03);
             return false;
         }
 
-        let r_getp = self.read_word_direct(buf_base + 0x12);
+        let r_getp = self.read_mem_word(buf_base + 0x12);
         let get_addr = (u32::from(buf_seg) << 4).wrapping_add(u32::from(r_getp));
-        let entry = self.read_word_direct(get_addr);
+        let entry = self.read_mem_word(get_addr);
 
         // Advance get pointer with wrap.
-        let r_tailp = self.read_word_direct(buf_base + 0x0C);
-        let r_headp = self.read_word_direct(buf_base + 0x0A);
+        let r_tailp = self.read_mem_word(buf_base + 0x0C);
+        let r_headp = self.read_mem_word(buf_base + 0x0A);
         let mut new_getp = r_getp + 2;
         if new_getp >= r_tailp {
             new_getp = r_headp;
         }
 
         let new_count = count - 1;
-        self.memory.write_byte(buf_base + 0x0E, new_count as u8);
-        self.memory
-            .write_byte(buf_base + 0x0F, (new_count >> 8) as u8);
-        self.memory.write_byte(buf_base + 0x12, new_getp as u8);
-        self.memory
-            .write_byte(buf_base + 0x13, (new_getp >> 8) as u8);
+        self.write_mem_word(buf_base + 0x0E, new_count);
+        self.write_mem_word(buf_base + 0x12, new_getp);
 
         // XON flow control: send XON if XOFF was active and count dropped below threshold.
-        let flag = self.read_byte_direct(buf_base + 0x02);
-        if (flag & 0x08) != 0 && new_count < self.read_word_direct(buf_base + 0x06) {
+        let flag = self.read_mem_byte(buf_base + 0x02);
+        if (flag & 0x08) != 0 && new_count < self.read_mem_word(buf_base + 0x06) {
             self.serial.write_data(0x11); // XON
-            self.memory
-                .write_byte(buf_base + 0x02, (flag & !0x08) & !0x20);
+            self.write_mem_byte(buf_base + 0x02, (flag & !0x08) & !0x20);
         } else {
-            self.memory.write_byte(buf_base + 0x02, flag & !0x20);
+            self.write_mem_byte(buf_base + 0x02, flag & !0x20);
         }
 
         // Return full entry word in CX (CL=status/error, CH=data).
@@ -250,10 +234,10 @@ impl<T: Tracing> Pc9801Bus<T> {
 
         self.serial.write_command(cmd);
 
-        let flag = self.read_byte_direct(buf_base + 0x02);
+        let flag = self.read_mem_byte(buf_base + 0x02);
         if cmd & 0x40 != 0 {
             // IR (internal reset): clear INIT flag, disable RxRDY, mask IRQ 4.
-            self.memory.write_byte(buf_base + 0x02, flag & !0x80);
+            self.write_mem_byte(buf_base + 0x02, flag & !0x80);
             self.system_ppi.state.port_c &= !0x01;
             self.pic.state.chips[0].imr |= 0x10;
         } else if cmd & 0x04 == 0 {
@@ -267,7 +251,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         }
         self.pic.invalidate_irq_cache();
 
-        self.memory.write_byte(buf_base + 0x03, cmd);
+        self.write_mem_byte(buf_base + 0x03, cmd);
         cpu.set_ah(0x00);
     }
 

--- a/crates/machine/src/bus/bios/crt.rs
+++ b/crates/machine/src/bus/bios/crt.rs
@@ -231,7 +231,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let font_base = 0x82000 + (char_code as u8 as usize) * 16;
                 for i in 0..8 {
                     let byte = self.memory.font_read(font_base + i);
-                    self.memory.write_byte(dest_base + 2 + i as u32, byte);
+                    self.write_mem_byte(dest_base + 2 + i as u32, byte);
                 }
             }
             0x29..=0x2B => {
@@ -240,7 +240,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let font_offset = cgrom_kanji_offset(high_byte, char_code as u8) as usize;
                 for i in 0..16 {
                     let byte = self.memory.font_read(font_offset + i);
-                    self.memory.write_byte(dest_base + 2 + i as u32, byte);
+                    self.write_mem_byte(dest_base + 2 + i as u32, byte);
                 }
             }
             0x80 => {
@@ -249,7 +249,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let font_base = 0x80000 + (char_code as u8 as usize) * 16;
                 for i in 0..16 {
                     let byte = self.memory.font_read(font_base + i);
-                    self.memory.write_byte(dest_base + 2 + i as u32, byte);
+                    self.write_mem_byte(dest_base + 2 + i as u32, byte);
                 }
             }
             _ => {
@@ -260,9 +260,8 @@ impl<T: Tracing> Pc9801Bus<T> {
                 for i in 0..16 {
                     let left = self.memory.font_read(font_offset + i);
                     let right = self.memory.font_read(font_offset + 0x800 + i);
-                    self.memory.write_byte(dest_base + 2 + (i as u32) * 2, left);
-                    self.memory
-                        .write_byte(dest_base + 2 + (i as u32) * 2 + 1, right);
+                    self.write_mem_byte(dest_base + 2 + (i as u32) * 2, left);
+                    self.write_mem_byte(dest_base + 2 + (i as u32) * 2 + 1, right);
                 }
             }
         }

--- a/crates/machine/src/bus/bios/crt.rs
+++ b/crates/machine/src/bus/bios/crt.rs
@@ -167,8 +167,8 @@ impl<T: Tracing> Pc9801Bus<T> {
                 break;
             }
             let entry_addr = (seg << 4).wrapping_add(u32::from(table_off));
-            let addr_word = self.read_word_direct(entry_addr) >> 1;
-            let lines = self.read_word_direct(entry_addr + 2) as u32 * raster;
+            let addr_word = self.read_mem_word(entry_addr) >> 1;
+            let lines = self.read_mem_word(entry_addr + 2) as u32 * raster;
 
             self.gdc_master.state.scroll[area_index].start_address = u32::from(addr_word);
             self.gdc_master.state.scroll[area_index].line_count = lines as u16;
@@ -309,8 +309,8 @@ impl<T: Tracing> Pc9801Bus<T> {
         let font_offset = cgrom_kanji_offset(jis_row, jis_col) as usize;
 
         for i in 0..16 {
-            let left = self.read_byte_direct(src_base + 2 + (i as u32) * 2);
-            let right = self.read_byte_direct(src_base + 2 + (i as u32) * 2 + 1);
+            let left = self.read_mem_byte(src_base + 2 + (i as u32) * 2);
+            let right = self.read_mem_byte(src_base + 2 + (i as u32) * 2 + 1);
             self.memory.font_write(font_offset + i, left);
             self.memory.font_write(font_offset + 0x800 + i, right);
         }

--- a/crates/machine/src/bus/bios/disk.rs
+++ b/crates/machine/src/bus/bios/disk.rs
@@ -466,9 +466,9 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let addr = self.hle_linear_address(cpu, SegmentRegister::ES, u32::from(bp));
                 let cr0 = self.hle_cr0;
                 let cr3 = self.hle_cr3;
-                let memory = &self.memory;
+                let memory = &mut self.memory;
                 self.sasi.execute_write(drive_idx, xfer, pos, addr, |a| {
-                    let phys = super::hle_page_translate(cr0, cr3, a, memory);
+                    let phys = super::hle_page_translate_read(cr0, cr3, a, memory);
                     memory.read_byte(phys)
                 })
             }
@@ -484,7 +484,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let memory = &mut self.memory;
                 self.sasi
                     .execute_read(drive_idx, xfer, pos, addr, |a, byte| {
-                        let phys = super::hle_page_translate(cr0, cr3, a, memory);
+                        let phys = super::hle_page_translate_write(cr0, cr3, a, memory);
                         memory.write_byte(phys, byte);
                     })
             }
@@ -582,9 +582,9 @@ impl<T: Tracing> Pc9801Bus<T> {
                     let addr = self.hle_linear_address(cpu, SegmentRegister::ES, u32::from(bp));
                     let cr0 = self.hle_cr0;
                     let cr3 = self.hle_cr3;
-                    let memory = &self.memory;
+                    let memory = &mut self.memory;
                     self.ide.execute_write(drive_idx, xfer, pos, addr, |a| {
-                        let phys = super::hle_page_translate(cr0, cr3, a, memory);
+                        let phys = super::hle_page_translate_read(cr0, cr3, a, memory);
                         memory.read_byte(phys)
                     })
                 }
@@ -600,7 +600,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                     let memory = &mut self.memory;
                     self.ide
                         .execute_read(drive_idx, xfer, pos, addr, |a, byte| {
-                            let phys = super::hle_page_translate(cr0, cr3, a, memory);
+                            let phys = super::hle_page_translate_write(cr0, cr3, a, memory);
                             memory.write_byte(phys, byte);
                         })
                 }

--- a/crates/machine/src/bus/bios/disk.rs
+++ b/crates/machine/src/bus/bios/disk.rs
@@ -180,7 +180,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 for _ in 0..sector_count {
                     let mut data = vec![0u8; sector_size];
                     for (j, data_byte) in data.iter_mut().enumerate() {
-                        *data_byte = self.read_byte_direct(buf_addr + offset + j as u32);
+                        *data_byte = self.read_mem_byte(buf_addr + offset + j as u32);
                     }
                     if !self.floppy.write_sector_data(
                         drive,
@@ -389,10 +389,10 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let mut chrn = Vec::with_capacity(sector_count);
                 for i in 0..sector_count {
                     let base = buf_addr + (i as u32) * 4;
-                    let c = self.read_byte_direct(base);
-                    let h = self.read_byte_direct(base + 1);
-                    let r = self.read_byte_direct(base + 2);
-                    let n = self.read_byte_direct(base + 3);
+                    let c = self.read_mem_byte(base);
+                    let h = self.read_mem_byte(base + 1);
+                    let r = self.read_mem_byte(base + 2);
+                    let n = self.read_mem_byte(base + 3);
                     chrn.push((c, h, r, n));
                 }
                 self.floppy

--- a/crates/machine/src/bus/bios/graphics.rs
+++ b/crates/machine/src/bus/bios/graphics.rs
@@ -124,7 +124,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         // map to digital[0..3], with reversed indexing vs NP21W's degpal.
         let mut col = [0u8; 4];
         for (i, col_byte) in col.iter_mut().enumerate() {
-            *col_byte = self.read_byte_direct(src_base + 4 + i as u32);
+            *col_byte = self.read_mem_byte(src_base + 4 + i as u32);
         }
         self.palette.state.digital[0] = ((col[2] & 0x0F) << 4) | (col[0] & 0x0F);
         self.palette.state.digital[1] = ((col[3] & 0x0F) << 4) | (col[1] & 0x0F);
@@ -138,12 +138,12 @@ impl<T: Tracing> Pc9801Bus<T> {
         let ucw_base = (u32::from(src_seg) << 4).wrapping_add(u32::from(src_off));
         let ch = cpu.ch();
 
-        let gbon_ptn = self.read_byte_direct(ucw_base); // GBON_PTN
-        let gbdotu = self.read_byte_direct(ucw_base + 2); // GBDOTU
-        let x = self.read_word_direct(ucw_base + 0x08) as u32; // GBSX1
-        let mut y = self.read_word_direct(ucw_base + 0x0A) as u32; // GBSY1
-        let length = self.read_word_direct(ucw_base + 0x0C) as u32; // GBLNG1
-        let pat_addr = self.read_word_direct(ucw_base + 0x0E); // GBWDPA
+        let gbon_ptn = self.read_mem_byte(ucw_base); // GBON_PTN
+        let gbdotu = self.read_mem_byte(ucw_base + 2); // GBDOTU
+        let x = self.read_mem_word(ucw_base + 0x08) as u32; // GBSX1
+        let mut y = self.read_mem_word(ucw_base + 0x0A) as u32; // GBSY1
+        let length = self.read_mem_word(ucw_base + 0x0C) as u32; // GBLNG1
+        let pat_addr = self.read_mem_word(ucw_base + 0x0E); // GBWDPA
 
         // 200-line page offset.
         if (ch & 0xC0) == 0x40 {
@@ -155,7 +155,7 @@ impl<T: Tracing> Pc9801Bus<T> {
 
         let mut i = 0u32;
         loop {
-            let pat_byte = self.read_byte_direct((ds << 4).wrapping_add(u32::from(pat_addr) + i));
+            let pat_byte = self.read_mem_byte((ds << 4).wrapping_add(u32::from(pat_addr) + i));
             let remaining = length - i * 8;
             let bits = if remaining < 8 { remaining } else { 8 };
             let mask = if bits < 8 {
@@ -231,9 +231,9 @@ impl<T: Tracing> Pc9801Bus<T> {
         let ucw_base = (u32::from(ucw_seg) << 4).wrapping_add(u32::from(ucw_off));
         let out_base = u32::from(cpu.es()) << 4;
 
-        let x = self.read_word_direct(ucw_base + 0x08); // GBSX1
-        let y = self.read_word_direct(ucw_base + 0x0A); // GBSY1
-        let lines = self.read_word_direct(ucw_base + 0x0C); // GBLNG1
+        let x = self.read_mem_word(ucw_base + 0x08); // GBSX1
+        let y = self.read_mem_word(ucw_base + 0x0A); // GBSY1
+        let lines = self.read_mem_word(ucw_base + 0x0C); // GBLNG1
 
         let pitch_bytes = 80u16;
         let word_x = x / 16;
@@ -248,8 +248,8 @@ impl<T: Tracing> Pc9801Bus<T> {
             // Read from B-plane (offset 0x0000 in graphics VRAM).
             let b_lo = self.memory.state.graphics_vram[byte_offset as usize];
             let b_hi = self.memory.state.graphics_vram[byte_offset as usize + 1];
-            self.memory.write_byte(out_base + out_offset, b_lo);
-            self.memory.write_byte(out_base + out_offset + 1, b_hi);
+            self.write_mem_byte(out_base + out_offset, b_lo);
+            self.write_mem_byte(out_base + out_offset + 1, b_hi);
             out_offset += 2;
         }
     }
@@ -260,13 +260,13 @@ impl<T: Tracing> Pc9801Bus<T> {
         let ucw_base = (u32::from(src_seg) << 4).wrapping_add(u32::from(src_off));
         let ch = cpu.ch();
 
-        let gbon_ptn = self.read_byte_direct(ucw_base); // GBON_PTN
-        let gbdotu = self.read_byte_direct(ucw_base + 2); // GBDOTU
-        let x1 = self.read_word_direct(ucw_base + 0x08) as i32; // GBSX1
-        let mut y1 = self.read_word_direct(ucw_base + 0x0A) as i32; // GBSY1
-        let x2 = self.read_word_direct(ucw_base + 0x16) as i32; // GBSX2
-        let mut y2 = self.read_word_direct(ucw_base + 0x18) as i32; // GBSY2
-        let gbdtyp = self.read_byte_direct(ucw_base + 0x28); // GBDTYP
+        let gbon_ptn = self.read_mem_byte(ucw_base); // GBON_PTN
+        let gbdotu = self.read_mem_byte(ucw_base + 2); // GBDOTU
+        let x1 = self.read_mem_word(ucw_base + 0x08) as i32; // GBSX1
+        let mut y1 = self.read_mem_word(ucw_base + 0x0A) as i32; // GBSY1
+        let x2 = self.read_mem_word(ucw_base + 0x16) as i32; // GBSX2
+        let mut y2 = self.read_mem_word(ucw_base + 0x18) as i32; // GBSY2
+        let gbdtyp = self.read_mem_byte(ucw_base + 0x28); // GBDTYP
 
         if (ch & 0xC0) == 0x40 {
             y1 += 200;
@@ -274,8 +274,8 @@ impl<T: Tracing> Pc9801Bus<T> {
         }
 
         // Line style pattern from GBMDOTI (bit-reversed).
-        let pat_hi = reverse_bits(self.read_byte_direct(ucw_base + 0x20));
-        let pat_lo = reverse_bits(self.read_byte_direct(ucw_base + 0x21));
+        let pat_hi = reverse_bits(self.read_mem_byte(ucw_base + 0x20));
+        let pat_lo = reverse_bits(self.read_mem_byte(ucw_base + 0x21));
         let pattern = ((pat_hi as u16) << 8) | pat_lo as u16;
 
         let ope = gbdotu & 3;
@@ -284,7 +284,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             0x01 => self.draw_line(x1, y1, x2, y2, pattern, gbon_ptn, ope, ch),
             0x00 | 0x02 => self.draw_rect(x1, y1, x2, y2, pattern, gbon_ptn, ope, ch),
             _ => {
-                let radius = self.read_word_direct(ucw_base + 0x1C) as i32; // GBCIR
+                let radius = self.read_mem_word(ucw_base + 0x1C) as i32; // GBCIR
                 self.draw_circle(x1, y1, radius, pattern, gbon_ptn, ope, ch);
             }
         }
@@ -413,12 +413,12 @@ impl<T: Tracing> Pc9801Bus<T> {
         let ucw_base = (u32::from(src_seg) << 4).wrapping_add(u32::from(src_off));
         let ch = cpu.ch();
 
-        let gbon_ptn = self.read_byte_direct(ucw_base); // GBON_PTN
-        let gbdotu = self.read_byte_direct(ucw_base + 2); // GBDOTU
-        let x = self.read_word_direct(ucw_base + 0x08) as u32; // GBSX1
-        let mut y = self.read_word_direct(ucw_base + 0x0A) as u32; // GBSY1
-        let gblng1 = self.read_word_direct(ucw_base + 0x0C); // GBLNG1
-        let gblng2 = self.read_word_direct(ucw_base + 0x1E); // GBLNG2
+        let gbon_ptn = self.read_mem_byte(ucw_base); // GBON_PTN
+        let gbdotu = self.read_mem_byte(ucw_base + 2); // GBDOTU
+        let x = self.read_mem_word(ucw_base + 0x08) as u32; // GBSX1
+        let mut y = self.read_mem_word(ucw_base + 0x0A) as u32; // GBSY1
+        let gblng1 = self.read_mem_word(ucw_base + 0x0C); // GBLNG1
+        let gblng2 = self.read_mem_word(ucw_base + 0x1E); // GBLNG2
 
         if (ch & 0xC0) == 0x40 {
             y += 200;
@@ -427,7 +427,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         // Read 8 bytes of GBMDOTI pattern and bit-reverse each.
         let mut pat = [0u8; 8];
         for (i, pat_byte) in pat.iter_mut().enumerate() {
-            *pat_byte = reverse_bits(self.read_byte_direct(ucw_base + 0x20 + i as u32));
+            *pat_byte = reverse_bits(self.read_mem_byte(ucw_base + 0x20 + i as u32));
         }
 
         // Height (DC+1 scan lines) and width from GBLNG1/GBLNG2.

--- a/crates/machine/src/bus/bios/keyboard.rs
+++ b/crates/machine/src/bus/bios/keyboard.rs
@@ -37,9 +37,9 @@ impl<T: Tracing> Pc9801Bus<T> {
                     // Rewrite the IRQ handler's IRET frame so it returns into
                     // the COPY/STOP vector first, with the original return
                     // frame stacked behind it.
-                    let orig_ip = self.read_word_direct(iret_base);
-                    let orig_cs = self.read_word_direct(iret_base + 0x02);
-                    let orig_flags = self.read_word_direct(iret_base + 0x04);
+                    let orig_ip = self.read_mem_word(iret_base);
+                    let orig_cs = self.read_mem_word(iret_base + 0x02);
+                    let orig_flags = self.read_mem_word(iret_base + 0x04);
                     self.write_mem_word(iret_base + 0x06, orig_ip);
                     self.write_mem_word(iret_base + 0x08, orig_cs);
                     self.write_mem_word(iret_base + 0x0A, orig_flags);
@@ -193,12 +193,12 @@ impl<T: Tracing> Pc9801Bus<T> {
             // Block until a key is available by rewinding the caller's return IP
             // in the IRET frame to re-execute the INT 18H instruction (2 bytes: CD 18).
             let base = iret_stack_base(cpu);
-            let caller_ip = self.read_word_direct(base);
+            let caller_ip = self.read_mem_word(base);
             self.write_mem_word(base, caller_ip.wrapping_sub(2));
 
             // Ensure IF is set in the IRET flags so hardware interrupts (especially
             // IRQ 1 keyboard) can fire during the wait loop.
-            let flags = self.read_word_direct(base + 4);
+            let flags = self.read_mem_word(base + 4);
             self.write_mem_word(base + 4, flags | 0x0200);
 
             // Burn enough cycles so the timeslice ends and the timer interrupt can fire.

--- a/crates/machine/src/bus/bios/serial_rs232c.rs
+++ b/crates/machine/src/bus/bios/serial_rs232c.rs
@@ -24,7 +24,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         let buf_base = (u32::from(buf_segment) << 4).wrapping_add(u32::from(buf_offset));
 
         if buf_base != 0 {
-            let mut flag = self.read_byte_direct(buf_base + 0x02);
+            let mut flag = self.read_mem_byte(buf_base + 0x02);
             let mut data = data;
 
             if flag & 0x40 == 0 {
@@ -58,34 +58,29 @@ impl<T: Tracing> Pc9801Bus<T> {
                     data = 0;
                 }
                 // Buffer not full: store data.
-                let r_putp = self.read_word_direct(buf_base + 0x10);
-                let r_tailp = self.read_word_direct(buf_base + 0x0C);
+                let r_putp = self.read_mem_word(buf_base + 0x10);
+                let r_tailp = self.read_mem_word(buf_base + 0x0C);
 
                 // Store (data << 8) | status at put pointer.
                 let entry = u16::from(status) | (u16::from(data) << 8);
                 let put_addr = (u32::from(buf_segment) << 4).wrapping_add(u32::from(r_putp));
-                self.memory.write_byte(put_addr, entry as u8);
-                self.memory.write_byte(put_addr + 1, (entry >> 8) as u8);
+                self.write_mem_word(put_addr, entry);
 
                 // Advance put pointer with wrap.
                 let mut new_putp = r_putp + 2;
                 if new_putp >= r_tailp {
-                    let r_headp = self.read_word_direct(buf_base + 0x0A);
+                    let r_headp = self.read_mem_word(buf_base + 0x0A);
                     new_putp = r_headp;
                 }
-                self.memory.write_byte(buf_base + 0x10, new_putp as u8);
-                self.memory
-                    .write_byte(buf_base + 0x11, (new_putp >> 8) as u8);
+                self.write_mem_word(buf_base + 0x10, new_putp);
 
                 // Increment counter.
-                let r_cnt = self.read_word_direct(buf_base + 0x0E);
+                let r_cnt = self.read_mem_word(buf_base + 0x0E);
                 let new_cnt = r_cnt + 1;
-                self.memory.write_byte(buf_base + 0x0E, new_cnt as u8);
-                self.memory
-                    .write_byte(buf_base + 0x0F, (new_cnt >> 8) as u8);
+                self.write_mem_word(buf_base + 0x0E, new_cnt);
 
                 // Check for buffer full (put pointer caught up to get pointer).
-                let r_getp = self.read_word_direct(buf_base + 0x12);
+                let r_getp = self.read_mem_word(buf_base + 0x12);
                 if new_putp == r_getp {
                     flag |= 0x40; // RFLAG_BFULL
                 }
@@ -93,7 +88,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 // XON/XOFF flow control: send XOFF if threshold reached.
                 // RFLAG_XON=0x10, RFLAG_XOFF=0x08.
                 if (flag & 0x18) == 0x10 {
-                    let r_xon = self.read_word_direct(buf_base + 0x08);
+                    let r_xon = self.read_mem_word(buf_base + 0x08);
                     if new_cnt >= r_xon {
                         self.serial.write_data(0x13); // XOFF
                         flag |= 0x08; // RFLAG_XOFF
@@ -101,16 +96,16 @@ impl<T: Tracing> Pc9801Bus<T> {
                 }
             } else {
                 // Buffer full: set overflow flag (RFLAG_BOVF=0x20) in R_CMD (offset 0x03).
-                let r_cmd = self.read_byte_direct(buf_base + 0x03);
-                self.memory.write_byte(buf_base + 0x03, r_cmd | 0x20);
+                let r_cmd = self.read_mem_byte(buf_base + 0x03);
+                self.write_mem_byte(buf_base + 0x03, r_cmd | 0x20);
             }
 
             // Set interrupt flag (RINT_INT=0x80) in R_INT.
-            let r_int = self.read_byte_direct(buf_base);
-            self.memory.write_byte(buf_base, r_int | 0x80);
+            let r_int = self.read_mem_byte(buf_base);
+            self.write_mem_byte(buf_base, r_int | 0x80);
 
             // Write back updated flag.
-            self.memory.write_byte(buf_base + 0x02, flag);
+            self.write_mem_byte(buf_base + 0x02, flag);
         }
 
         // Send EOI to master PIC.

--- a/crates/machine/src/bus/bios/timer.rs
+++ b/crates/machine/src/bus/bios/timer.rs
@@ -40,7 +40,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             let callback_segment = self.ram_read_u16(0x001E);
 
             if callback_offset != 0 || callback_segment != 0 {
-                let orig_flags = self.read_word_direct(iret_base + 0x04);
+                let orig_flags = self.read_mem_word(iret_base + 0x04);
                 let callback_base = iret_base.wrapping_sub(6);
                 self.write_mem_word(callback_base, callback_offset);
                 self.write_mem_word(callback_base + 0x02, callback_segment);

--- a/crates/machine/src/bus/fdd_hle.rs
+++ b/crates/machine/src/bus/fdd_hle.rs
@@ -198,7 +198,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         let r = dx as u8;
         let n = (cx >> 8) as u8;
         let requested_sector_size = 128usize << n;
-        let buffer_address = self.fdd640k_buffer_address(es, bp, 0);
+        let buffer_address = self.fdd640k_buffer_address(es, bp, 0, false);
         let transfer_bytes = if bx == 0 {
             requested_sector_size
         } else {
@@ -225,7 +225,8 @@ impl<T: Tracing> Pc9801Bus<T> {
                 if !diagnostic {
                     let copy_len = data.len().min(transfer_bytes - offset);
                     for (index, &byte) in data.iter().take(copy_len).enumerate() {
-                        let address = self.fdd640k_buffer_address(es, bp, (offset + index) as u32);
+                        let address =
+                            self.fdd640k_buffer_address(es, bp, (offset + index) as u32, true);
                         self.memory.write_byte(address, byte);
                     }
                 }
@@ -243,7 +244,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                         let copy_len = data.len().min(transfer_bytes - offset);
                         for (index, &byte) in data.iter().take(copy_len).enumerate() {
                             let address =
-                                self.fdd640k_buffer_address(es, bp, (offset + index) as u32);
+                                self.fdd640k_buffer_address(es, bp, (offset + index) as u32, true);
                             self.memory.write_byte(address, byte);
                         }
                     }
@@ -328,7 +329,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         let r = dx as u8;
         let n = (cx >> 8) as u8;
         let sector_size = 128usize << n;
-        let buffer_address = self.fdd640k_buffer_address(es, bp, 0);
+        let buffer_address = self.fdd640k_buffer_address(es, bp, 0, false);
         let transfer_bytes = if bx == 0 { sector_size } else { bx as usize };
         let sector_count = transfer_bytes / sector_size;
 
@@ -384,7 +385,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         for _ in 0..sector_count {
             let mut data = vec![0u8; sector_size];
             for (index, byte) in data.iter_mut().enumerate() {
-                let address = self.fdd640k_buffer_address(es, bp, offset + index as u32);
+                let address = self.fdd640k_buffer_address(es, bp, offset + index as u32, false);
                 *byte = self.memory.read_byte(address);
             }
 
@@ -477,18 +478,14 @@ impl<T: Tracing> Pc9801Bus<T> {
 
         for index in 0..sector_count {
             let base = (index as u32) * 4;
-            let c = self
-                .memory
-                .read_byte(self.fdd640k_buffer_address(es, bp, base));
-            let h = self
-                .memory
-                .read_byte(self.fdd640k_buffer_address(es, bp, base + 1));
-            let r = self
-                .memory
-                .read_byte(self.fdd640k_buffer_address(es, bp, base + 2));
-            let n = self
-                .memory
-                .read_byte(self.fdd640k_buffer_address(es, bp, base + 3));
+            let c_addr = self.fdd640k_buffer_address(es, bp, base, false);
+            let h_addr = self.fdd640k_buffer_address(es, bp, base + 1, false);
+            let r_addr = self.fdd640k_buffer_address(es, bp, base + 2, false);
+            let n_addr = self.fdd640k_buffer_address(es, bp, base + 3, false);
+            let c = self.memory.read_byte(c_addr);
+            let h = self.memory.read_byte(h_addr);
+            let r = self.memory.read_byte(r_addr);
+            let n = self.memory.read_byte(n_addr);
             chrn.push((c, h, r, n));
         }
 
@@ -497,11 +494,15 @@ impl<T: Tracing> Pc9801Bus<T> {
         0x00
     }
 
-    fn fdd640k_buffer_address(&self, es: u16, bp: u16, offset: u32) -> u32 {
+    fn fdd640k_buffer_address(&mut self, es: u16, bp: u16, offset: u32, write: bool) -> u32 {
         let linear = (u32::from(es) << 4)
             .wrapping_add(u32::from(bp))
             .wrapping_add(offset);
-        bios::hle_page_translate(self.hle_cr0, self.hle_cr3, linear, &self.memory)
+        if write {
+            bios::hle_page_translate_write(self.hle_cr0, self.hle_cr3, linear, &mut self.memory)
+        } else {
+            bios::hle_page_translate_read(self.hle_cr0, self.hle_cr3, linear, &mut self.memory)
+        }
     }
 
     fn fdd640k_segment_wraps(bp: u16, length: usize) -> bool {

--- a/crates/machine/src/bus/hdd.rs
+++ b/crates/machine/src/bus/hdd.rs
@@ -143,9 +143,9 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let addr = device::sasi::buffer_address(es, bp);
                 let cr0 = self.hle_cr0;
                 let cr3 = self.hle_cr3;
-                let memory = &self.memory;
+                let memory = &mut self.memory;
                 self.sasi.execute_write(drive_idx, xfer, pos, addr, |a| {
-                    let phys = bios::hle_page_translate(cr0, cr3, a, memory);
+                    let phys = bios::hle_page_translate_read(cr0, cr3, a, memory);
                     memory.read_byte(phys)
                 })
             }
@@ -161,7 +161,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let memory = &mut self.memory;
                 self.sasi
                     .execute_read(drive_idx, xfer, pos, addr, |a, byte| {
-                        let phys = bios::hle_page_translate(cr0, cr3, a, memory);
+                        let phys = bios::hle_page_translate_write(cr0, cr3, a, memory);
                         memory.write_byte(phys, byte);
                     })
             }
@@ -310,9 +310,9 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let addr = device::ide::buffer_address(es, bp);
                 let cr0 = self.hle_cr0;
                 let cr3 = self.hle_cr3;
-                let memory = &self.memory;
+                let memory = &mut self.memory;
                 self.ide.execute_write(drive_idx, xfer, pos, addr, |a| {
-                    let phys = bios::hle_page_translate(cr0, cr3, a, memory);
+                    let phys = bios::hle_page_translate_read(cr0, cr3, a, memory);
                     memory.read_byte(phys)
                 })
             }
@@ -328,7 +328,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let memory = &mut self.memory;
                 self.ide
                     .execute_read(drive_idx, xfer, pos, addr, |a, byte| {
-                        let phys = bios::hle_page_translate(cr0, cr3, a, memory);
+                        let phys = bios::hle_page_translate_write(cr0, cr3, a, memory);
                         memory.write_byte(phys, byte);
                     })
             }


### PR DESCRIPTION
With these fixes, Windows 3.1 now starts and reached the desktop. There are still issues left, but this is a huge step forward.

<img width="2115" height="1677" alt="image" src="https://github.com/user-attachments/assets/e22b55a8-bcd5-49e6-8ae3-fe48266e89a1" />
