### PR TITLE
fix: fault atomicity for the remaining instructions of the 386

### DIFF
--- a/crates/cpu/src/i286.rs
+++ b/crates/cpu/src/i286.rs
@@ -1,5 +1,8 @@
 //! Implements the Intel 80286 emulation.
 //!
+//! The protected mode is not fully developed in this core.
+//! Only some version of OS/2 1.x should need it.
+//!
 //! Following references were used to write the emulator:
 //!
 //! - Intel Corporation, "80286 Programmer's Reference Manual".

--- a/crates/cpu/src/i386.rs
+++ b/crates/cpu/src/i386.rs
@@ -39,6 +39,16 @@ pub const CPU_MODEL_486: u8 = 1;
 
 const EFLAGS_RESUME_FLAG: u32 = 0x0001_0000;
 
+/// Marker returned from any 386 primitive that may have raised a CPU exception.
+///
+/// The exception itself is already delivered into CPU state by `raise_fault*`;
+/// `Fault` is pure call-stack signalling so callers can propagate the abort
+/// via the `?` operator instead of inspecting `fault_pending` after every call.
+pub(super) struct Fault;
+
+/// Result alias for any 386 operation that may abort due to a raised fault.
+pub(super) type Step<T = ()> = Result<T, Fault>;
+
 #[derive(Clone, Copy)]
 struct SegmentDescriptor {
     base: u32,
@@ -436,12 +446,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         // there. fault_pending is asserted here so the prefix-decode loop
         // terminates instead of dispatching a stray 0 opcode at the handler.
         if unlikely(eip > self.seg_limits[SegReg32::CS as usize]) {
-            self.raise_fault_with_code(13, 0, bus);
+            let _: Step<()> = self.raise_fault_with_code(13, 0, bus);
             self.fault_pending = true;
             return 0;
         }
         let linear = self.seg_bases[SegReg32::CS as usize].wrapping_add(eip);
-        let Some(addr) = self.fetch_physical_address(linear, bus) else {
+        let Ok(addr) = self.fetch_physical_address(linear, bus) else {
             self.prefetch_valid = false;
             return 0;
         };
@@ -467,14 +477,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     }
 
     #[inline(always)]
-    fn fetch_physical_address(&mut self, linear: u32, bus: &mut impl common::Bus) -> Option<u32> {
+    fn fetch_physical_address(&mut self, linear: u32, bus: &mut impl common::Bus) -> Step<u32> {
         let page = linear >> 12;
         if likely(
             self.fetch_page_valid
                 && self.fetch_page_tag == page
                 && (!self.is_user_page_access() || self.fetch_page_user),
         ) {
-            return Some(self.fetch_page_phys | (linear & 0xFFF));
+            return Ok(self.fetch_page_phys | (linear & 0xFFF));
         }
 
         let addr = self.translate_linear(linear, false, bus)?;
@@ -487,7 +497,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             true
         };
-        Some(addr)
+        Ok(addr)
     }
 
     #[inline(always)]
@@ -496,7 +506,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             let eip = self.effective_eip();
             let linear = self.seg_bases[SegReg32::CS as usize].wrapping_add(eip);
             if likely((linear & 0xFFF) <= 0xFFE) {
-                let Some(addr) = self.fetch_physical_address(linear, bus) else {
+                let Ok(addr) = self.fetch_physical_address(linear, bus) else {
                     return 0;
                 };
                 let value = bus.read_word(addr);
@@ -515,7 +525,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             let eip = self.effective_eip();
             let linear = self.seg_bases[SegReg32::CS as usize].wrapping_add(eip);
             if likely((linear & 0xFFF) <= 0xFFC) {
-                let Some(addr) = self.fetch_physical_address(linear, bus) else {
+                let Ok(addr) = self.fetch_physical_address(linear, bus) else {
                     return 0;
                 };
                 let value = bus.read_dword(addr);
@@ -582,47 +592,41 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.is_protected_mode() && (self.eflags_upper & 0x0002_0000) != 0
     }
 
-    /// Returns `true` if the current privilege level and IOPL allow I/O access to `port`.
-    /// When access is denied and the IOPB does not grant it, raises #GP(0) and returns `false`.
-    /// CLI/STI/HLT use separate IOPL/CPL checks - this function is only for I/O port instructions.
-    fn check_io_privilege(&mut self, port: u16, size: u8, bus: &mut impl common::Bus) -> bool {
+    /// Returns `Ok(())` if the current privilege level and IOPL allow I/O access
+    /// to `port`. When access is denied and the IOPB does not grant it, raises
+    /// `#GP(0)` and returns `Err(Fault)`. CLI/STI/HLT use separate IOPL/CPL
+    /// checks - this function is only for I/O port instructions.
+    fn check_io_privilege(&mut self, port: u16, size: u8, bus: &mut impl common::Bus) -> Step {
         if !self.is_protected_mode() {
-            return true;
+            return Ok(());
         }
         if !self.is_virtual_mode() && self.cpl() <= u16::from(self.flags.iopl) {
-            return true;
+            return Ok(());
         }
         if bus.is_io_port_unrestricted(port) {
-            return true;
+            return Ok(());
         }
         // CPL > IOPL (or VM86 with IOPL < 3): consult I/O Permission Bitmap in TSS.
         // TSS must be a 386 TSS (type field >= 9) and large enough to hold the IOPB pointer.
         if self.tr_limit < 0x67 || (self.tr_rights & 0x0F) < 9 {
-            self.raise_fault_with_code(13, 0, bus);
-            return false;
+            return self.raise_fault_with_code(13, 0, bus);
         }
-        let Some(iopb) = self.read_word_linear(bus, self.tr_base.wrapping_add(0x66)) else {
-            return false;
-        };
+        let iopb = self.read_word_linear(bus, self.tr_base.wrapping_add(0x66))?;
         let byte_idx = u32::from(iopb).wrapping_add(u32::from(port) / 8);
         // Read two consecutive bytes from the IOPB to handle accesses that span a
         // byte boundary (e.g. a dword access starting at port 7 touches bits in two
         // bytes). The +1 also satisfies the Intel spec requirement for a 0xFF sentinel
         // byte immediately after the IOPB inside the TSS.
         if byte_idx + 1 > self.tr_limit {
-            self.raise_fault_with_code(13, 0, bus);
-            return false;
+            return self.raise_fault_with_code(13, 0, bus);
         }
         let linear = self.tr_base.wrapping_add(byte_idx);
-        let Some(map) = self.read_word_linear(bus, linear) else {
-            return false;
-        };
+        let map = self.read_word_linear(bus, linear)?;
         let mask = (1u16 << size) - 1;
         if (map >> (port & 7)) & mask != 0 {
-            self.raise_fault_with_code(13, 0, bus);
-            return false;
+            return self.raise_fault_with_code(13, 0, bus);
         }
-        true
+        Ok(())
     }
 
     /// Reads the next instruction byte from CS:IP without advancing IP.
@@ -630,7 +634,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     fn peek_byte(&mut self, bus: &mut impl common::Bus) -> u8 {
         let eip = self.effective_eip();
         let linear = self.seg_bases[SegReg32::CS as usize].wrapping_add(eip);
-        let Some(addr) = self.fetch_physical_address(linear, bus) else {
+        let Ok(addr) = self.fetch_physical_address(linear, bus) else {
             return 0;
         };
         if self.prefetch_valid && self.prefetch_addr == addr {
@@ -722,9 +726,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         &mut self,
         selector: u16,
         bus: &mut impl common::Bus,
-    ) -> Option<SegmentDescriptor> {
-        let addr = self.descriptor_addr_checked(selector)?;
-        self.decode_descriptor_at(addr, bus)
+    ) -> Step<Option<SegmentDescriptor>> {
+        let Some(addr) = self.descriptor_addr_checked(selector) else {
+            return Ok(None);
+        };
+        Ok(Some(self.decode_descriptor_at(addr, bus)?))
     }
 
     fn descriptor_dpl(rights: u8) -> u16 {
@@ -759,24 +765,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         rights & 0x80 != 0
     }
 
-    fn raise_segment_not_present(
+    fn raise_segment_not_present<T>(
         &mut self,
         seg: SegReg32,
         selector: u16,
         bus: &mut impl common::Bus,
-    ) {
+    ) -> Step<T> {
         let vector = if seg == SegReg32::SS { 12 } else { 11 };
-        self.raise_fault_with_code(vector, Self::segment_error_code(selector), bus);
+        self.raise_fault_with_code(vector, Self::segment_error_code(selector), bus)
     }
 
-    fn raise_segment_protection(
+    fn raise_segment_protection<T>(
         &mut self,
         seg: SegReg32,
         selector: u16,
         bus: &mut impl common::Bus,
-    ) {
+    ) -> Step<T> {
         let vector = if seg == SegReg32::SS { 12 } else { 13 };
-        self.raise_fault_with_code(vector, Self::segment_error_code(selector), bus);
+        self.raise_fault_with_code(vector, Self::segment_error_code(selector), bus)
     }
 
     fn load_protected_segment(
@@ -784,26 +790,22 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         seg: SegReg32,
         selector: u16,
         bus: &mut impl common::Bus,
-    ) -> bool {
+    ) -> Step {
         if matches!(
             seg,
             SegReg32::DS | SegReg32::ES | SegReg32::FS | SegReg32::GS
         ) && selector & 0xFFFC == 0
         {
             self.set_null_segment(seg, selector);
-            return true;
+            return Ok(());
         }
         if selector & 0xFFFC == 0 {
             // Null selector for CS or SS: always #GP(0) per 386 manual.
-            self.raise_fault_with_code(13, 0, bus);
-            return false;
+            return self.raise_fault_with_code(13, 0, bus);
         }
 
-        let Some(descriptor) = self.decode_descriptor(selector, bus) else {
-            if !self.fault_pending {
-                self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-            }
-            return false;
+        let Some(descriptor) = self.decode_descriptor(selector, bus)? else {
+            return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
         };
         let rights = descriptor.rights;
         let cpl = self.cpl();
@@ -813,25 +815,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         match seg {
             SegReg32::CS => {
                 if !Self::descriptor_is_segment(rights) || !Self::descriptor_is_code(rights) {
-                    self.raise_segment_protection(seg, selector, bus);
-                    return false;
+                    return self.raise_segment_protection(seg, selector, bus);
                 }
                 if Self::descriptor_is_conforming_code(rights) {
                     if dpl > cpl {
-                        self.raise_segment_protection(seg, selector, bus);
-                        return false;
+                        return self.raise_segment_protection(seg, selector, bus);
                     }
                 } else if dpl != cpl || rpl > cpl {
-                    self.raise_segment_protection(seg, selector, bus);
-                    return false;
+                    return self.raise_segment_protection(seg, selector, bus);
                 }
                 if !Self::descriptor_present(rights) {
-                    self.raise_segment_not_present(seg, selector, bus);
-                    return false;
+                    return self.raise_segment_not_present(seg, selector, bus);
                 }
-                if self.set_accessed_bit(selector, bus).is_none() {
-                    return false;
-                }
+                self.set_accessed_bit(selector, bus)?;
                 if Self::descriptor_is_conforming_code(rights) {
                     let adjusted = (selector & !3) | cpl;
                     self.set_loaded_segment_cache(seg, adjusted, descriptor);
@@ -839,47 +835,38 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     let adjusted = (selector & !3) | dpl;
                     self.set_loaded_segment_cache(seg, adjusted, descriptor);
                 }
-                return true;
+                return Ok(());
             }
             SegReg32::SS => {
                 if !Self::descriptor_is_segment(rights) || !Self::descriptor_is_writable(rights) {
-                    self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-                    return false;
+                    return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
                 }
                 if dpl != cpl || rpl != cpl {
-                    self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-                    return false;
+                    return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
                 }
                 if !Self::descriptor_present(rights) {
-                    self.raise_fault_with_code(12, Self::segment_error_code(selector), bus);
-                    return false;
+                    return self.raise_fault_with_code(12, Self::segment_error_code(selector), bus);
                 }
             }
             SegReg32::DS | SegReg32::ES | SegReg32::FS | SegReg32::GS => {
                 if !Self::descriptor_is_segment(rights) {
-                    self.raise_segment_protection(seg, selector, bus);
-                    return false;
+                    return self.raise_segment_protection(seg, selector, bus);
                 }
                 if !Self::descriptor_is_readable(rights) {
-                    self.raise_segment_protection(seg, selector, bus);
-                    return false;
+                    return self.raise_segment_protection(seg, selector, bus);
                 }
                 if !Self::descriptor_is_conforming_code(rights) && dpl < cpl.max(rpl) {
-                    self.raise_segment_protection(seg, selector, bus);
-                    return false;
+                    return self.raise_segment_protection(seg, selector, bus);
                 }
                 if !Self::descriptor_present(rights) {
-                    self.raise_segment_not_present(seg, selector, bus);
-                    return false;
+                    return self.raise_segment_not_present(seg, selector, bus);
                 }
             }
         }
 
-        if self.set_accessed_bit(selector, bus).is_none() {
-            return false;
-        }
+        self.set_accessed_bit(selector, bus)?;
         self.set_loaded_segment_cache(seg, selector, descriptor);
-        true
+        Ok(())
     }
 
     /// Validates a candidate SS for an inter-privilege IRET return without
@@ -895,38 +882,29 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         selector: u16,
         target_cpl: u16,
         bus: &mut impl common::Bus,
-    ) -> Option<(u8, u16)> {
+    ) -> Step<Option<(u8, u16)>> {
         if selector & 0xFFFC == 0 {
-            return Some((13, 0));
+            return Ok(Some((13, 0)));
         }
-        let descriptor = match self.decode_descriptor(selector, bus) {
-            Some(d) => d,
-            None => {
-                if self.fault_pending {
-                    // A #PF was raised during the descriptor read; the
-                    // caller will see fault_pending and abort without
-                    // overwriting it with a synthesized #GP.
-                    return None;
-                }
-                return Some((13, Self::segment_error_code(selector)));
-            }
+        let Some(descriptor) = self.decode_descriptor(selector, bus)? else {
+            return Ok(Some((13, Self::segment_error_code(selector))));
         };
         let rights = descriptor.rights;
         let rpl = selector & 0x0003;
         let dpl = Self::descriptor_dpl(rights);
         if rpl != target_cpl {
-            return Some((13, Self::segment_error_code(selector)));
+            return Ok(Some((13, Self::segment_error_code(selector))));
         }
         if !Self::descriptor_is_segment(rights) || !Self::descriptor_is_writable(rights) {
-            return Some((13, Self::segment_error_code(selector)));
+            return Ok(Some((13, Self::segment_error_code(selector))));
         }
         if dpl != target_cpl {
-            return Some((13, Self::segment_error_code(selector)));
+            return Ok(Some((13, Self::segment_error_code(selector))));
         }
         if !Self::descriptor_present(rights) {
-            return Some((12, Self::segment_error_code(selector)));
+            return Ok(Some((12, Self::segment_error_code(selector))));
         }
-        None
+        Ok(None)
     }
 
     fn load_cs_for_return(
@@ -934,16 +912,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         selector: u16,
         new_ip: u32,
         bus: &mut impl common::Bus,
-    ) -> bool {
+    ) -> Step {
         if selector & 0xFFFC == 0 {
-            self.raise_fault_with_code(13, 0, bus);
-            return false;
+            return self.raise_fault_with_code(13, 0, bus);
         }
-        let Some(descriptor) = self.decode_descriptor(selector, bus) else {
-            if !self.fault_pending {
-                self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-            }
-            return false;
+        let Some(descriptor) = self.decode_descriptor(selector, bus)? else {
+            return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
         };
         let rights = descriptor.rights;
         let cpl = self.cpl();
@@ -951,36 +925,28 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let dpl = Self::descriptor_dpl(rights);
 
         if rpl < cpl {
-            self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-            return false;
+            return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
         }
         if !Self::descriptor_is_segment(rights) || !Self::descriptor_is_code(rights) {
-            self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-            return false;
+            return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
         }
         if Self::descriptor_is_conforming_code(rights) {
             if dpl > rpl {
-                self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-                return false;
+                return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
             }
         } else if dpl != rpl {
-            self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-            return false;
+            return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
         }
         if !Self::descriptor_present(rights) {
-            self.raise_fault_with_code(11, Self::segment_error_code(selector), bus);
-            return false;
+            return self.raise_fault_with_code(11, Self::segment_error_code(selector), bus);
         }
         if new_ip > descriptor.limit {
-            self.raise_fault_with_code(13, 0, bus);
-            return false;
+            return self.raise_fault_with_code(13, 0, bus);
         }
-        if self.set_accessed_bit(selector, bus).is_none() {
-            return false;
-        }
+        self.set_accessed_bit(selector, bus)?;
         let adjusted = (selector & !3) | rpl;
         self.set_loaded_segment_cache(SegReg32::CS, adjusted, descriptor);
-        true
+        Ok(())
     }
 
     /// Validates a candidate CS for an inter- or same-privilege return
@@ -1001,18 +967,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         selector: u16,
         new_ip: u32,
         bus: &mut impl common::Bus,
-    ) -> Option<Result<CsReturnValidation, (u8, u16)>> {
+    ) -> Step<Result<CsReturnValidation, (u8, u16)>> {
         if selector & 0xFFFC == 0 {
-            return Some(Err((13, 0)));
+            return Ok(Err((13, 0)));
         }
-        let descriptor = match self.decode_descriptor(selector, bus) {
-            Some(d) => d,
-            None => {
-                if self.fault_pending {
-                    return None;
-                }
-                return Some(Err((13, Self::segment_error_code(selector))));
-            }
+        let Some(descriptor) = self.decode_descriptor(selector, bus)? else {
+            return Ok(Err((13, Self::segment_error_code(selector))));
         };
         let rights = descriptor.rights;
         let cpl = self.cpl();
@@ -1020,26 +980,26 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let dpl = Self::descriptor_dpl(rights);
 
         if rpl < cpl {
-            return Some(Err((13, Self::segment_error_code(selector))));
+            return Ok(Err((13, Self::segment_error_code(selector))));
         }
         if !Self::descriptor_is_segment(rights) || !Self::descriptor_is_code(rights) {
-            return Some(Err((13, Self::segment_error_code(selector))));
+            return Ok(Err((13, Self::segment_error_code(selector))));
         }
         if Self::descriptor_is_conforming_code(rights) {
             if dpl > rpl {
-                return Some(Err((13, Self::segment_error_code(selector))));
+                return Ok(Err((13, Self::segment_error_code(selector))));
             }
         } else if dpl != rpl {
-            return Some(Err((13, Self::segment_error_code(selector))));
+            return Ok(Err((13, Self::segment_error_code(selector))));
         }
         if !Self::descriptor_present(rights) {
-            return Some(Err((11, Self::segment_error_code(selector))));
+            return Ok(Err((11, Self::segment_error_code(selector))));
         }
         if new_ip > descriptor.limit {
-            return Some(Err((13, 0)));
+            return Ok(Err((13, 0)));
         }
         let adjusted_selector = (selector & !3) | rpl;
-        Some(Ok(CsReturnValidation {
+        Ok(Ok(CsReturnValidation {
             descriptor,
             adjusted_selector,
         }))
@@ -1053,35 +1013,29 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         selector: u16,
         target_cpl: u16,
         bus: &mut impl common::Bus,
-    ) -> Option<Result<SsReturnValidation, (u8, u16)>> {
+    ) -> Step<Result<SsReturnValidation, (u8, u16)>> {
         if selector & 0xFFFC == 0 {
-            return Some(Err((13, 0)));
+            return Ok(Err((13, 0)));
         }
-        let descriptor = match self.decode_descriptor(selector, bus) {
-            Some(d) => d,
-            None => {
-                if self.fault_pending {
-                    return None;
-                }
-                return Some(Err((13, Self::segment_error_code(selector))));
-            }
+        let Some(descriptor) = self.decode_descriptor(selector, bus)? else {
+            return Ok(Err((13, Self::segment_error_code(selector))));
         };
         let rights = descriptor.rights;
         let rpl = selector & 0x0003;
         let dpl = Self::descriptor_dpl(rights);
         if rpl != target_cpl {
-            return Some(Err((13, Self::segment_error_code(selector))));
+            return Ok(Err((13, Self::segment_error_code(selector))));
         }
         if !Self::descriptor_is_segment(rights) || !Self::descriptor_is_writable(rights) {
-            return Some(Err((13, Self::segment_error_code(selector))));
+            return Ok(Err((13, Self::segment_error_code(selector))));
         }
         if dpl != target_cpl {
-            return Some(Err((13, Self::segment_error_code(selector))));
+            return Ok(Err((13, Self::segment_error_code(selector))));
         }
         if !Self::descriptor_present(rights) {
-            return Some(Err((12, Self::segment_error_code(selector))));
+            return Ok(Err((12, Self::segment_error_code(selector))));
         }
-        Some(Ok(SsReturnValidation { descriptor }))
+        Ok(Ok(SsReturnValidation { descriptor }))
     }
 
     /// Returns the post-IRET decision for a data segment without committing
@@ -1094,42 +1048,40 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         seg: SegReg32,
         new_cpl: u16,
         bus: &mut impl common::Bus,
-    ) -> Option<DataSegmentDecision> {
+    ) -> Step<DataSegmentDecision> {
         if !self.seg_valid[seg as usize] {
-            return Some(DataSegmentDecision::NoChange);
+            return Ok(DataSegmentDecision::NoChange);
         }
         let selector = self.sregs[seg as usize];
         if selector & 0xFFFC == 0 {
-            return Some(DataSegmentDecision::Null { selector });
+            return Ok(DataSegmentDecision::Null { selector });
         }
         let saved_supervisor_override = self.supervisor_override;
         self.supervisor_override = true;
         let descriptor = self.decode_descriptor(selector, bus);
         self.supervisor_override = saved_supervisor_override;
-        if self.fault_pending {
-            return None;
-        }
+        let descriptor = descriptor?;
         let Some(descriptor) = descriptor else {
-            return Some(DataSegmentDecision::Null { selector: 0 });
+            return Ok(DataSegmentDecision::Null { selector: 0 });
         };
         let rights = descriptor.rights;
         if !Self::descriptor_is_segment(rights) {
-            return Some(DataSegmentDecision::Null { selector: 0 });
+            return Ok(DataSegmentDecision::Null { selector: 0 });
         }
         if Self::descriptor_is_code(rights) && !Self::descriptor_is_readable(rights) {
-            return Some(DataSegmentDecision::Null { selector: 0 });
+            return Ok(DataSegmentDecision::Null { selector: 0 });
         }
         if !Self::descriptor_present(rights) {
-            return Some(DataSegmentDecision::Null { selector: 0 });
+            return Ok(DataSegmentDecision::Null { selector: 0 });
         }
         if !Self::descriptor_is_conforming_code(rights) {
             let dpl = Self::descriptor_dpl(rights);
             let rpl = selector & 3;
             if dpl < new_cpl || dpl < rpl {
-                return Some(DataSegmentDecision::Null { selector: 0 });
+                return Ok(DataSegmentDecision::Null { selector: 0 });
             }
         }
-        Some(DataSegmentDecision::Keep {
+        Ok(DataSegmentDecision::Keep {
             selector,
             descriptor,
         })
@@ -1155,19 +1107,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         size: u32,
         write: bool,
         bus: &mut impl common::Bus,
-    ) -> bool {
+    ) -> Step {
         if self.fault_pending {
-            return false;
+            return Err(Fault);
         }
         if !self.is_protected_mode() {
-            return true;
+            return Ok(());
         }
 
         if !self.is_virtual_mode() {
             if !self.seg_valid[seg as usize] {
                 let vector = if seg == SegReg32::SS { 12 } else { 13 };
-                self.raise_fault_with_code(vector, 0, bus);
-                return false;
+                return self.raise_fault_with_code(vector, 0, bus);
             }
 
             let rights = self.seg_rights[seg as usize];
@@ -1181,24 +1132,28 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     0xFFFF
                 };
                 if offset <= limit || end > upper || wrapped {
-                    self.raise_fault_with_code(if seg == SegReg32::SS { 12 } else { 13 }, 0, bus);
-                    return false;
+                    return self.raise_fault_with_code(
+                        if seg == SegReg32::SS { 12 } else { 13 },
+                        0,
+                        bus,
+                    );
                 }
             } else if end > limit || wrapped {
-                self.raise_fault_with_code(if seg == SegReg32::SS { 12 } else { 13 }, 0, bus);
-                return false;
+                return self.raise_fault_with_code(
+                    if seg == SegReg32::SS { 12 } else { 13 },
+                    0,
+                    bus,
+                );
             }
 
             if write {
                 if !Self::descriptor_is_writable(rights) {
                     let vector = if seg == SegReg32::SS { 12 } else { 13 };
-                    self.raise_fault_with_code(vector, 0, bus);
-                    return false;
+                    return self.raise_fault_with_code(vector, 0, bus);
                 }
             } else if !Self::descriptor_is_readable(rights) {
                 let vector = if seg == SegReg32::SS { 12 } else { 13 };
-                self.raise_fault_with_code(vector, 0, bus);
-                return false;
+                return self.raise_fault_with_code(vector, 0, bus);
             }
         }
 
@@ -1220,13 +1175,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             if alignment_mask != 0 {
                 let linear = self.seg_base(seg).wrapping_add(offset);
                 if linear & alignment_mask != 0 {
-                    self.raise_fault_with_code(17, 0, bus);
-                    return false;
+                    return self.raise_fault_with_code(17, 0, bus);
                 }
             }
         }
 
-        true
+        Ok(())
     }
 
     #[inline(always)]
@@ -1235,15 +1189,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
         delta: u32,
         for_update: bool,
-    ) -> Option<u16> {
+    ) -> Step<u16> {
         let offset = if self.address_size_override {
             self.eo32.wrapping_add(delta)
         } else {
             (self.eo32 as u16).wrapping_add(delta as u16) as u32
         };
-        if !self.check_segment_access(self.ea_seg, offset, 2, for_update, bus) {
-            return None;
-        }
+        self.check_segment_access(self.ea_seg, offset, 2, for_update, bus)?;
         let l0 = self.seg_addr(delta);
         let same_page = if self.address_size_override {
             l0 & 0xFFF <= 0xFFE
@@ -1252,26 +1204,26 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         if same_page {
             let a0 = self.translate_linear(l0, for_update, bus)?;
-            return Some(bus.read_word(a0));
+            return Ok(bus.read_word(a0));
         }
         let l1 = self.seg_addr(delta.wrapping_add(1));
         let a0 = self.translate_linear(l0, for_update, bus)?;
         let a1 = self.translate_linear(l1, for_update, bus)?;
-        Some(bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8))
+        Ok(bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8))
     }
 
     #[inline(always)]
-    fn seg_read_word_at(&mut self, bus: &mut impl common::Bus, delta: u32) -> Option<u16> {
+    fn seg_read_word_at(&mut self, bus: &mut impl common::Bus, delta: u32) -> Step<u16> {
         self.seg_read_word_at_with(bus, delta, false)
     }
 
     #[inline(always)]
-    fn seg_read_word(&mut self, bus: &mut impl common::Bus) -> Option<u16> {
+    fn seg_read_word(&mut self, bus: &mut impl common::Bus) -> Step<u16> {
         self.seg_read_word_at_with(bus, 0, false)
     }
 
     #[inline(always)]
-    pub(super) fn seg_read_word_for_update(&mut self, bus: &mut impl common::Bus) -> Option<u16> {
+    pub(super) fn seg_read_word_for_update(&mut self, bus: &mut impl common::Bus) -> Step<u16> {
         self.seg_read_word_at_with(bus, 0, true)
     }
 
@@ -1281,15 +1233,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
         delta: u32,
         for_update: bool,
-    ) -> Option<u32> {
+    ) -> Step<u32> {
         let offset = if self.address_size_override {
             self.eo32.wrapping_add(delta)
         } else {
             (self.eo32 as u16).wrapping_add(delta as u16) as u32
         };
-        if !self.check_segment_access(self.ea_seg, offset, 4, for_update, bus) {
-            return None;
-        }
+        self.check_segment_access(self.ea_seg, offset, 4, for_update, bus)?;
         let l0 = self.seg_addr(delta);
         let same_page = if self.address_size_override {
             l0 & 0xFFF <= 0xFFC
@@ -1298,7 +1248,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         if same_page {
             let a0 = self.translate_linear(l0, for_update, bus)?;
-            return Some(bus.read_dword(a0));
+            return Ok(bus.read_dword(a0));
         }
         let l1 = self.seg_addr(delta.wrapping_add(1));
         let l2 = self.seg_addr(delta.wrapping_add(2));
@@ -1307,34 +1257,30 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let a1 = self.translate_linear(l1, for_update, bus)?;
         let a2 = self.translate_linear(l2, for_update, bus)?;
         let a3 = self.translate_linear(l3, for_update, bus)?;
-        Some(
-            bus.read_byte(a0) as u32
-                | ((bus.read_byte(a1) as u32) << 8)
-                | ((bus.read_byte(a2) as u32) << 16)
-                | ((bus.read_byte(a3) as u32) << 24),
-        )
+        Ok(bus.read_byte(a0) as u32
+            | ((bus.read_byte(a1) as u32) << 8)
+            | ((bus.read_byte(a2) as u32) << 16)
+            | ((bus.read_byte(a3) as u32) << 24))
     }
 
     #[inline(always)]
-    fn seg_read_dword_at(&mut self, bus: &mut impl common::Bus, delta: u32) -> Option<u32> {
+    fn seg_read_dword_at(&mut self, bus: &mut impl common::Bus, delta: u32) -> Step<u32> {
         self.seg_read_dword_at_with(bus, delta, false)
     }
 
     #[inline(always)]
-    fn seg_read_dword(&mut self, bus: &mut impl common::Bus) -> Option<u32> {
+    fn seg_read_dword(&mut self, bus: &mut impl common::Bus) -> Step<u32> {
         self.seg_read_dword_at_with(bus, 0, false)
     }
 
     #[inline(always)]
-    pub(super) fn seg_read_dword_for_update(&mut self, bus: &mut impl common::Bus) -> Option<u32> {
+    pub(super) fn seg_read_dword_for_update(&mut self, bus: &mut impl common::Bus) -> Step<u32> {
         self.seg_read_dword_at_with(bus, 0, true)
     }
 
     #[inline(always)]
-    fn seg_write_word(&mut self, bus: &mut impl common::Bus, value: u16) {
-        if !self.check_segment_access(self.ea_seg, self.eo32, 2, true, bus) {
-            return;
-        }
+    fn seg_write_word(&mut self, bus: &mut impl common::Bus, value: u16) -> Step {
+        self.check_segment_access(self.ea_seg, self.eo32, 2, true, bus)?;
         let l0 = self.seg_addr(0);
         let same_page = if self.address_size_override {
             l0 & 0xFFF <= 0xFFE
@@ -1342,28 +1288,21 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             l0 & 0xFFF <= 0xFFE && (self.eo32 as u16) <= 0xFFFE
         };
         if same_page {
-            let Some(a0) = self.translate_linear(l0, true, bus) else {
-                return;
-            };
+            let a0 = self.translate_linear(l0, true, bus)?;
             bus.write_word(a0, value);
-            return;
+            return Ok(());
         }
         let l1 = self.seg_addr(1);
-        let Some(a0) = self.translate_linear(l0, true, bus) else {
-            return;
-        };
-        let Some(a1) = self.translate_linear(l1, true, bus) else {
-            return;
-        };
+        let a0 = self.translate_linear(l0, true, bus)?;
+        let a1 = self.translate_linear(l1, true, bus)?;
         bus.write_byte(a0, value as u8);
         bus.write_byte(a1, (value >> 8) as u8);
+        Ok(())
     }
 
     #[inline(always)]
-    fn seg_write_dword(&mut self, bus: &mut impl common::Bus, value: u32) {
-        if !self.check_segment_access(self.ea_seg, self.eo32, 4, true, bus) {
-            return;
-        }
+    fn seg_write_dword(&mut self, bus: &mut impl common::Bus, value: u32) -> Step {
+        self.check_segment_access(self.ea_seg, self.eo32, 4, true, bus)?;
         let l0 = self.seg_addr(0);
         let same_page = if self.address_size_override {
             l0 & 0xFFF <= 0xFFC
@@ -1371,31 +1310,22 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             l0 & 0xFFF <= 0xFFC && (self.eo32 as u16) <= 0xFFFC
         };
         if same_page {
-            let Some(a0) = self.translate_linear(l0, true, bus) else {
-                return;
-            };
+            let a0 = self.translate_linear(l0, true, bus)?;
             bus.write_dword(a0, value);
-            return;
+            return Ok(());
         }
         let l1 = self.seg_addr(1);
         let l2 = self.seg_addr(2);
         let l3 = self.seg_addr(3);
-        let Some(a0) = self.translate_linear(l0, true, bus) else {
-            return;
-        };
-        let Some(a1) = self.translate_linear(l1, true, bus) else {
-            return;
-        };
-        let Some(a2) = self.translate_linear(l2, true, bus) else {
-            return;
-        };
-        let Some(a3) = self.translate_linear(l3, true, bus) else {
-            return;
-        };
+        let a0 = self.translate_linear(l0, true, bus)?;
+        let a1 = self.translate_linear(l1, true, bus)?;
+        let a2 = self.translate_linear(l2, true, bus)?;
+        let a3 = self.translate_linear(l3, true, bus)?;
         bus.write_byte(a0, value as u8);
         bus.write_byte(a1, (value >> 8) as u8);
         bus.write_byte(a2, (value >> 16) as u8);
         bus.write_byte(a3, (value >> 24) as u8);
+        Ok(())
     }
 
     #[inline(always)]
@@ -1404,13 +1334,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
         seg: SegReg32,
         offset: u32,
-    ) -> Option<u8> {
-        if !self.check_segment_access(seg, offset, 1, false, bus) {
-            return None;
-        }
+    ) -> Step<u8> {
+        self.check_segment_access(seg, offset, 1, false, bus)?;
         let linear = self.seg_base(seg).wrapping_add(offset);
         let addr = self.translate_linear(linear, false, bus)?;
-        Some(bus.read_byte(addr))
+        Ok(bus.read_byte(addr))
     }
 
     #[inline(always)]
@@ -1420,15 +1348,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         seg: SegReg32,
         offset: u32,
         value: u8,
-    ) {
-        if !self.check_segment_access(seg, offset, 1, true, bus) {
-            return;
-        }
+    ) -> Step {
+        self.check_segment_access(seg, offset, 1, true, bus)?;
         let linear = self.seg_base(seg).wrapping_add(offset);
-        let Some(addr) = self.translate_linear(linear, true, bus) else {
-            return;
-        };
+        let addr = self.translate_linear(linear, true, bus)?;
         bus.write_byte(addr, value);
+        Ok(())
     }
 
     #[inline(always)]
@@ -1438,20 +1363,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         seg: SegReg32,
         offset: u32,
         for_update: bool,
-    ) -> Option<u16> {
-        if !self.check_segment_access(seg, offset, 2, for_update, bus) {
-            return None;
-        }
+    ) -> Step<u16> {
+        self.check_segment_access(seg, offset, 2, for_update, bus)?;
         let base = self.seg_base(seg);
         let l0 = base.wrapping_add(offset);
         if l0 & 0xFFF <= 0xFFE {
             let a0 = self.translate_linear(l0, for_update, bus)?;
-            return Some(bus.read_word(a0));
+            return Ok(bus.read_word(a0));
         }
         let l1 = base.wrapping_add(offset.wrapping_add(1));
         let a0 = self.translate_linear(l0, for_update, bus)?;
         let a1 = self.translate_linear(l1, for_update, bus)?;
-        Some(bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8))
+        Ok(bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8))
     }
 
     #[inline(always)]
@@ -1460,7 +1383,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
         seg: SegReg32,
         offset: u32,
-    ) -> Option<u16> {
+    ) -> Step<u16> {
         self.read_word_seg_with(bus, seg, offset, false)
     }
 
@@ -1470,7 +1393,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
         seg: SegReg32,
         offset: u32,
-    ) -> Option<u16> {
+    ) -> Step<u16> {
         self.read_word_seg_with(bus, seg, offset, true)
     }
 
@@ -1481,15 +1404,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         seg: SegReg32,
         offset: u32,
         for_update: bool,
-    ) -> Option<u32> {
-        if !self.check_segment_access(seg, offset, 4, for_update, bus) {
-            return None;
-        }
+    ) -> Step<u32> {
+        self.check_segment_access(seg, offset, 4, for_update, bus)?;
         let base = self.seg_base(seg);
         let l0 = base.wrapping_add(offset);
         if l0 & 0xFFF <= 0xFFC {
             let a0 = self.translate_linear(l0, for_update, bus)?;
-            return Some(bus.read_dword(a0));
+            return Ok(bus.read_dword(a0));
         }
         let l1 = base.wrapping_add(offset.wrapping_add(1));
         let l2 = base.wrapping_add(offset.wrapping_add(2));
@@ -1498,12 +1419,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let a1 = self.translate_linear(l1, for_update, bus)?;
         let a2 = self.translate_linear(l2, for_update, bus)?;
         let a3 = self.translate_linear(l3, for_update, bus)?;
-        Some(
-            bus.read_byte(a0) as u32
-                | ((bus.read_byte(a1) as u32) << 8)
-                | ((bus.read_byte(a2) as u32) << 16)
-                | ((bus.read_byte(a3) as u32) << 24),
-        )
+        Ok(bus.read_byte(a0) as u32
+            | ((bus.read_byte(a1) as u32) << 8)
+            | ((bus.read_byte(a2) as u32) << 16)
+            | ((bus.read_byte(a3) as u32) << 24))
     }
 
     #[inline(always)]
@@ -1512,7 +1431,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
         seg: SegReg32,
         offset: u32,
-    ) -> Option<u32> {
+    ) -> Step<u32> {
         self.read_dword_seg_with(bus, seg, offset, false)
     }
 
@@ -1522,7 +1441,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
         seg: SegReg32,
         offset: u32,
-    ) -> Option<u32> {
+    ) -> Step<u32> {
         self.read_dword_seg_with(bus, seg, offset, true)
     }
 
@@ -1533,28 +1452,21 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         seg: SegReg32,
         offset: u32,
         value: u16,
-    ) {
-        if !self.check_segment_access(seg, offset, 2, true, bus) {
-            return;
-        }
+    ) -> Step {
+        self.check_segment_access(seg, offset, 2, true, bus)?;
         let base = self.seg_base(seg);
         let l0 = base.wrapping_add(offset);
         if l0 & 0xFFF <= 0xFFE {
-            let Some(a0) = self.translate_linear(l0, true, bus) else {
-                return;
-            };
+            let a0 = self.translate_linear(l0, true, bus)?;
             bus.write_word(a0, value);
-            return;
+            return Ok(());
         }
         let l1 = base.wrapping_add(offset.wrapping_add(1));
-        let Some(a0) = self.translate_linear(l0, true, bus) else {
-            return;
-        };
-        let Some(a1) = self.translate_linear(l1, true, bus) else {
-            return;
-        };
+        let a0 = self.translate_linear(l0, true, bus)?;
+        let a1 = self.translate_linear(l1, true, bus)?;
         bus.write_byte(a0, value as u8);
         bus.write_byte(a1, (value >> 8) as u8);
+        Ok(())
     }
 
     #[inline(always)]
@@ -1564,38 +1476,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         seg: SegReg32,
         offset: u32,
         value: u32,
-    ) {
-        if !self.check_segment_access(seg, offset, 4, true, bus) {
-            return;
-        }
+    ) -> Step {
+        self.check_segment_access(seg, offset, 4, true, bus)?;
         let base = self.seg_base(seg);
         let l0 = base.wrapping_add(offset);
         if l0 & 0xFFF <= 0xFFC {
-            let Some(a0) = self.translate_linear(l0, true, bus) else {
-                return;
-            };
+            let a0 = self.translate_linear(l0, true, bus)?;
             bus.write_dword(a0, value);
-            return;
+            return Ok(());
         }
         let l1 = base.wrapping_add(offset.wrapping_add(1));
         let l2 = base.wrapping_add(offset.wrapping_add(2));
         let l3 = base.wrapping_add(offset.wrapping_add(3));
-        let Some(a0) = self.translate_linear(l0, true, bus) else {
-            return;
-        };
-        let Some(a1) = self.translate_linear(l1, true, bus) else {
-            return;
-        };
-        let Some(a2) = self.translate_linear(l2, true, bus) else {
-            return;
-        };
-        let Some(a3) = self.translate_linear(l3, true, bus) else {
-            return;
-        };
+        let a0 = self.translate_linear(l0, true, bus)?;
+        let a1 = self.translate_linear(l1, true, bus)?;
+        let a2 = self.translate_linear(l2, true, bus)?;
+        let a3 = self.translate_linear(l3, true, bus)?;
         bus.write_byte(a0, value as u8);
         bus.write_byte(a1, (value >> 8) as u8);
         bus.write_byte(a2, (value >> 16) as u8);
         bus.write_byte(a3, (value >> 24) as u8);
+        Ok(())
     }
 
     #[inline(always)]
@@ -1606,46 +1507,37 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.seg_granularity[SegReg32::SS as usize] & 0x40 != 0
     }
 
-    fn push(&mut self, bus: &mut impl common::Bus, value: u16) {
+    fn push(&mut self, bus: &mut impl common::Bus, value: u16) -> Step {
         let sp = if self.use_esp() {
             self.regs.dword(crate::DwordReg::ESP).wrapping_sub(2)
         } else {
             self.regs.word(WordReg::SP).wrapping_sub(2) as u32
         };
-        if !self.check_segment_access(SegReg32::SS, sp, 2, true, bus) {
-            return;
-        }
+        self.check_segment_access(SegReg32::SS, sp, 2, true, bus)?;
         let base = self.seg_base(SegReg32::SS);
         let l0 = base.wrapping_add(sp);
         if l0 & 0xFFF <= 0xFFE {
-            let Some(a0) = self.translate_linear(l0, true, bus) else {
-                return;
-            };
+            let a0 = self.translate_linear(l0, true, bus)?;
             self.commit_sp(sp);
             bus.write_word(a0, value);
-            return;
+            return Ok(());
         }
         let l1 = base.wrapping_add(sp.wrapping_add(1));
-        let Some(a0) = self.translate_linear(l0, true, bus) else {
-            return;
-        };
-        let Some(a1) = self.translate_linear(l1, true, bus) else {
-            return;
-        };
+        let a0 = self.translate_linear(l0, true, bus)?;
+        let a1 = self.translate_linear(l1, true, bus)?;
         self.commit_sp(sp);
         bus.write_byte(a0, value as u8);
         bus.write_byte(a1, (value >> 8) as u8);
+        Ok(())
     }
 
-    fn pop(&mut self, bus: &mut impl common::Bus) -> Option<u16> {
+    fn pop(&mut self, bus: &mut impl common::Bus) -> Step<u16> {
         let sp = if self.use_esp() {
             self.regs.dword(crate::DwordReg::ESP)
         } else {
             self.regs.word(WordReg::SP) as u32
         };
-        if !self.check_segment_access(SegReg32::SS, sp, 2, false, bus) {
-            return None;
-        }
+        self.check_segment_access(SegReg32::SS, sp, 2, false, bus)?;
         let base = self.seg_base(SegReg32::SS);
         let l0 = base.wrapping_add(sp);
         let value = if l0 & 0xFFF <= 0xFFE {
@@ -1658,48 +1550,37 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8)
         };
         self.commit_sp(sp.wrapping_add(2));
-        Some(value)
+        Ok(value)
     }
 
-    fn push_dword(&mut self, bus: &mut impl common::Bus, value: u32) {
+    fn push_dword(&mut self, bus: &mut impl common::Bus, value: u32) -> Step {
         let sp = if self.use_esp() {
             self.regs.dword(crate::DwordReg::ESP).wrapping_sub(4)
         } else {
             self.regs.word(WordReg::SP).wrapping_sub(4) as u32
         };
-        if !self.check_segment_access(SegReg32::SS, sp, 4, true, bus) {
-            return;
-        }
+        self.check_segment_access(SegReg32::SS, sp, 4, true, bus)?;
         let base = self.seg_base(SegReg32::SS);
         let l0 = base.wrapping_add(sp);
         if l0 & 0xFFF <= 0xFFC {
-            let Some(a0) = self.translate_linear(l0, true, bus) else {
-                return;
-            };
+            let a0 = self.translate_linear(l0, true, bus)?;
             self.commit_sp(sp);
             bus.write_dword(a0, value);
-            return;
+            return Ok(());
         }
         let l1 = base.wrapping_add(sp.wrapping_add(1));
         let l2 = base.wrapping_add(sp.wrapping_add(2));
         let l3 = base.wrapping_add(sp.wrapping_add(3));
-        let Some(a0) = self.translate_linear(l0, true, bus) else {
-            return;
-        };
-        let Some(a1) = self.translate_linear(l1, true, bus) else {
-            return;
-        };
-        let Some(a2) = self.translate_linear(l2, true, bus) else {
-            return;
-        };
-        let Some(a3) = self.translate_linear(l3, true, bus) else {
-            return;
-        };
+        let a0 = self.translate_linear(l0, true, bus)?;
+        let a1 = self.translate_linear(l1, true, bus)?;
+        let a2 = self.translate_linear(l2, true, bus)?;
+        let a3 = self.translate_linear(l3, true, bus)?;
         self.commit_sp(sp);
         bus.write_byte(a0, value as u8);
         bus.write_byte(a1, (value >> 8) as u8);
         bus.write_byte(a2, (value >> 16) as u8);
         bus.write_byte(a3, (value >> 24) as u8);
+        Ok(())
     }
 
     #[inline(always)]
@@ -1711,15 +1592,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
     }
 
-    fn pop_dword(&mut self, bus: &mut impl common::Bus) -> Option<u32> {
+    fn pop_dword(&mut self, bus: &mut impl common::Bus) -> Step<u32> {
         let sp = if self.use_esp() {
             self.regs.dword(crate::DwordReg::ESP)
         } else {
             self.regs.word(WordReg::SP) as u32
         };
-        if !self.check_segment_access(SegReg32::SS, sp, 4, false, bus) {
-            return None;
-        }
+        self.check_segment_access(SegReg32::SS, sp, 4, false, bus)?;
         let base = self.seg_base(SegReg32::SS);
         let l0 = base.wrapping_add(sp);
         let value = if l0 & 0xFFF <= 0xFFC {
@@ -1739,14 +1618,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 | ((bus.read_byte(a3) as u32) << 24)
         };
         self.commit_sp(sp.wrapping_add(4));
-        Some(value)
+        Ok(value)
     }
 
-    fn load_segment(&mut self, seg: SegReg32, selector: u16, bus: &mut impl common::Bus) -> bool {
+    fn load_segment(&mut self, seg: SegReg32, selector: u16, bus: &mut impl common::Bus) -> Step {
         if !self.is_protected_mode() || self.is_virtual_mode() {
             self.sregs[seg as usize] = selector;
             self.set_real_segment_cache(seg, selector);
-            return true;
+            return Ok(());
         }
         self.load_protected_segment(seg, selector, bus)
     }
@@ -1768,14 +1647,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     }
 
     /// Sets the accessed bit on the descriptor for `selector`. Returns
-    /// `None` if the descriptor byte's translation faulted (the page
-    /// fault is already pending); callers must abort the segment commit
-    /// in that case so the load is restartable. Null/out-of-table
-    /// selectors return `Some(())` without touching memory - those
+    /// `Err(Fault)` if the descriptor byte's translation faulted (the
+    /// page fault is already pending); callers must abort the segment
+    /// commit in that case so the load is restartable. Null/out-of-table
+    /// selectors return `Ok(())` without touching memory - those
     /// cases are unreachable from a successful `decode_descriptor`.
-    fn set_accessed_bit(&mut self, selector: u16, bus: &mut impl common::Bus) -> Option<()> {
+    fn set_accessed_bit(&mut self, selector: u16, bus: &mut impl common::Bus) -> Step {
         let Some(addr) = self.descriptor_addr_checked(selector) else {
-            return Some(());
+            return Ok(());
         };
         let saved_supervisor_override = self.supervisor_override;
         self.supervisor_override = true;
@@ -1787,79 +1666,79 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         if rights & 0x01 == 0 {
             bus.write_byte(phys, rights | 0x01);
         }
-        Some(())
+        Ok(())
     }
 
-    fn revalidate_data_segment(&mut self, seg: SegReg32, new_cpl: u16, bus: &mut impl common::Bus) {
+    fn revalidate_data_segment(
+        &mut self,
+        seg: SegReg32,
+        new_cpl: u16,
+        bus: &mut impl common::Bus,
+    ) -> Step {
         if !self.seg_valid[seg as usize] {
-            return;
+            return Ok(());
         }
         let selector = self.sregs[seg as usize];
         if selector & 0xFFFC == 0 {
             self.set_null_segment(seg, selector);
-            return;
+            return Ok(());
         }
         let saved_supervisor_override = self.supervisor_override;
         self.supervisor_override = true;
         let descriptor = self.decode_descriptor(selector, bus);
         self.supervisor_override = saved_supervisor_override;
-        if self.fault_pending {
-            return;
-        }
+        let descriptor = descriptor?;
         let Some(descriptor) = descriptor else {
             self.set_null_segment(seg, 0);
-            return;
+            return Ok(());
         };
         let rights = descriptor.rights;
         if !Self::descriptor_is_segment(rights) {
             self.set_null_segment(seg, 0);
-            return;
+            return Ok(());
         }
         if Self::descriptor_is_code(rights) && !Self::descriptor_is_readable(rights) {
             self.set_null_segment(seg, 0);
-            return;
+            return Ok(());
         }
         if !Self::descriptor_present(rights) {
             self.set_null_segment(seg, 0);
-            return;
+            return Ok(());
         }
         if !Self::descriptor_is_conforming_code(rights) {
             let dpl = Self::descriptor_dpl(rights);
             let rpl = selector & 3;
             if dpl < new_cpl || dpl < rpl {
                 self.set_null_segment(seg, 0);
-                return;
+                return Ok(());
             }
         }
         self.set_loaded_segment_cache(seg, selector, descriptor);
+        Ok(())
     }
 
-    pub(super) fn read_word_linear(
-        &mut self,
-        bus: &mut impl common::Bus,
-        addr: u32,
-    ) -> Option<u16> {
+    pub(super) fn read_word_linear(&mut self, bus: &mut impl common::Bus, addr: u32) -> Step<u16> {
         if addr & 0xFFF <= 0xFFE {
             let a0 = self.translate_linear(addr, false, bus)?;
-            return Some(bus.read_word(a0));
+            return Ok(bus.read_word(a0));
         }
         let a0 = self.translate_linear(addr, false, bus)?;
         let a1 = self.translate_linear(addr.wrapping_add(1), false, bus)?;
-        Some(bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8))
+        Ok(bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8))
     }
 
     pub(super) fn read_word_linear_for_update(
         &mut self,
         bus: &mut impl common::Bus,
         addr: u32,
-    ) -> Option<u16> {
+    ) -> Step<u16> {
         if addr & 0xFFF <= 0xFFE {
             let a0 = self.translate_linear(addr, true, bus)?;
-            return Some(bus.read_word(a0));
+            return Ok(bus.read_word(a0));
         }
         let a0 = self.translate_linear(addr, true, bus)?;
         let a1 = self.translate_linear(addr.wrapping_add(1), true, bus)?;
-        Some(bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8))
+        Ok(bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8))
     }
 
     pub(super) fn write_word_linear(
@@ -1867,88 +1746,76 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
         addr: u32,
         value: u16,
-    ) -> Option<()> {
+    ) -> Step {
         if addr & 0xFFF <= 0xFFE {
             let a0 = self.translate_linear(addr, true, bus)?;
             bus.write_word(a0, value);
-            return Some(());
+            return Ok(());
         }
         let a0 = self.translate_linear(addr, true, bus)?;
         let a1 = self.translate_linear(addr.wrapping_add(1), true, bus)?;
         bus.write_byte(a0, value as u8);
         bus.write_byte(a1, (value >> 8) as u8);
-        Some(())
+        Ok(())
     }
 
-    fn read_dword_linear(&mut self, bus: &mut impl common::Bus, addr: u32) -> Option<u32> {
+    fn read_dword_linear(&mut self, bus: &mut impl common::Bus, addr: u32) -> Step<u32> {
         if addr & 0xFFF <= 0xFFC {
             let a0 = self.translate_linear(addr, false, bus)?;
-            return Some(bus.read_dword(a0));
+            return Ok(bus.read_dword(a0));
         }
         let a0 = self.translate_linear(addr, false, bus)?;
         let a1 = self.translate_linear(addr.wrapping_add(1), false, bus)?;
         let a2 = self.translate_linear(addr.wrapping_add(2), false, bus)?;
         let a3 = self.translate_linear(addr.wrapping_add(3), false, bus)?;
-        Some(
-            bus.read_byte(a0) as u32
-                | ((bus.read_byte(a1) as u32) << 8)
-                | ((bus.read_byte(a2) as u32) << 16)
-                | ((bus.read_byte(a3) as u32) << 24),
-        )
+        Ok(bus.read_byte(a0) as u32
+            | ((bus.read_byte(a1) as u32) << 8)
+            | ((bus.read_byte(a2) as u32) << 16)
+            | ((bus.read_byte(a3) as u32) << 24))
     }
 
     pub(super) fn read_dword_linear_for_update(
         &mut self,
         bus: &mut impl common::Bus,
         addr: u32,
-    ) -> Option<u32> {
+    ) -> Step<u32> {
         if addr & 0xFFF <= 0xFFC {
             let a0 = self.translate_linear(addr, true, bus)?;
-            return Some(bus.read_dword(a0));
+            return Ok(bus.read_dword(a0));
         }
         let a0 = self.translate_linear(addr, true, bus)?;
         let a1 = self.translate_linear(addr.wrapping_add(1), true, bus)?;
         let a2 = self.translate_linear(addr.wrapping_add(2), true, bus)?;
         let a3 = self.translate_linear(addr.wrapping_add(3), true, bus)?;
-        Some(
-            bus.read_byte(a0) as u32
-                | ((bus.read_byte(a1) as u32) << 8)
-                | ((bus.read_byte(a2) as u32) << 16)
-                | ((bus.read_byte(a3) as u32) << 24),
-        )
+        Ok(bus.read_byte(a0) as u32
+            | ((bus.read_byte(a1) as u32) << 8)
+            | ((bus.read_byte(a2) as u32) << 16)
+            | ((bus.read_byte(a3) as u32) << 24))
     }
 
-    fn write_dword_linear(&mut self, bus: &mut impl common::Bus, addr: u32, value: u32) {
+    fn write_dword_linear(&mut self, bus: &mut impl common::Bus, addr: u32, value: u32) -> Step {
         if addr & 0xFFF <= 0xFFC {
-            let Some(a0) = self.translate_linear(addr, true, bus) else {
-                return;
-            };
+            let a0 = self.translate_linear(addr, true, bus)?;
             bus.write_dword(a0, value);
-            return;
+            return Ok(());
         }
-        let Some(a0) = self.translate_linear(addr, true, bus) else {
-            return;
-        };
-        let Some(a1) = self.translate_linear(addr.wrapping_add(1), true, bus) else {
-            return;
-        };
-        let Some(a2) = self.translate_linear(addr.wrapping_add(2), true, bus) else {
-            return;
-        };
-        let Some(a3) = self.translate_linear(addr.wrapping_add(3), true, bus) else {
-            return;
-        };
+        let a0 = self.translate_linear(addr, true, bus)?;
+        let a1 = self.translate_linear(addr.wrapping_add(1), true, bus)?;
+        let a2 = self.translate_linear(addr.wrapping_add(2), true, bus)?;
+        let a3 = self.translate_linear(addr.wrapping_add(3), true, bus)?;
         bus.write_byte(a0, value as u8);
         bus.write_byte(a1, (value >> 8) as u8);
         bus.write_byte(a2, (value >> 16) as u8);
         bus.write_byte(a3, (value >> 24) as u8);
+        Ok(())
     }
 
-    fn switch_task(&mut self, ntask: u16, task_type: TaskType, bus: &mut impl common::Bus) {
+    fn switch_task(&mut self, ntask: u16, task_type: TaskType, bus: &mut impl common::Bus) -> Step {
         let saved_supervisor_override = self.supervisor_override;
         self.supervisor_override = true;
-        let _ = self.switch_task_inner(ntask, task_type, bus);
+        let result = self.switch_task_inner(ntask, task_type, bus);
         self.supervisor_override = saved_supervisor_override;
+        result
     }
 
     fn switch_task_inner(
@@ -1956,15 +1823,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         ntask: u16,
         task_type: TaskType,
         bus: &mut impl common::Bus,
-    ) -> Option<()> {
+    ) -> Step {
         if ntask & 0x0004 != 0 {
-            self.raise_fault_with_code(10, Self::segment_error_code(ntask), bus);
-            return None;
+            return self.raise_fault_with_code(10, Self::segment_error_code(ntask), bus);
         }
 
         let Some(naddr) = self.descriptor_addr_checked(ntask) else {
-            self.raise_fault_with_code(10, Self::segment_error_code(ntask), bus);
-            return None;
+            return self.raise_fault_with_code(10, Self::segment_error_code(ntask), bus);
         };
 
         let ndesc = self.decode_descriptor_at(naddr, bus)?;
@@ -1975,29 +1840,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let r = ndesc_rights;
         let tss_type = r & 0x0F;
         if Self::descriptor_is_segment(r) || !matches!(tss_type, 1 | 3 | 9 | 11) {
-            self.raise_fault_with_code(13, Self::segment_error_code(ntask), bus);
-            return None;
+            return self.raise_fault_with_code(13, Self::segment_error_code(ntask), bus);
         }
         if task_type == TaskType::Iret {
             if r & 0x02 == 0 {
-                self.raise_fault_with_code(13, Self::segment_error_code(ntask), bus);
-                return None;
+                return self.raise_fault_with_code(13, Self::segment_error_code(ntask), bus);
             }
         } else if r & 0x02 != 0 {
-            self.raise_fault_with_code(13, Self::segment_error_code(ntask), bus);
-            return None;
+            return self.raise_fault_with_code(13, Self::segment_error_code(ntask), bus);
         }
 
         if !Self::descriptor_present(r) {
-            self.raise_fault_with_code(11, Self::segment_error_code(ntask), bus);
-            return None;
+            return self.raise_fault_with_code(11, Self::segment_error_code(ntask), bus);
         }
 
         let is_386_tss = matches!(tss_type, 9 | 11);
         let min_limit: u32 = if is_386_tss { 103 } else { 43 };
         if ndesc_limit < min_limit {
-            self.raise_fault_with_code(10, Self::segment_error_code(ntask), bus);
-            return None;
+            return self.raise_fault_with_code(10, Self::segment_error_code(ntask), bus);
         }
 
         let mut flags = self.flags.compress();
@@ -2013,114 +1873,114 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         if old_is_386 {
             let eip = self.ip_upper | self.ip as u32;
             let eflags = self.eflags_upper | flags as u32;
-            self.write_dword_linear(bus, old_base.wrapping_add(32), eip);
-            self.write_dword_linear(bus, old_base.wrapping_add(36), eflags);
+            self.write_dword_linear(bus, old_base.wrapping_add(32), eip)?;
+            self.write_dword_linear(bus, old_base.wrapping_add(36), eflags)?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(40),
                 self.regs.dword(crate::DwordReg::EAX),
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(44),
                 self.regs.dword(crate::DwordReg::ECX),
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(48),
                 self.regs.dword(crate::DwordReg::EDX),
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(52),
                 self.regs.dword(crate::DwordReg::EBX),
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(56),
                 self.regs.dword(crate::DwordReg::ESP),
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(60),
                 self.regs.dword(crate::DwordReg::EBP),
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(64),
                 self.regs.dword(crate::DwordReg::ESI),
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(68),
                 self.regs.dword(crate::DwordReg::EDI),
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(72),
                 self.sregs[SegReg32::ES as usize] as u32,
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(76),
                 self.sregs[SegReg32::CS as usize] as u32,
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(80),
                 self.sregs[SegReg32::SS as usize] as u32,
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(84),
                 self.sregs[SegReg32::DS as usize] as u32,
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(88),
                 self.sregs[SegReg32::FS as usize] as u32,
-            );
+            )?;
             self.write_dword_linear(
                 bus,
                 old_base.wrapping_add(92),
                 self.sregs[SegReg32::GS as usize] as u32,
-            );
+            )?;
         } else {
-            self.write_word_linear(bus, old_base.wrapping_add(14), self.ip);
-            self.write_word_linear(bus, old_base.wrapping_add(16), flags);
-            self.write_word_linear(bus, old_base.wrapping_add(18), self.regs.word(WordReg::AX));
-            self.write_word_linear(bus, old_base.wrapping_add(20), self.regs.word(WordReg::CX));
-            self.write_word_linear(bus, old_base.wrapping_add(22), self.regs.word(WordReg::DX));
-            self.write_word_linear(bus, old_base.wrapping_add(24), self.regs.word(WordReg::BX));
-            self.write_word_linear(bus, old_base.wrapping_add(26), self.regs.word(WordReg::SP));
-            self.write_word_linear(bus, old_base.wrapping_add(28), self.regs.word(WordReg::BP));
-            self.write_word_linear(bus, old_base.wrapping_add(30), self.regs.word(WordReg::SI));
-            self.write_word_linear(bus, old_base.wrapping_add(32), self.regs.word(WordReg::DI));
+            self.write_word_linear(bus, old_base.wrapping_add(14), self.ip)?;
+            self.write_word_linear(bus, old_base.wrapping_add(16), flags)?;
+            self.write_word_linear(bus, old_base.wrapping_add(18), self.regs.word(WordReg::AX))?;
+            self.write_word_linear(bus, old_base.wrapping_add(20), self.regs.word(WordReg::CX))?;
+            self.write_word_linear(bus, old_base.wrapping_add(22), self.regs.word(WordReg::DX))?;
+            self.write_word_linear(bus, old_base.wrapping_add(24), self.regs.word(WordReg::BX))?;
+            self.write_word_linear(bus, old_base.wrapping_add(26), self.regs.word(WordReg::SP))?;
+            self.write_word_linear(bus, old_base.wrapping_add(28), self.regs.word(WordReg::BP))?;
+            self.write_word_linear(bus, old_base.wrapping_add(30), self.regs.word(WordReg::SI))?;
+            self.write_word_linear(bus, old_base.wrapping_add(32), self.regs.word(WordReg::DI))?;
             self.write_word_linear(
                 bus,
                 old_base.wrapping_add(34),
                 self.sregs[SegReg32::ES as usize],
-            );
+            )?;
             self.write_word_linear(
                 bus,
                 old_base.wrapping_add(36),
                 self.sregs[SegReg32::CS as usize],
-            );
+            )?;
             self.write_word_linear(
                 bus,
                 old_base.wrapping_add(38),
                 self.sregs[SegReg32::SS as usize],
-            );
+            )?;
             self.write_word_linear(
                 bus,
                 old_base.wrapping_add(40),
                 self.sregs[SegReg32::DS as usize],
-            );
+            )?;
         }
 
         // Write back-link to new TSS after old state is saved.
         if task_type == TaskType::Call {
-            self.write_word_linear(bus, ndesc_base, self.tr);
+            self.write_word_linear(bus, ndesc_base, self.tr)?;
         }
 
         // Read all fields from new TSS.
@@ -2242,23 +2102,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
         // Load LDT from new TSS.
         if ntss_ldt & 0x0004 != 0 {
-            self.raise_fault_with_code(10, Self::segment_error_code(ntss_ldt), bus);
-            return None;
+            return self.raise_fault_with_code(10, Self::segment_error_code(ntss_ldt), bus);
         }
         if ntss_ldt & 0xFFFC != 0 {
             let Some(ldtaddr) = self.descriptor_addr_checked(ntss_ldt) else {
-                self.raise_fault_with_code(10, Self::segment_error_code(ntss_ldt), bus);
-                return None;
+                return self.raise_fault_with_code(10, Self::segment_error_code(ntss_ldt), bus);
             };
             let ldt_desc = self.decode_descriptor_at(ldtaddr, bus)?;
             let lr = ldt_desc.rights;
             if Self::descriptor_is_segment(lr) || (lr & 0x0F) != 0x02 {
-                self.raise_fault_with_code(10, Self::segment_error_code(ntss_ldt), bus);
-                return None;
+                return self.raise_fault_with_code(10, Self::segment_error_code(ntss_ldt), bus);
             }
             if !Self::descriptor_present(lr) {
-                self.raise_fault_with_code(10, Self::segment_error_code(ntss_ldt), bus);
-                return None;
+                return self.raise_fault_with_code(10, Self::segment_error_code(ntss_ldt), bus);
             }
             let ldt_base = ldt_desc.base;
             let ldt_limit = ldt_desc.limit;
@@ -2303,20 +2159,20 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.set_real_segment_cache(SegReg32::GS, ntss_gs);
             self.ip = ntss_eip as u16;
             self.ip_upper = 0;
-            return None;
+            return Ok(());
         }
 
         // Load segment registers from new TSS. SS first (uses new CS RPL as CPL).
         let new_cpl = ntss_cs & 3;
-        self.load_task_data_segment(SegReg32::SS, ntss_ss, new_cpl, bus);
-        self.load_task_code_segment(ntss_cs, ntss_eip, bus);
+        self.load_task_data_segment(SegReg32::SS, ntss_ss, new_cpl, bus)?;
+        self.load_task_code_segment(ntss_cs, ntss_eip, bus)?;
         let cpl = self.cpl();
-        self.load_task_data_segment(SegReg32::ES, ntss_es, cpl, bus);
-        self.load_task_data_segment(SegReg32::DS, ntss_ds, cpl, bus);
-        self.load_task_data_segment(SegReg32::FS, ntss_fs, cpl, bus);
-        self.load_task_data_segment(SegReg32::GS, ntss_gs, cpl, bus);
+        self.load_task_data_segment(SegReg32::ES, ntss_es, cpl, bus)?;
+        self.load_task_data_segment(SegReg32::DS, ntss_ds, cpl, bus)?;
+        self.load_task_data_segment(SegReg32::FS, ntss_fs, cpl, bus)?;
+        self.load_task_data_segment(SegReg32::GS, ntss_gs, cpl, bus)?;
 
-        Some(())
+        Ok(())
     }
 
     fn load_task_data_segment(
@@ -2325,93 +2181,81 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         selector: u16,
         required_cpl: u16,
         bus: &mut impl common::Bus,
-    ) {
+    ) -> Step {
         if selector & 0xFFFC == 0 {
             self.set_null_segment(seg, selector);
-            return;
+            return Ok(());
         }
-        let Some(descriptor) = self.decode_descriptor(selector, bus) else {
-            if !self.fault_pending {
-                self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
-            }
-            return;
+        let Some(descriptor) = self.decode_descriptor(selector, bus)? else {
+            return self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
         };
         let rights = descriptor.rights;
         if seg == SegReg32::SS {
             if !Self::descriptor_is_segment(rights) || !Self::descriptor_is_writable(rights) {
-                self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
-                return;
+                return self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
             }
             let dpl = Self::descriptor_dpl(rights);
             let rpl = selector & 3;
             if dpl != required_cpl || rpl != required_cpl {
-                self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
-                return;
+                return self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
             }
         } else {
             if !Self::descriptor_is_segment(rights) || !Self::descriptor_is_readable(rights) {
-                self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
-                return;
+                return self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
             }
             if !Self::descriptor_is_conforming_code(rights) {
                 let dpl = Self::descriptor_dpl(rights);
                 let rpl = selector & 3;
                 if dpl < required_cpl.max(rpl) {
-                    self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
-                    return;
+                    return self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
                 }
             }
         }
         if !Self::descriptor_present(rights) {
-            self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
-            return;
+            return self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
         }
-        self.set_accessed_bit(selector, bus);
+        self.set_accessed_bit(selector, bus)?;
         self.set_loaded_segment_cache(seg, selector, descriptor);
+        Ok(())
     }
 
-    fn load_task_code_segment(&mut self, selector: u16, offset: u32, bus: &mut impl common::Bus) {
+    fn load_task_code_segment(
+        &mut self,
+        selector: u16,
+        offset: u32,
+        bus: &mut impl common::Bus,
+    ) -> Step {
         if selector & 0xFFFC == 0 {
-            self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
-            return;
+            return self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
         }
-        let Some(descriptor) = self.decode_descriptor(selector, bus) else {
-            if !self.fault_pending {
-                self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
-            }
-            return;
+        let Some(descriptor) = self.decode_descriptor(selector, bus)? else {
+            return self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
         };
         let rights = descriptor.rights;
         if !Self::descriptor_is_segment(rights) || !Self::descriptor_is_code(rights) {
-            self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
-            return;
+            return self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
         }
         let dpl = Self::descriptor_dpl(rights);
         let rpl = selector & 3;
         if Self::descriptor_is_conforming_code(rights) {
             if dpl > rpl {
-                self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
-                return;
+                return self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
             }
         } else if dpl != rpl {
-            self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
-            return;
+            return self.raise_fault_with_code(10, Self::segment_error_code(selector), bus);
         }
         if !Self::descriptor_present(rights) {
-            self.raise_fault_with_code(11, Self::segment_error_code(selector), bus);
-            return;
+            return self.raise_fault_with_code(11, Self::segment_error_code(selector), bus);
         }
         if offset > descriptor.limit {
-            self.raise_fault_with_code(10, 0, bus);
-            return;
+            return self.raise_fault_with_code(10, 0, bus);
         }
-        if self.set_accessed_bit(selector, bus).is_none() {
-            return;
-        }
+        self.set_accessed_bit(selector, bus)?;
         let adjusted = (selector & !3) | rpl;
         self.set_loaded_segment_cache(SegReg32::CS, adjusted, descriptor);
         self.ip = offset as u16;
         self.ip_upper = offset & 0xFFFF_0000;
+        Ok(())
     }
 
     fn code_descriptor(
@@ -2422,70 +2266,57 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         old_cs: u16,
         old_eip: u32,
         bus: &mut impl common::Bus,
-    ) -> bool {
+    ) -> Step {
         let Some(addr) = self.descriptor_addr_checked(selector) else {
-            self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-            return false;
+            return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
         };
 
-        let Some(desc) = self.decode_descriptor_at(addr, bus) else {
-            // Fault was raised during descriptor read; propagate abort.
-            return false;
-        };
+        let desc = self.decode_descriptor_at(addr, bus)?;
         let r = desc.rights;
         let cpl = self.cpl();
         let rpl = selector & 3;
 
         if Self::descriptor_is_segment(r) {
             if !Self::descriptor_is_code(r) {
-                self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-                return false;
+                return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
             }
             if Self::descriptor_is_conforming_code(r) {
                 if Self::descriptor_dpl(r) > cpl {
-                    self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-                    return false;
+                    return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
                 }
             } else if rpl > cpl || Self::descriptor_dpl(r) != cpl {
-                self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-                return false;
+                return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
             }
             if !Self::descriptor_present(r) {
-                self.raise_fault_with_code(11, Self::segment_error_code(selector), bus);
-                return false;
+                return self.raise_fault_with_code(11, Self::segment_error_code(selector), bus);
             }
             if offset > desc.limit {
-                self.raise_fault_with_code(13, 0, bus);
-                return false;
+                return self.raise_fault_with_code(13, 0, bus);
             }
-            if self.set_accessed_bit(selector, bus).is_none() {
-                return false;
-            }
+            self.set_accessed_bit(selector, bus)?;
             let adjusted = (selector & !3) | cpl;
             self.set_loaded_segment_cache(SegReg32::CS, adjusted, desc);
             self.ip = offset as u16;
             self.ip_upper = offset & 0xFFFF_0000;
             if gate == TaskType::Call {
                 if self.operand_size_override {
-                    self.push_dword(bus, old_cs as u32);
-                    self.push_dword(bus, old_eip);
+                    self.push_dword(bus, old_cs as u32)?;
+                    self.push_dword(bus, old_eip)?;
                 } else {
-                    self.push(bus, old_cs);
-                    self.push(bus, old_eip as u16);
+                    self.push(bus, old_cs)?;
+                    self.push(bus, old_eip as u16)?;
                 }
             }
-            return true;
+            return Ok(());
         }
 
         // System descriptor.
         let dpl = Self::descriptor_dpl(r);
         if dpl < cpl.max(rpl) {
-            self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-            return false;
+            return self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
         }
         if !Self::descriptor_present(r) {
-            self.raise_fault_with_code(11, Self::segment_error_code(selector), bus);
-            return false;
+            return self.raise_fault_with_code(11, Self::segment_error_code(selector), bus);
         }
 
         let gate_type = r & 0x0F;
@@ -2493,64 +2324,62 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             4 | 12 => {
                 // Call gate (4=286, 12=386).
                 let is_386_gate = gate_type == 12;
-                let Some(gate_selector) = self.read_word_linear(bus, addr.wrapping_add(2)) else {
-                    return false;
-                };
+                let gate_selector = self.read_word_linear(bus, addr.wrapping_add(2))?;
                 let gc_linear = addr.wrapping_add(4);
-                let Some(gc_phys) = self.translate_linear(gc_linear, false, bus) else {
-                    return false;
-                };
+                let gc_phys = self.translate_linear(gc_linear, false, bus)?;
                 let gate_count = bus.read_byte(gc_phys) & 0x1F;
                 let gate_offset = if is_386_gate {
-                    let Some(lo) = self.read_word_linear(bus, addr) else {
-                        return false;
-                    };
-                    let Some(hi) = self.read_word_linear(bus, addr.wrapping_add(6)) else {
-                        return false;
-                    };
+                    let lo = self.read_word_linear(bus, addr)?;
+                    let hi = self.read_word_linear(bus, addr.wrapping_add(6))?;
                     lo as u32 | ((hi as u32) << 16)
                 } else {
-                    let Some(lo) = self.read_word_linear(bus, addr) else {
-                        return false;
-                    };
+                    let lo = self.read_word_linear(bus, addr)?;
                     lo as u32
                 };
 
                 let Some(target_addr) = self.descriptor_addr_checked(gate_selector) else {
-                    self.raise_fault_with_code(13, Self::segment_error_code(gate_selector), bus);
-                    return false;
+                    return self.raise_fault_with_code(
+                        13,
+                        Self::segment_error_code(gate_selector),
+                        bus,
+                    );
                 };
-                let Some(target_desc) = self.decode_descriptor_at(target_addr, bus) else {
-                    return false;
-                };
+                let target_desc = self.decode_descriptor_at(target_addr, bus)?;
                 let tr = target_desc.rights;
                 if !Self::descriptor_is_code(tr) || !Self::descriptor_is_segment(tr) {
-                    self.raise_fault_with_code(13, Self::segment_error_code(gate_selector), bus);
-                    return false;
+                    return self.raise_fault_with_code(
+                        13,
+                        Self::segment_error_code(gate_selector),
+                        bus,
+                    );
                 }
                 let target_dpl = Self::descriptor_dpl(tr);
                 if target_dpl > cpl {
-                    self.raise_fault_with_code(13, Self::segment_error_code(gate_selector), bus);
-                    return false;
+                    return self.raise_fault_with_code(
+                        13,
+                        Self::segment_error_code(gate_selector),
+                        bus,
+                    );
                 }
                 if !Self::descriptor_present(tr) {
-                    self.raise_fault_with_code(11, Self::segment_error_code(gate_selector), bus);
-                    return false;
+                    return self.raise_fault_with_code(
+                        11,
+                        Self::segment_error_code(gate_selector),
+                        bus,
+                    );
                 }
                 if gate_offset > target_desc.limit {
-                    self.raise_fault_with_code(13, 0, bus);
-                    return false;
+                    return self.raise_fault_with_code(13, 0, bus);
                 }
 
                 if !Self::descriptor_is_conforming_code(tr) && target_dpl < cpl {
                     // Inter-privilege call via call gate.
                     if gate == TaskType::Jmp {
-                        self.raise_fault_with_code(
+                        return self.raise_fault_with_code(
                             13,
                             Self::segment_error_code(gate_selector),
                             bus,
                         );
-                        return false;
                     }
 
                     let is_386_tss = self.tr_rights & 0x0F >= 9;
@@ -2561,25 +2390,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     };
                     let tss_ss_offset = tss_sp_offset + if is_386_tss { 4 } else { 2 };
                     let tss_esp = if is_386_tss {
-                        let Some(v) =
-                            self.read_dword_linear(bus, self.tr_base.wrapping_add(tss_sp_offset))
-                        else {
-                            return false;
-                        };
-                        v
+                        self.read_dword_linear(bus, self.tr_base.wrapping_add(tss_sp_offset))?
                     } else {
-                        let Some(v) =
-                            self.read_word_linear(bus, self.tr_base.wrapping_add(tss_sp_offset))
-                        else {
-                            return false;
-                        };
-                        v as u32
+                        self.read_word_linear(bus, self.tr_base.wrapping_add(tss_sp_offset))? as u32
                     };
-                    let Some(tss_ss) =
-                        self.read_word_linear(bus, self.tr_base.wrapping_add(tss_ss_offset))
-                    else {
-                        return false;
-                    };
+                    let tss_ss =
+                        self.read_word_linear(bus, self.tr_base.wrapping_add(tss_ss_offset))?;
 
                     let saved_ss = self.sregs[SegReg32::SS as usize];
                     let saved_esp = if self.use_esp() {
@@ -2592,31 +2408,40 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
                     // Validate the new SS descriptor without committing it yet.
                     if tss_ss & 0xFFFC == 0 {
-                        self.raise_fault_with_code(10, 0, bus);
-                        return false;
+                        return self.raise_fault_with_code(10, 0, bus);
                     }
-                    let Some(new_ss_desc) = self.decode_descriptor(tss_ss, bus) else {
-                        if !self.fault_pending {
-                            self.raise_fault_with_code(10, Self::segment_error_code(tss_ss), bus);
-                        }
-                        return false;
+                    let Some(new_ss_desc) = self.decode_descriptor(tss_ss, bus)? else {
+                        return self.raise_fault_with_code(
+                            10,
+                            Self::segment_error_code(tss_ss),
+                            bus,
+                        );
                     };
                     let new_ss_rights = new_ss_desc.rights;
                     if !Self::descriptor_is_segment(new_ss_rights)
                         || !Self::descriptor_is_writable(new_ss_rights)
                     {
-                        self.raise_fault_with_code(10, Self::segment_error_code(tss_ss), bus);
-                        return false;
+                        return self.raise_fault_with_code(
+                            10,
+                            Self::segment_error_code(tss_ss),
+                            bus,
+                        );
                     }
                     let new_ss_dpl = Self::descriptor_dpl(new_ss_rights);
                     let new_ss_rpl = tss_ss & 3;
                     if new_ss_dpl != target_dpl || new_ss_rpl != target_dpl {
-                        self.raise_fault_with_code(10, Self::segment_error_code(tss_ss), bus);
-                        return false;
+                        return self.raise_fault_with_code(
+                            10,
+                            Self::segment_error_code(tss_ss),
+                            bus,
+                        );
                     }
                     if !Self::descriptor_present(new_ss_rights) {
-                        self.raise_fault_with_code(10, Self::segment_error_code(tss_ss), bus);
-                        return false;
+                        return self.raise_fault_with_code(
+                            10,
+                            Self::segment_error_code(tss_ss),
+                            bus,
+                        );
                     }
 
                     // Stack-space pre-check: verify the new stack has room for
@@ -2639,13 +2464,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                         stack_top >= total_push_bytes
                     };
                     if !stack_space_ok {
-                        self.raise_fault_with_code(12, 0, bus);
-                        return false;
+                        return self.raise_fault_with_code(12, 0, bus);
                     }
 
-                    if self.set_accessed_bit(tss_ss, bus).is_none() {
-                        return false;
-                    }
+                    self.set_accessed_bit(tss_ss, bus)?;
                     self.set_loaded_segment_cache(SegReg32::SS, tss_ss, new_ss_desc);
                     if self.use_esp() {
                         self.regs.set_dword(crate::DwordReg::ESP, tss_esp);
@@ -2654,8 +2476,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     }
 
                     if is_386_gate {
-                        self.push_dword(bus, saved_ss as u32);
-                        self.push_dword(bus, saved_esp);
+                        self.push_dword(bus, saved_ss as u32)?;
+                        self.push_dword(bus, saved_esp)?;
                         for i in (0..gate_count as u32).rev() {
                             let offset = saved_esp.wrapping_add(i * 4);
                             let offset = if old_ss_is_32bit {
@@ -2663,16 +2485,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                             } else {
                                 offset & 0xFFFF
                             };
-                            let Some(param) =
-                                self.read_dword_linear(bus, old_ss_base.wrapping_add(offset))
-                            else {
-                                return false;
-                            };
-                            self.push_dword(bus, param);
+                            let param =
+                                self.read_dword_linear(bus, old_ss_base.wrapping_add(offset))?;
+                            self.push_dword(bus, param)?;
                         }
                     } else {
-                        self.push(bus, saved_ss);
-                        self.push(bus, saved_esp as u16);
+                        self.push(bus, saved_ss)?;
+                        self.push(bus, saved_esp as u16)?;
                         for i in (0..gate_count as u16).rev() {
                             let offset = saved_esp.wrapping_add(i as u32 * 2);
                             let offset = if old_ss_is_32bit {
@@ -2680,19 +2499,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                             } else {
                                 offset & 0xFFFF
                             };
-                            let Some(param) =
-                                self.read_word_linear(bus, old_ss_base.wrapping_add(offset))
-                            else {
-                                return false;
-                            };
-                            self.push(bus, param);
+                            let param =
+                                self.read_word_linear(bus, old_ss_base.wrapping_add(offset))?;
+                            self.push(bus, param)?;
                         }
                     }
                 }
 
-                if self.set_accessed_bit(gate_selector, bus).is_none() {
-                    return false;
-                }
+                self.set_accessed_bit(gate_selector, bus)?;
                 // Conforming targets preserve the calling CPL; non-conforming
                 // targets adopt the target's DPL as the new CPL.
                 let new_cpl = if Self::descriptor_is_conforming_code(tr) {
@@ -2706,66 +2520,64 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.ip_upper = gate_offset & 0xFFFF_0000;
                 if gate == TaskType::Call {
                     if is_386_gate {
-                        self.push_dword(bus, old_cs as u32);
-                        self.push_dword(bus, old_eip);
+                        self.push_dword(bus, old_cs as u32)?;
+                        self.push_dword(bus, old_eip)?;
                     } else {
-                        self.push(bus, old_cs);
-                        self.push(bus, old_eip as u16);
+                        self.push(bus, old_cs)?;
+                        self.push(bus, old_eip as u16)?;
                     }
                 }
-                true
+                Ok(())
             }
             5 => {
                 // Task gate.
-                let Some(task_selector) = self.read_word_linear(bus, addr.wrapping_add(2)) else {
-                    return false;
-                };
-                self.switch_task(task_selector, gate, bus);
+                let task_selector = self.read_word_linear(bus, addr.wrapping_add(2))?;
+                self.switch_task(task_selector, gate, bus)?;
                 let flags_val = self.flags.compress();
                 let cpl = self.cpl();
                 self.flags.load_flags(flags_val, cpl, true);
-                true
+                Ok(())
             }
             1 | 9 => {
                 // Available TSS descriptor.
-                self.switch_task(selector, gate, bus);
+                self.switch_task(selector, gate, bus)?;
                 let flags_val = self.flags.compress();
                 let cpl = self.cpl();
                 self.flags.load_flags(flags_val, cpl, true);
-                true
+                Ok(())
             }
             3 | 11 => {
                 // Busy TSS.
-                self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-                false
+                self.raise_fault_with_code(13, Self::segment_error_code(selector), bus)
             }
-            _ => {
-                self.raise_fault_with_code(13, Self::segment_error_code(selector), bus);
-                false
-            }
+            _ => self.raise_fault_with_code(13, Self::segment_error_code(selector), bus),
         }
     }
 
     /// Reads the 8-byte descriptor at `addr` (a linear address).
-    /// Returns `None` if any byte's translation faulted (the page
-    /// fault is already pending). Callers must propagate `None` as an
-    /// abort; never fall back to a sentinel descriptor.
+    /// Returns `Err(Fault)` if any byte's translation faulted (the page
+    /// fault is already pending). Callers must propagate as an abort;
+    /// never fall back to a sentinel descriptor.
     #[inline]
-    fn read_descriptor_byte(&mut self, linear: u32, bus: &mut impl common::Bus) -> Option<u8> {
+    fn read_descriptor_byte(&mut self, linear: u32, bus: &mut impl common::Bus) -> Step<u8> {
         let phys = self.translate_linear(linear, false, bus)?;
-        Some(bus.read_byte(phys))
+        Ok(bus.read_byte(phys))
     }
 
     fn decode_descriptor_at(
         &mut self,
         addr: u32,
         bus: &mut impl common::Bus,
-    ) -> Option<SegmentDescriptor> {
+    ) -> Step<SegmentDescriptor> {
         let saved_supervisor_override = self.supervisor_override;
         self.supervisor_override = true;
         // translate_linear short-circuits once fault_pending is set, so the
         // later reads after a fault on byte N are cheap no-ops returning
-        // None. Collect first, restore the override, then propagate.
+        // Err. Collect first, restore the override, then propagate.
+        // Read all bytes first so that a fault on byte N still restores the
+        // supervisor_override before we propagate. translate_linear short-
+        // circuits once fault_pending is set, so reads after the first fault
+        // are cheap no-ops that propagate Err.
         let b0 = self.read_descriptor_byte(addr, bus);
         let b1 = self.read_descriptor_byte(addr.wrapping_add(1), bus);
         let b2 = self.read_descriptor_byte(addr.wrapping_add(2), bus);
@@ -2791,12 +2603,107 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             raw_limit
         };
-        Some(SegmentDescriptor {
+        Ok(SegmentDescriptor {
             base,
             limit,
             rights,
             granularity: b6,
         })
+    }
+
+    fn execute_with_prefixes(&mut self, bus: &mut impl common::Bus) -> Step {
+        // 80486 PRM 9.9.13: instructions longer than 15 bytes raise #GP.
+        // Track prefix bytes consumed and bail if a 15th would be next:
+        // a 15-byte all-prefix run still requires an opcode byte, so the
+        // total length necessarily exceeds the limit.
+        let mut prefix_count: u32 = 0;
+        let mut opcode = self.fetch(bus);
+        if self.fault_pending {
+            return Err(Fault);
+        }
+        loop {
+            match opcode {
+                0x26 | 0x2E | 0x36 | 0x3E | 0x64 | 0x65 | 0x66 | 0x67 | 0xF0 => {
+                    if unlikely(prefix_count >= 14) {
+                        return self.raise_fault_with_code(13, 0, bus);
+                    }
+                    prefix_count += 1;
+                }
+                _ => {}
+            }
+            match opcode {
+                0x26 => {
+                    self.seg_prefix = true;
+                    self.prefix_seg = SegReg32::ES;
+                    self.clk(Self::timing(0, 1));
+                    opcode = self.fetch(bus);
+                }
+                0x2E => {
+                    self.seg_prefix = true;
+                    self.prefix_seg = SegReg32::CS;
+                    self.clk(Self::timing(0, 1));
+                    opcode = self.fetch(bus);
+                }
+                0x36 => {
+                    self.seg_prefix = true;
+                    self.prefix_seg = SegReg32::SS;
+                    self.clk(Self::timing(0, 1));
+                    opcode = self.fetch(bus);
+                }
+                0x3E => {
+                    self.seg_prefix = true;
+                    self.prefix_seg = SegReg32::DS;
+                    self.clk(Self::timing(0, 1));
+                    opcode = self.fetch(bus);
+                }
+                0x64 => {
+                    self.seg_prefix = true;
+                    self.prefix_seg = SegReg32::FS;
+                    self.clk(Self::timing(0, 1));
+                    opcode = self.fetch(bus);
+                }
+                0x65 => {
+                    self.seg_prefix = true;
+                    self.prefix_seg = SegReg32::GS;
+                    self.clk(Self::timing(0, 1));
+                    opcode = self.fetch(bus);
+                }
+                0x66 => {
+                    self.operand_size_override = !self.code_segment_32bit();
+                    self.clk(Self::timing(0, 1));
+                    opcode = self.fetch(bus);
+                }
+                0x67 => {
+                    self.address_size_override = !self.code_segment_32bit();
+                    self.clk(Self::timing(0, 1));
+                    opcode = self.fetch(bus);
+                }
+                0xF0 => {
+                    self.lock_prefix = true;
+                    self.clk(Self::timing(0, 1));
+                    opcode = self.fetch(bus);
+                }
+                _ => {
+                    if unlikely(self.lock_prefix && opcode != 0x0F && !Self::is_lockable(opcode)) {
+                        return self.raise_fault(6, bus);
+                    }
+                    if unlikely(
+                        self.lock_prefix
+                            && Self::is_lockable(opcode)
+                            && Self::lockable_modrm_is_register(self.peek_byte(bus)),
+                    ) {
+                        // 80486 PRM 13.1.1: LOCK with a lockable opcode
+                        // is still illegal when the destination operand
+                        // is a register (ModR/M mod == 11b).
+                        return self.raise_fault(6, bus);
+                    }
+                    return self.dispatch(opcode, bus);
+                }
+            }
+            if self.fault_pending {
+                return Err(Fault);
+            }
+        }
     }
 
     fn execute_one(&mut self, bus: &mut impl common::Bus) {
@@ -2828,98 +2735,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.address_size_override = d_bit;
 
         if self.rep_active {
-            self.continue_rep(bus);
+            let _ = self.continue_rep(bus);
         } else {
-            // 80486 PRM 9.9.13: instructions longer than 15 bytes raise #GP.
-            // Track prefix bytes consumed and bail if a 15th would be next:
-            // a 15-byte all-prefix run still requires an opcode byte, so the
-            // total length necessarily exceeds the limit.
-            let mut prefix_count: u32 = 0;
-            let mut opcode = self.fetch(bus);
-            while likely(!self.fault_pending) {
-                match opcode {
-                    0x26 | 0x2E | 0x36 | 0x3E | 0x64 | 0x65 | 0x66 | 0x67 | 0xF0 => {
-                        if unlikely(prefix_count >= 14) {
-                            self.raise_fault_with_code(13, 0, bus);
-                            break;
-                        }
-                        prefix_count += 1;
-                    }
-                    _ => {}
-                }
-                match opcode {
-                    0x26 => {
-                        self.seg_prefix = true;
-                        self.prefix_seg = SegReg32::ES;
-                        self.clk(Self::timing(0, 1));
-                        opcode = self.fetch(bus);
-                    }
-                    0x2E => {
-                        self.seg_prefix = true;
-                        self.prefix_seg = SegReg32::CS;
-                        self.clk(Self::timing(0, 1));
-                        opcode = self.fetch(bus);
-                    }
-                    0x36 => {
-                        self.seg_prefix = true;
-                        self.prefix_seg = SegReg32::SS;
-                        self.clk(Self::timing(0, 1));
-                        opcode = self.fetch(bus);
-                    }
-                    0x3E => {
-                        self.seg_prefix = true;
-                        self.prefix_seg = SegReg32::DS;
-                        self.clk(Self::timing(0, 1));
-                        opcode = self.fetch(bus);
-                    }
-                    0x64 => {
-                        self.seg_prefix = true;
-                        self.prefix_seg = SegReg32::FS;
-                        self.clk(Self::timing(0, 1));
-                        opcode = self.fetch(bus);
-                    }
-                    0x65 => {
-                        self.seg_prefix = true;
-                        self.prefix_seg = SegReg32::GS;
-                        self.clk(Self::timing(0, 1));
-                        opcode = self.fetch(bus);
-                    }
-                    0x66 => {
-                        self.operand_size_override = !self.code_segment_32bit();
-                        self.clk(Self::timing(0, 1));
-                        opcode = self.fetch(bus);
-                    }
-                    0x67 => {
-                        self.address_size_override = !self.code_segment_32bit();
-                        self.clk(Self::timing(0, 1));
-                        opcode = self.fetch(bus);
-                    }
-                    0xF0 => {
-                        self.lock_prefix = true;
-                        self.clk(Self::timing(0, 1));
-                        opcode = self.fetch(bus);
-                    }
-                    _ => {
-                        if unlikely(
-                            self.lock_prefix && opcode != 0x0F && !Self::is_lockable(opcode),
-                        ) {
-                            self.raise_fault(6, bus);
-                        } else if unlikely(
-                            self.lock_prefix
-                                && Self::is_lockable(opcode)
-                                && Self::lockable_modrm_is_register(self.peek_byte(bus)),
-                        ) {
-                            // 80486 PRM 13.1.1: LOCK with a lockable opcode
-                            // is still illegal when the destination operand
-                            // is a register (ModR/M mod == 11b).
-                            self.raise_fault(6, bus);
-                        } else {
-                            self.dispatch(opcode, bus);
-                        }
-                        break;
-                    }
-                }
-            }
+            let _ = self.execute_with_prefixes(bus);
         }
 
         if likely(!self.preserve_resume_flag && !self.rep_active) {
@@ -2927,13 +2745,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
 
         if unlikely(tf_was_set && !self.fault_pending && !inhibit) {
-            self.raise_trap(1, bus);
+            let _ = self.raise_trap(1, bus);
         }
 
         if unlikely(self.debug_trap_pending && !self.fault_pending) {
             self.debug_trap_pending = false;
             self.dr6 |= 0x8000; // BT (bit 15) - task switch debug trap
-            self.raise_trap(1, bus);
+            let _ = self.raise_trap(1, bus);
         }
     }
 

--- a/crates/cpu/src/i386/execute.rs
+++ b/crates/cpu/src/i386/execute.rs
@@ -2050,18 +2050,34 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let penalty = self.sp_penalty();
 
         if !self.is_protected_mode() || self.is_virtual_mode() {
-            if self.operand_size_override {
-                let eip = self.pop_dword(bus)?;
-                let cs_dword = self.pop_dword(bus)?;
-                let cs = cs_dword as u16;
-                self.load_segment(SegReg32::CS, cs, bus)?;
-                self.ip = eip as u16;
-                self.ip_upper = eip & 0xFFFF_0000;
+            let use_esp = self.use_esp();
+            let sp = if use_esp {
+                self.regs.dword(DwordReg::ESP)
             } else {
-                let ip = self.pop(bus)?;
-                let cs = self.pop(bus)?;
-                self.load_segment(SegReg32::CS, cs, bus)?;
-                self.ip = ip;
+                self.regs.word(WordReg::SP) as u32
+            };
+            let stack_offset = |delta: u32| -> u32 {
+                if use_esp {
+                    sp.wrapping_add(delta)
+                } else {
+                    (sp as u16).wrapping_add(delta as u16) as u32
+                }
+            };
+            let ss_base = self.seg_base(SegReg32::SS);
+            if self.operand_size_override {
+                let new_eip = self.read_dword_linear(bus, ss_base.wrapping_add(stack_offset(0)))?;
+                let new_cs_dword =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(stack_offset(4)))?;
+                self.load_segment(SegReg32::CS, new_cs_dword as u16, bus)?;
+                self.commit_sp(stack_offset(8));
+                self.ip = new_eip as u16;
+                self.ip_upper = new_eip & 0xFFFF_0000;
+            } else {
+                let new_ip = self.read_word_linear(bus, ss_base.wrapping_add(stack_offset(0)))?;
+                let new_cs = self.read_word_linear(bus, ss_base.wrapping_add(stack_offset(2)))?;
+                self.load_segment(SegReg32::CS, new_cs, bus)?;
+                self.commit_sp(stack_offset(4));
+                self.ip = new_ip;
                 self.ip_upper = 0;
             }
             match CPU_MODEL {
@@ -2216,22 +2232,36 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let imm = self.fetchword(bus);
 
         if !self.is_protected_mode() || self.is_virtual_mode() {
-            if self.operand_size_override {
-                let eip = self.pop_dword(bus)?;
-                let cs_dword = self.pop_dword(bus)?;
-                let cs = cs_dword as u16;
-                self.load_segment(SegReg32::CS, cs, bus)?;
-                self.ip = eip as u16;
-                self.ip_upper = eip & 0xFFFF_0000;
+            let use_esp = self.use_esp();
+            let sp = if use_esp {
+                self.regs.dword(DwordReg::ESP)
             } else {
-                let ip = self.pop(bus)?;
-                let cs = self.pop(bus)?;
-                self.load_segment(SegReg32::CS, cs, bus)?;
-                self.ip = ip;
+                self.regs.word(WordReg::SP) as u32
+            };
+            let stack_offset = |delta: u32| -> u32 {
+                if use_esp {
+                    sp.wrapping_add(delta)
+                } else {
+                    (sp as u16).wrapping_add(delta as u16) as u32
+                }
+            };
+            let ss_base = self.seg_base(SegReg32::SS);
+            if self.operand_size_override {
+                let new_eip = self.read_dword_linear(bus, ss_base.wrapping_add(stack_offset(0)))?;
+                let new_cs_dword =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(stack_offset(4)))?;
+                self.load_segment(SegReg32::CS, new_cs_dword as u16, bus)?;
+                self.commit_sp(stack_offset(8u32.wrapping_add(imm as u32)));
+                self.ip = new_eip as u16;
+                self.ip_upper = new_eip & 0xFFFF_0000;
+            } else {
+                let new_ip = self.read_word_linear(bus, ss_base.wrapping_add(stack_offset(0)))?;
+                let new_cs = self.read_word_linear(bus, ss_base.wrapping_add(stack_offset(2)))?;
+                self.load_segment(SegReg32::CS, new_cs, bus)?;
+                self.commit_sp(stack_offset(4u32.wrapping_add(imm as u32)));
+                self.ip = new_ip;
                 self.ip_upper = 0;
             }
-            let sp = self.regs.word(WordReg::SP).wrapping_add(imm);
-            self.regs.set_word(WordReg::SP, sp);
             match CPU_MODEL {
                 CPU_MODEL_386 => {
                     let m = self.next_instruction_length_approx(bus);

--- a/crates/cpu/src/i386/execute.rs
+++ b/crates/cpu/src/i386/execute.rs
@@ -1,93 +1,90 @@
-use super::{CPU_MODEL_386, CPU_MODEL_486, I386};
+use super::{CPU_MODEL_386, CPU_MODEL_486, Fault, I386, Step};
 use crate::{ByteReg, DwordReg, SegReg32, WordReg};
 
 impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
-    pub(super) fn dispatch(&mut self, opcode: u8, bus: &mut impl common::Bus) {
-        if self.fault_pending {
-            return;
-        }
+    pub(super) fn dispatch(&mut self, opcode: u8, bus: &mut impl common::Bus) -> Step {
         match opcode {
             // ADD
-            0x00 => self.add_br8(bus),
-            0x01 => self.add_wr16(bus),
-            0x02 => self.add_r8b(bus),
-            0x03 => self.add_r16w(bus),
+            0x00 => self.add_br8(bus)?,
+            0x01 => self.add_wr16(bus)?,
+            0x02 => self.add_r8b(bus)?,
+            0x03 => self.add_r16w(bus)?,
             0x04 => self.add_ald8(bus),
             0x05 => self.add_axd16(bus),
-            0x06 => self.push_seg(SegReg32::ES, bus),
-            0x07 => self.pop_seg(SegReg32::ES, bus),
+            0x06 => self.push_seg(SegReg32::ES, bus)?,
+            0x07 => self.pop_seg(SegReg32::ES, bus)?,
 
             // OR
-            0x08 => self.or_br8(bus),
-            0x09 => self.or_wr16(bus),
-            0x0A => self.or_r8b(bus),
-            0x0B => self.or_r16w(bus),
+            0x08 => self.or_br8(bus)?,
+            0x09 => self.or_wr16(bus)?,
+            0x0A => self.or_r8b(bus)?,
+            0x0B => self.or_r16w(bus)?,
             0x0C => self.or_ald8(bus),
             0x0D => self.or_axd16(bus),
-            0x0E => self.push_seg(SegReg32::CS, bus),
-            0x0F => self.extended_0f(bus),
+            0x0E => self.push_seg(SegReg32::CS, bus)?,
+            0x0F => self.extended_0f(bus)?,
 
             // ADC
-            0x10 => self.adc_br8(bus),
-            0x11 => self.adc_wr16(bus),
-            0x12 => self.adc_r8b(bus),
-            0x13 => self.adc_r16w(bus),
+            0x10 => self.adc_br8(bus)?,
+            0x11 => self.adc_wr16(bus)?,
+            0x12 => self.adc_r8b(bus)?,
+            0x13 => self.adc_r16w(bus)?,
             0x14 => self.adc_ald8(bus),
             0x15 => self.adc_axd16(bus),
-            0x16 => self.push_seg(SegReg32::SS, bus),
+            0x16 => self.push_seg(SegReg32::SS, bus)?,
             0x17 => {
-                self.pop_seg(SegReg32::SS, bus);
+                self.pop_seg(SegReg32::SS, bus)?;
                 self.inhibit_all = 1;
             }
 
             // SBB
-            0x18 => self.sbb_br8(bus),
-            0x19 => self.sbb_wr16(bus),
-            0x1A => self.sbb_r8b(bus),
-            0x1B => self.sbb_r16w(bus),
+            0x18 => self.sbb_br8(bus)?,
+            0x19 => self.sbb_wr16(bus)?,
+            0x1A => self.sbb_r8b(bus)?,
+            0x1B => self.sbb_r16w(bus)?,
             0x1C => self.sbb_ald8(bus),
             0x1D => self.sbb_axd16(bus),
-            0x1E => self.push_seg(SegReg32::DS, bus),
-            0x1F => self.pop_seg(SegReg32::DS, bus),
+            0x1E => self.push_seg(SegReg32::DS, bus)?,
+            0x1F => self.pop_seg(SegReg32::DS, bus)?,
 
             // AND
-            0x20 => self.and_br8(bus),
-            0x21 => self.and_wr16(bus),
-            0x22 => self.and_r8b(bus),
-            0x23 => self.and_r16w(bus),
+            0x20 => self.and_br8(bus)?,
+            0x21 => self.and_wr16(bus)?,
+            0x22 => self.and_r8b(bus)?,
+            0x23 => self.and_r16w(bus)?,
             0x24 => self.and_ald8(bus),
             0x25 => self.and_axd16(bus),
-            0x26 => self.invalid(bus),
+            0x26 => self.invalid(bus)?,
             0x27 => self.daa(bus),
 
             // SUB
-            0x28 => self.sub_br8(bus),
-            0x29 => self.sub_wr16(bus),
-            0x2A => self.sub_r8b(bus),
-            0x2B => self.sub_r16w(bus),
+            0x28 => self.sub_br8(bus)?,
+            0x29 => self.sub_wr16(bus)?,
+            0x2A => self.sub_r8b(bus)?,
+            0x2B => self.sub_r16w(bus)?,
             0x2C => self.sub_ald8(bus),
             0x2D => self.sub_axd16(bus),
-            0x2E => self.invalid(bus),
+            0x2E => self.invalid(bus)?,
             0x2F => self.das(bus),
 
             // XOR
-            0x30 => self.xor_br8(bus),
-            0x31 => self.xor_wr16(bus),
-            0x32 => self.xor_r8b(bus),
-            0x33 => self.xor_r16w(bus),
+            0x30 => self.xor_br8(bus)?,
+            0x31 => self.xor_wr16(bus)?,
+            0x32 => self.xor_r8b(bus)?,
+            0x33 => self.xor_r16w(bus)?,
             0x34 => self.xor_ald8(bus),
             0x35 => self.xor_axd16(bus),
-            0x36 => self.invalid(bus),
+            0x36 => self.invalid(bus)?,
             0x37 => self.aaa(bus),
 
             // CMP
-            0x38 => self.cmp_br8(bus),
-            0x39 => self.cmp_wr16(bus),
-            0x3A => self.cmp_r8b(bus),
-            0x3B => self.cmp_r16w(bus),
+            0x38 => self.cmp_br8(bus)?,
+            0x39 => self.cmp_wr16(bus)?,
+            0x3A => self.cmp_r8b(bus)?,
+            0x3B => self.cmp_r16w(bus)?,
             0x3C => self.cmp_ald8(bus),
             0x3D => self.cmp_axd16(bus),
-            0x3E => self.invalid(bus),
+            0x3E => self.invalid(bus)?,
             0x3F => self.aas(bus),
 
             // INC word registers
@@ -111,42 +108,42 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             0x4F => self.dec_word_reg(WordReg::DI),
 
             // PUSH word registers
-            0x50 => self.push_word_reg(WordReg::AX, bus),
-            0x51 => self.push_word_reg(WordReg::CX, bus),
-            0x52 => self.push_word_reg(WordReg::DX, bus),
-            0x53 => self.push_word_reg(WordReg::BX, bus),
-            0x54 => self.push_sp(bus),
-            0x55 => self.push_word_reg(WordReg::BP, bus),
-            0x56 => self.push_word_reg(WordReg::SI, bus),
-            0x57 => self.push_word_reg(WordReg::DI, bus),
+            0x50 => self.push_word_reg(WordReg::AX, bus)?,
+            0x51 => self.push_word_reg(WordReg::CX, bus)?,
+            0x52 => self.push_word_reg(WordReg::DX, bus)?,
+            0x53 => self.push_word_reg(WordReg::BX, bus)?,
+            0x54 => self.push_sp(bus)?,
+            0x55 => self.push_word_reg(WordReg::BP, bus)?,
+            0x56 => self.push_word_reg(WordReg::SI, bus)?,
+            0x57 => self.push_word_reg(WordReg::DI, bus)?,
 
             // POP word registers
-            0x58 => self.pop_word_reg(WordReg::AX, bus),
-            0x59 => self.pop_word_reg(WordReg::CX, bus),
-            0x5A => self.pop_word_reg(WordReg::DX, bus),
-            0x5B => self.pop_word_reg(WordReg::BX, bus),
-            0x5C => self.pop_word_reg(WordReg::SP, bus),
-            0x5D => self.pop_word_reg(WordReg::BP, bus),
-            0x5E => self.pop_word_reg(WordReg::SI, bus),
-            0x5F => self.pop_word_reg(WordReg::DI, bus),
+            0x58 => self.pop_word_reg(WordReg::AX, bus)?,
+            0x59 => self.pop_word_reg(WordReg::CX, bus)?,
+            0x5A => self.pop_word_reg(WordReg::DX, bus)?,
+            0x5B => self.pop_word_reg(WordReg::BX, bus)?,
+            0x5C => self.pop_word_reg(WordReg::SP, bus)?,
+            0x5D => self.pop_word_reg(WordReg::BP, bus)?,
+            0x5E => self.pop_word_reg(WordReg::SI, bus)?,
+            0x5F => self.pop_word_reg(WordReg::DI, bus)?,
 
             // 80186 instructions
-            0x60 => self.pusha(bus),
-            0x61 => self.popa(bus),
-            0x62 => self.bound(bus),
-            0x63 => self.arpl(bus),
-            0x64 => self.invalid(bus),
-            0x65 => self.invalid(bus),
-            0x66 => self.invalid(bus),
-            0x67 => self.invalid(bus),
-            0x68 => self.push_imm16(bus),
-            0x69 => self.imul_r16w_imm16(bus),
-            0x6A => self.push_imm8(bus),
-            0x6B => self.imul_r16w_imm8(bus),
-            0x6C => self.insb(bus),
-            0x6D => self.insw(bus),
-            0x6E => self.outsb(bus),
-            0x6F => self.outsw(bus),
+            0x60 => self.pusha(bus)?,
+            0x61 => self.popa(bus)?,
+            0x62 => self.bound(bus)?,
+            0x63 => self.arpl(bus)?,
+            0x64 => self.invalid(bus)?,
+            0x65 => self.invalid(bus)?,
+            0x66 => self.invalid(bus)?,
+            0x67 => self.invalid(bus)?,
+            0x68 => self.push_imm16(bus)?,
+            0x69 => self.imul_r16w_imm16(bus)?,
+            0x6A => self.push_imm8(bus)?,
+            0x6B => self.imul_r16w_imm8(bus)?,
+            0x6C => self.insb(bus)?,
+            0x6D => self.insw(bus)?,
+            0x6E => self.outsb(bus)?,
+            0x6F => self.outsw(bus)?,
 
             // Jcc (short jumps)
             0x70 => self.jcc(bus, self.flags.of()),
@@ -170,30 +167,30 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             ),
 
             // Group 1
-            0x80 => self.group_80(bus),
-            0x81 => self.group_81(bus),
-            0x82 => self.group_82(bus),
-            0x83 => self.group_83(bus),
+            0x80 => self.group_80(bus)?,
+            0x81 => self.group_81(bus)?,
+            0x82 => self.group_82(bus)?,
+            0x83 => self.group_83(bus)?,
 
             // TEST
-            0x84 => self.test_br8(bus),
-            0x85 => self.test_wr16(bus),
+            0x84 => self.test_br8(bus)?,
+            0x85 => self.test_wr16(bus)?,
 
             // XCHG
-            0x86 => self.xchg_br8(bus),
-            0x87 => self.xchg_wr16(bus),
+            0x86 => self.xchg_br8(bus)?,
+            0x87 => self.xchg_wr16(bus)?,
 
             // MOV r/m, reg
-            0x88 => self.mov_br8(bus),
-            0x89 => self.mov_wr16(bus),
-            0x8A => self.mov_r8b(bus),
-            0x8B => self.mov_r16w(bus),
+            0x88 => self.mov_br8(bus)?,
+            0x89 => self.mov_wr16(bus)?,
+            0x8A => self.mov_r8b(bus)?,
+            0x8B => self.mov_r16w(bus)?,
 
             // MOV r/m, sreg / LEA / MOV sreg, r/m
-            0x8C => self.mov_rm_sreg(bus),
-            0x8D => self.lea(bus),
-            0x8E => self.mov_sreg_rm(bus),
-            0x8F => self.pop_rm(bus),
+            0x8C => self.mov_rm_sreg(bus)?,
+            0x8D => self.lea(bus)?,
+            0x8E => self.mov_sreg_rm(bus)?,
+            0x8F => self.pop_rm(bus)?,
 
             // XCHG AX, reg / NOP
             0x90 => self.clk(Self::timing(3, 1)),
@@ -210,36 +207,36 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             0x99 => self.cwd(),
 
             // CALL far, WAIT
-            0x9A => self.call_far(bus),
-            0x9B => self.fpu_wait(bus),
-            0x9C => self.pushf(bus),
-            0x9D => self.popf(bus),
+            0x9A => self.call_far(bus)?,
+            0x9B => self.fpu_wait(bus)?,
+            0x9C => self.pushf(bus)?,
+            0x9D => self.popf(bus)?,
             0x9E => self.sahf(),
             0x9F => self.lahf(),
 
             // MOV AL/AX, [addr] and [addr], AL/AX
-            0xA0 => self.mov_al_moffs(bus),
-            0xA1 => self.mov_aw_moffs(bus),
-            0xA2 => self.mov_moffs_al(bus),
-            0xA3 => self.mov_moffs_aw(bus),
+            0xA0 => self.mov_al_moffs(bus)?,
+            0xA1 => self.mov_aw_moffs(bus)?,
+            0xA2 => self.mov_moffs_al(bus)?,
+            0xA3 => self.mov_moffs_aw(bus)?,
 
             // String ops
-            0xA4 => self.movsb(bus),
-            0xA5 => self.movsw(bus),
-            0xA6 => self.cmpsb(bus),
-            0xA7 => self.cmpsw(bus),
+            0xA4 => self.movsb(bus)?,
+            0xA5 => self.movsw(bus)?,
+            0xA6 => self.cmpsb(bus)?,
+            0xA7 => self.cmpsw(bus)?,
 
             // TEST AL/AX, imm
             0xA8 => self.test_al_imm8(bus),
             0xA9 => self.test_aw_imm16(bus),
 
             // STOS, LODS, SCAS
-            0xAA => self.stosb(bus),
-            0xAB => self.stosw(bus),
-            0xAC => self.lodsb(bus),
-            0xAD => self.lodsw(bus),
-            0xAE => self.scasb(bus),
-            0xAF => self.scasw(bus),
+            0xAA => self.stosb(bus)?,
+            0xAB => self.stosw(bus)?,
+            0xAC => self.lodsb(bus)?,
+            0xAD => self.lodsw(bus)?,
+            0xAE => self.scasb(bus)?,
+            0xAF => self.scasw(bus)?,
 
             // MOV byte reg, imm8
             0xB0 => self.mov_byte_reg_imm(ByteReg::AL, bus),
@@ -262,40 +259,40 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             0xBF => self.mov_word_reg_imm(WordReg::DI, bus),
 
             // Shift/rotate groups
-            0xC0 => self.group_c0(bus),
-            0xC1 => self.group_c1(bus),
+            0xC0 => self.group_c0(bus)?,
+            0xC1 => self.group_c1(bus)?,
 
             // RET near imm16, RET near
-            0xC2 => self.ret_near_imm(bus),
-            0xC3 => self.ret_near(bus),
+            0xC2 => self.ret_near_imm(bus)?,
+            0xC3 => self.ret_near(bus)?,
 
             // LES, LDS
-            0xC4 => self.les(bus),
-            0xC5 => self.lds(bus),
+            0xC4 => self.les(bus)?,
+            0xC5 => self.lds(bus)?,
 
             // MOV r/m, imm
-            0xC6 => self.mov_rm_imm8(bus),
-            0xC7 => self.mov_rm_imm16(bus),
+            0xC6 => self.mov_rm_imm8(bus)?,
+            0xC7 => self.mov_rm_imm16(bus)?,
 
             // ENTER, LEAVE
-            0xC8 => self.enter(bus),
-            0xC9 => self.leave(bus),
+            0xC8 => self.enter(bus)?,
+            0xC9 => self.leave(bus)?,
 
             // RET far imm16, RET far
-            0xCA => self.ret_far_imm(bus),
-            0xCB => self.ret_far(bus),
+            0xCA => self.ret_far_imm(bus)?,
+            0xCB => self.ret_far(bus)?,
 
             // INT 3, INT imm8, INTO, IRET
-            0xCC => self.int3(bus),
-            0xCD => self.int_imm(bus),
-            0xCE => self.into(bus),
-            0xCF => self.iret(bus),
+            0xCC => self.int3(bus)?,
+            0xCD => self.int_imm(bus)?,
+            0xCE => self.into(bus)?,
+            0xCF => self.iret(bus)?,
 
             // Shift/rotate groups
-            0xD0 => self.group_d0(bus),
-            0xD1 => self.group_d1(bus),
-            0xD2 => self.group_d2(bus),
-            0xD3 => self.group_d3(bus),
+            0xD0 => self.group_d0(bus)?,
+            0xD1 => self.group_d1(bus)?,
+            0xD2 => self.group_d2(bus)?,
+            0xD3 => self.group_d3(bus)?,
 
             // AAM, AAD
             0xD4 => self.aam(bus),
@@ -305,10 +302,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             0xD6 => self.salc(),
 
             // XLAT
-            0xD7 => self.xlat(bus),
+            0xD7 => self.xlat(bus)?,
 
             // FPU escape
-            0xD8..=0xDF => self.fpu_escape(opcode, bus),
+            0xD8..=0xDF => self.fpu_escape(opcode, bus)?,
 
             // LOOPNE, LOOPE, LOOP, JCXZ
             0xE0 => self.loopne(bus),
@@ -317,128 +314,112 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             0xE3 => self.jcxz(bus),
 
             // IN, OUT
-            0xE4 => self.in_al_imm(bus),
-            0xE5 => self.in_aw_imm(bus),
-            0xE6 => self.out_imm_al(bus),
-            0xE7 => self.out_imm_aw(bus),
+            0xE4 => self.in_al_imm(bus)?,
+            0xE5 => self.in_aw_imm(bus)?,
+            0xE6 => self.out_imm_al(bus)?,
+            0xE7 => self.out_imm_aw(bus)?,
 
             // CALL near, JMP near, JMP far, JMP short
-            0xE8 => self.call_near(bus),
+            0xE8 => self.call_near(bus)?,
             0xE9 => self.jmp_near(bus),
-            0xEA => self.jmp_far(bus),
+            0xEA => self.jmp_far(bus)?,
             0xEB => self.jmp_short(bus),
 
             // IN, OUT (DX port)
-            0xEC => self.in_al_dw(bus),
-            0xED => self.in_aw_dw(bus),
-            0xEE => self.out_dw_al(bus),
-            0xEF => self.out_dw_aw(bus),
+            0xEC => self.in_al_dw(bus)?,
+            0xED => self.in_aw_dw(bus)?,
+            0xEE => self.out_dw_al(bus)?,
+            0xEF => self.out_dw_aw(bus)?,
 
-            0xF0 => self.invalid(bus),
-            0xF1 => self.invalid(bus),
+            0xF0 => self.invalid(bus)?,
+            0xF1 => self.invalid(bus)?,
 
             // REPNE, REPE
-            0xF2 => self.repne(bus),
-            0xF3 => self.repe(bus),
+            0xF2 => self.repne(bus)?,
+            0xF3 => self.repe(bus)?,
 
             // HLT
-            0xF4 => self.hlt(bus),
+            0xF4 => self.hlt(bus)?,
 
             // CMC
             0xF5 => self.cmc(),
 
             // Group 3 byte/word
-            0xF6 => self.group_f6(bus),
-            0xF7 => self.group_f7(bus),
+            0xF6 => self.group_f6(bus)?,
+            0xF7 => self.group_f7(bus)?,
 
             // CLC, STC, CLI, STI, CLD, STD
             0xF8 => self.clc(),
             0xF9 => self.stc(),
-            0xFA => self.cli(bus),
-            0xFB => self.sti(bus),
+            0xFA => self.cli(bus)?,
+            0xFB => self.sti(bus)?,
             0xFC => self.cld(),
             0xFD => self.std(),
 
             // Group 4/5
-            0xFE => self.group_fe(bus),
-            0xFF => self.group_ff(bus),
+            0xFE => self.group_fe(bus)?,
+            0xFF => self.group_ff(bus)?,
         }
+        Ok(())
     }
 
-    fn add_br8(&mut self, bus: &mut impl common::Bus) {
+    fn add_br8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let Some(dst) = self.get_rm_byte_for_update(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte_for_update(modrm, bus)?;
         let result = self.alu_add_byte(dst, src);
-        self.putback_rm_byte(modrm, result, bus);
-        if self.fault_pending {
-            return;
-        }
+        self.putback_rm_byte(modrm, result, bus)?;
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
+        Ok(())
     }
 
-    fn add_wr16(&mut self, bus: &mut impl common::Bus) {
+    fn add_wr16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword_for_update(modrm, bus)?;
             let result = self.alu_add_dword(dst, src);
-            self.putback_rm_dword(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_dword(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let Some(dst) = self.get_rm_word_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word_for_update(modrm, bus)?;
             let result = self.alu_add_word(dst, src);
-            self.putback_rm_word(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_word(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
+        Ok(())
     }
 
-    fn add_r8b(&mut self, bus: &mut impl common::Bus) {
+    fn add_r8b(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let dst = self.regs.byte(self.reg_byte(modrm));
-        let Some(src) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let src = self.get_rm_byte(modrm, bus)?;
         let result = self.alu_add_byte(dst, src);
         let reg = self.reg_byte(modrm);
         self.regs.set_byte(reg, result);
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 2));
+        Ok(())
     }
 
-    fn add_r16w(&mut self, bus: &mut impl common::Bus) {
+    fn add_r16w(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let dst = self.regs.dword(self.reg_dword(modrm));
-            let Some(src) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_dword(modrm, bus)?;
             let result = self.alu_add_dword(dst, src);
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 2);
         } else {
             let dst = self.regs.word(self.reg_word(modrm));
-            let Some(src) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_word(modrm, bus)?;
             let result = self.alu_add_word(dst, src);
             let reg = self.reg_word(modrm);
             self.regs.set_word(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 1);
         }
+        Ok(())
     }
 
     fn add_ald8(&mut self, bus: &mut impl common::Bus) {
@@ -464,80 +445,63 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 1));
     }
 
-    fn or_br8(&mut self, bus: &mut impl common::Bus) {
+    fn or_br8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let Some(dst) = self.get_rm_byte_for_update(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte_for_update(modrm, bus)?;
         let result = self.alu_or_byte(dst, src);
-        self.putback_rm_byte(modrm, result, bus);
-        if self.fault_pending {
-            return;
-        }
+        self.putback_rm_byte(modrm, result, bus)?;
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
+        Ok(())
     }
 
-    fn or_wr16(&mut self, bus: &mut impl common::Bus) {
+    fn or_wr16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword_for_update(modrm, bus)?;
             let result = self.alu_or_dword(dst, src);
-            self.putback_rm_dword(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_dword(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let Some(dst) = self.get_rm_word_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word_for_update(modrm, bus)?;
             let result = self.alu_or_word(dst, src);
-            self.putback_rm_word(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_word(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
+        Ok(())
     }
 
-    fn or_r8b(&mut self, bus: &mut impl common::Bus) {
+    fn or_r8b(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let dst = self.regs.byte(self.reg_byte(modrm));
-        let Some(src) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let src = self.get_rm_byte(modrm, bus)?;
         let result = self.alu_or_byte(dst, src);
         let reg = self.reg_byte(modrm);
         self.regs.set_byte(reg, result);
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 2));
+        Ok(())
     }
 
-    fn or_r16w(&mut self, bus: &mut impl common::Bus) {
+    fn or_r16w(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let dst = self.regs.dword(self.reg_dword(modrm));
-            let Some(src) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_dword(modrm, bus)?;
             let result = self.alu_or_dword(dst, src);
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 2);
         } else {
             let dst = self.regs.word(self.reg_word(modrm));
-            let Some(src) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_word(modrm, bus)?;
             let result = self.alu_or_word(dst, src);
             let reg = self.reg_word(modrm);
             self.regs.set_word(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 1);
         }
+        Ok(())
     }
 
     fn or_ald8(&mut self, bus: &mut impl common::Bus) {
@@ -563,84 +527,67 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 1));
     }
 
-    fn adc_br8(&mut self, bus: &mut impl common::Bus) {
+    fn adc_br8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let Some(dst) = self.get_rm_byte_for_update(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte_for_update(modrm, bus)?;
         let cf = self.flags.cf_val();
         let result = self.alu_adc_byte(dst, src, cf);
-        self.putback_rm_byte(modrm, result, bus);
-        if self.fault_pending {
-            return;
-        }
+        self.putback_rm_byte(modrm, result, bus)?;
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
+        Ok(())
     }
 
-    fn adc_wr16(&mut self, bus: &mut impl common::Bus) {
+    fn adc_wr16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let cf = self.flags.cf_val();
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword_for_update(modrm, bus)?;
             let result = self.alu_adc_dword(dst, src, cf);
-            self.putback_rm_dword(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_dword(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let Some(dst) = self.get_rm_word_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word_for_update(modrm, bus)?;
             let result = self.alu_adc_word(dst, src, cf);
-            self.putback_rm_word(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_word(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
+        Ok(())
     }
 
-    fn adc_r8b(&mut self, bus: &mut impl common::Bus) {
+    fn adc_r8b(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let dst = self.regs.byte(self.reg_byte(modrm));
-        let Some(src) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let src = self.get_rm_byte(modrm, bus)?;
         let cf = self.flags.cf_val();
         let result = self.alu_adc_byte(dst, src, cf);
         let reg = self.reg_byte(modrm);
         self.regs.set_byte(reg, result);
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 2));
+        Ok(())
     }
 
-    fn adc_r16w(&mut self, bus: &mut impl common::Bus) {
+    fn adc_r16w(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let cf = self.flags.cf_val();
         if self.operand_size_override {
             let dst = self.regs.dword(self.reg_dword(modrm));
-            let Some(src) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_dword(modrm, bus)?;
             let result = self.alu_adc_dword(dst, src, cf);
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 2);
         } else {
             let dst = self.regs.word(self.reg_word(modrm));
-            let Some(src) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_word(modrm, bus)?;
             let result = self.alu_adc_word(dst, src, cf);
             let reg = self.reg_word(modrm);
             self.regs.set_word(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 1);
         }
+        Ok(())
     }
 
     fn adc_ald8(&mut self, bus: &mut impl common::Bus) {
@@ -668,84 +615,67 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 1));
     }
 
-    fn sbb_br8(&mut self, bus: &mut impl common::Bus) {
+    fn sbb_br8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let Some(dst) = self.get_rm_byte_for_update(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte_for_update(modrm, bus)?;
         let cf = self.flags.cf_val();
         let result = self.alu_sbb_byte(dst, src, cf);
-        self.putback_rm_byte(modrm, result, bus);
-        if self.fault_pending {
-            return;
-        }
+        self.putback_rm_byte(modrm, result, bus)?;
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
+        Ok(())
     }
 
-    fn sbb_wr16(&mut self, bus: &mut impl common::Bus) {
+    fn sbb_wr16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let cf = self.flags.cf_val();
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword_for_update(modrm, bus)?;
             let result = self.alu_sbb_dword(dst, src, cf);
-            self.putback_rm_dword(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_dword(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let Some(dst) = self.get_rm_word_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word_for_update(modrm, bus)?;
             let result = self.alu_sbb_word(dst, src, cf);
-            self.putback_rm_word(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_word(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
+        Ok(())
     }
 
-    fn sbb_r8b(&mut self, bus: &mut impl common::Bus) {
+    fn sbb_r8b(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let dst = self.regs.byte(self.reg_byte(modrm));
-        let Some(src) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let src = self.get_rm_byte(modrm, bus)?;
         let cf = self.flags.cf_val();
         let result = self.alu_sbb_byte(dst, src, cf);
         let reg = self.reg_byte(modrm);
         self.regs.set_byte(reg, result);
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 2));
+        Ok(())
     }
 
-    fn sbb_r16w(&mut self, bus: &mut impl common::Bus) {
+    fn sbb_r16w(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let cf = self.flags.cf_val();
         if self.operand_size_override {
             let dst = self.regs.dword(self.reg_dword(modrm));
-            let Some(src) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_dword(modrm, bus)?;
             let result = self.alu_sbb_dword(dst, src, cf);
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 2);
         } else {
             let dst = self.regs.word(self.reg_word(modrm));
-            let Some(src) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_word(modrm, bus)?;
             let result = self.alu_sbb_word(dst, src, cf);
             let reg = self.reg_word(modrm);
             self.regs.set_word(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 1);
         }
+        Ok(())
     }
 
     fn sbb_ald8(&mut self, bus: &mut impl common::Bus) {
@@ -773,80 +703,63 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 1));
     }
 
-    fn and_br8(&mut self, bus: &mut impl common::Bus) {
+    fn and_br8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let Some(dst) = self.get_rm_byte_for_update(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte_for_update(modrm, bus)?;
         let result = self.alu_and_byte(dst, src);
-        self.putback_rm_byte(modrm, result, bus);
-        if self.fault_pending {
-            return;
-        }
+        self.putback_rm_byte(modrm, result, bus)?;
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
+        Ok(())
     }
 
-    fn and_wr16(&mut self, bus: &mut impl common::Bus) {
+    fn and_wr16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword_for_update(modrm, bus)?;
             let result = self.alu_and_dword(dst, src);
-            self.putback_rm_dword(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_dword(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let Some(dst) = self.get_rm_word_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word_for_update(modrm, bus)?;
             let result = self.alu_and_word(dst, src);
-            self.putback_rm_word(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_word(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
+        Ok(())
     }
 
-    fn and_r8b(&mut self, bus: &mut impl common::Bus) {
+    fn and_r8b(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let dst = self.regs.byte(self.reg_byte(modrm));
-        let Some(src) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let src = self.get_rm_byte(modrm, bus)?;
         let result = self.alu_and_byte(dst, src);
         let reg = self.reg_byte(modrm);
         self.regs.set_byte(reg, result);
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 2));
+        Ok(())
     }
 
-    fn and_r16w(&mut self, bus: &mut impl common::Bus) {
+    fn and_r16w(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let dst = self.regs.dword(self.reg_dword(modrm));
-            let Some(src) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_dword(modrm, bus)?;
             let result = self.alu_and_dword(dst, src);
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 2);
         } else {
             let dst = self.regs.word(self.reg_word(modrm));
-            let Some(src) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_word(modrm, bus)?;
             let result = self.alu_and_word(dst, src);
             let reg = self.reg_word(modrm);
             self.regs.set_word(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 1);
         }
+        Ok(())
     }
 
     fn and_ald8(&mut self, bus: &mut impl common::Bus) {
@@ -872,80 +785,63 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 1));
     }
 
-    fn sub_br8(&mut self, bus: &mut impl common::Bus) {
+    fn sub_br8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let Some(dst) = self.get_rm_byte_for_update(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte_for_update(modrm, bus)?;
         let result = self.alu_sub_byte(dst, src);
-        self.putback_rm_byte(modrm, result, bus);
-        if self.fault_pending {
-            return;
-        }
+        self.putback_rm_byte(modrm, result, bus)?;
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
+        Ok(())
     }
 
-    fn sub_wr16(&mut self, bus: &mut impl common::Bus) {
+    fn sub_wr16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword_for_update(modrm, bus)?;
             let result = self.alu_sub_dword(dst, src);
-            self.putback_rm_dword(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_dword(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let Some(dst) = self.get_rm_word_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word_for_update(modrm, bus)?;
             let result = self.alu_sub_word(dst, src);
-            self.putback_rm_word(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_word(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
+        Ok(())
     }
 
-    fn sub_r8b(&mut self, bus: &mut impl common::Bus) {
+    fn sub_r8b(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let dst = self.regs.byte(self.reg_byte(modrm));
-        let Some(src) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let src = self.get_rm_byte(modrm, bus)?;
         let result = self.alu_sub_byte(dst, src);
         let reg = self.reg_byte(modrm);
         self.regs.set_byte(reg, result);
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 2));
+        Ok(())
     }
 
-    fn sub_r16w(&mut self, bus: &mut impl common::Bus) {
+    fn sub_r16w(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let dst = self.regs.dword(self.reg_dword(modrm));
-            let Some(src) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_dword(modrm, bus)?;
             let result = self.alu_sub_dword(dst, src);
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 2);
         } else {
             let dst = self.regs.word(self.reg_word(modrm));
-            let Some(src) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_word(modrm, bus)?;
             let result = self.alu_sub_word(dst, src);
             let reg = self.reg_word(modrm);
             self.regs.set_word(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 1);
         }
+        Ok(())
     }
 
     fn sub_ald8(&mut self, bus: &mut impl common::Bus) {
@@ -971,80 +867,63 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 1));
     }
 
-    fn xor_br8(&mut self, bus: &mut impl common::Bus) {
+    fn xor_br8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let Some(dst) = self.get_rm_byte_for_update(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte_for_update(modrm, bus)?;
         let result = self.alu_xor_byte(dst, src);
-        self.putback_rm_byte(modrm, result, bus);
-        if self.fault_pending {
-            return;
-        }
+        self.putback_rm_byte(modrm, result, bus)?;
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
+        Ok(())
     }
 
-    fn xor_wr16(&mut self, bus: &mut impl common::Bus) {
+    fn xor_wr16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword_for_update(modrm, bus)?;
             let result = self.alu_xor_dword(dst, src);
-            self.putback_rm_dword(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_dword(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let Some(dst) = self.get_rm_word_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word_for_update(modrm, bus)?;
             let result = self.alu_xor_word(dst, src);
-            self.putback_rm_word(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_word(modrm, result, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
+        Ok(())
     }
 
-    fn xor_r8b(&mut self, bus: &mut impl common::Bus) {
+    fn xor_r8b(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let dst = self.regs.byte(self.reg_byte(modrm));
-        let Some(src) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let src = self.get_rm_byte(modrm, bus)?;
         let result = self.alu_xor_byte(dst, src);
         let reg = self.reg_byte(modrm);
         self.regs.set_byte(reg, result);
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 2));
+        Ok(())
     }
 
-    fn xor_r16w(&mut self, bus: &mut impl common::Bus) {
+    fn xor_r16w(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let dst = self.regs.dword(self.reg_dword(modrm));
-            let Some(src) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_dword(modrm, bus)?;
             let result = self.alu_xor_dword(dst, src);
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 2);
         } else {
             let dst = self.regs.word(self.reg_word(modrm));
-            let Some(src) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_word(modrm, bus)?;
             let result = self.alu_xor_word(dst, src);
             let reg = self.reg_word(modrm);
             self.regs.set_word(reg, result);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 1);
         }
+        Ok(())
     }
 
     fn xor_ald8(&mut self, bus: &mut impl common::Bus) {
@@ -1070,62 +949,54 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 1));
     }
 
-    fn cmp_br8(&mut self, bus: &mut impl common::Bus) {
+    fn cmp_br8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let Some(dst) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte(modrm, bus)?;
         self.alu_sub_byte(dst, src);
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(5, 2));
+        Ok(())
     }
 
-    fn cmp_wr16(&mut self, bus: &mut impl common::Bus) {
+    fn cmp_wr16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword(modrm, bus)?;
             self.alu_sub_dword(dst, src);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(5, 2), 2);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let Some(dst) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word(modrm, bus)?;
             self.alu_sub_word(dst, src);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(5, 2), 1);
         }
+        Ok(())
     }
 
-    fn cmp_r8b(&mut self, bus: &mut impl common::Bus) {
+    fn cmp_r8b(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let dst = self.regs.byte(self.reg_byte(modrm));
-        let Some(src) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let src = self.get_rm_byte(modrm, bus)?;
         self.alu_sub_byte(dst, src);
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 2));
+        Ok(())
     }
 
-    fn cmp_r16w(&mut self, bus: &mut impl common::Bus) {
+    fn cmp_r16w(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let dst = self.regs.dword(self.reg_dword(modrm));
-            let Some(src) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_dword(modrm, bus)?;
             self.alu_sub_dword(dst, src);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 2);
         } else {
             let dst = self.regs.word(self.reg_word(modrm));
-            let Some(src) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_word(modrm, bus)?;
             self.alu_sub_word(dst, src);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 2), 1);
         }
+        Ok(())
     }
 
     fn cmp_ald8(&mut self, bus: &mut impl common::Bus) {
@@ -1176,49 +1047,48 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 1));
     }
 
-    fn push_word_reg(&mut self, reg: WordReg, bus: &mut impl common::Bus) {
+    fn push_word_reg(&mut self, reg: WordReg, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
         if self.operand_size_override {
             let dreg = DwordReg::from_index(reg as u8);
             let val = self.regs.dword(dreg);
-            self.push_dword(bus, val);
+            self.push_dword(bus, val)?;
         } else {
             let val = self.regs.word(reg);
-            self.push(bus, val);
+            self.push(bus, val)?;
         }
         self.clk(Self::timing(2, 1) + penalty);
+        Ok(())
     }
 
-    pub(super) fn push_sp(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn push_sp(&mut self, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
         if self.operand_size_override {
             let esp = self.regs.dword(DwordReg::ESP);
-            self.push_dword(bus, esp);
+            self.push_dword(bus, esp)?;
         } else {
             let sp = self.regs.word(WordReg::SP);
-            self.push(bus, sp);
+            self.push(bus, sp)?;
         }
         self.clk(Self::timing(2, 1) + penalty);
+        Ok(())
     }
 
-    fn pop_word_reg(&mut self, reg: WordReg, bus: &mut impl common::Bus) {
+    fn pop_word_reg(&mut self, reg: WordReg, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
         if self.operand_size_override {
             let dreg = DwordReg::from_index(reg as u8);
-            let Some(val) = self.pop_dword(bus) else {
-                return;
-            };
+            let val = self.pop_dword(bus)?;
             self.regs.set_dword(dreg, val);
         } else {
-            let Some(val) = self.pop(bus) else {
-                return;
-            };
+            let val = self.pop(bus)?;
             self.regs.set_word(reg, val);
         }
         self.clk(Self::timing(4, 4) + penalty);
+        Ok(())
     }
 
-    pub(super) fn push_seg(&mut self, seg: SegReg32, bus: &mut impl common::Bus) {
+    pub(super) fn push_seg(&mut self, seg: SegReg32, bus: &mut impl common::Bus) -> Step {
         let val = self.sregs[seg as usize];
         let penalty = self.sp_penalty();
         if self.operand_size_override {
@@ -1238,27 +1108,22 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             let base = self.seg_base(SegReg32::SS);
             let l0 = base.wrapping_add(sp_new);
             if l0 & 0xFFF <= 0xFFE {
-                let Some(a0) = self.translate_linear(l0, true, bus) else {
-                    return;
-                };
+                let a0 = self.translate_linear(l0, true, bus)?;
                 bus.write_word(a0, val);
             } else {
-                let Some(a0) = self.translate_linear(l0, true, bus) else {
-                    return;
-                };
-                let Some(a1) = self.translate_linear(l0.wrapping_add(1), true, bus) else {
-                    return;
-                };
+                let a0 = self.translate_linear(l0, true, bus)?;
+                let a1 = self.translate_linear(l0.wrapping_add(1), true, bus)?;
                 bus.write_byte(a0, val as u8);
                 bus.write_byte(a1, (val >> 8) as u8);
             }
         } else {
-            self.push(bus, val);
+            self.push(bus, val)?;
         }
         self.clk(Self::timing(2, 3) + penalty);
+        Ok(())
     }
 
-    pub(super) fn pop_seg(&mut self, seg: SegReg32, bus: &mut impl common::Bus) {
+    pub(super) fn pop_seg(&mut self, seg: SegReg32, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
         let slot_size = if self.operand_size_override { 4 } else { 2 };
         let was_use_esp = self.use_esp();
@@ -1267,29 +1132,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             self.regs.word(WordReg::SP) as u32
         };
-        if !self.check_segment_access(SegReg32::SS, sp, slot_size, false, bus) {
-            return;
-        }
+        self.check_segment_access(SegReg32::SS, sp, slot_size, false, bus)?;
 
         let base = self.seg_base(SegReg32::SS);
         let l0 = base.wrapping_add(sp);
         let val = if l0 & 0xFFF <= 0xFFE {
-            let Some(a0) = self.translate_linear(l0, false, bus) else {
-                return;
-            };
+            let a0 = self.translate_linear(l0, false, bus)?;
             bus.read_word(a0)
         } else {
-            let Some(a0) = self.translate_linear(l0, false, bus) else {
-                return;
-            };
-            let Some(a1) = self.translate_linear(l0.wrapping_add(1), false, bus) else {
-                return;
-            };
+            let a0 = self.translate_linear(l0, false, bus)?;
+            let a1 = self.translate_linear(l0.wrapping_add(1), false, bus)?;
             bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8)
         };
-        if !self.load_segment(seg, val, bus) {
-            return;
-        }
+        self.load_segment(seg, val, bus)?;
         let new_sp = sp.wrapping_add(slot_size);
         if was_use_esp {
             self.regs.set_dword(DwordReg::ESP, new_sp);
@@ -1297,42 +1152,44 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.regs.set_word(WordReg::SP, new_sp as u16);
         }
         self.clk(Self::timing(7, 3) + penalty);
+        Ok(())
     }
 
-    fn pusha(&mut self, bus: &mut impl common::Bus) {
+    fn pusha(&mut self, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
         if self.operand_size_override {
             let esp = self.regs.dword(DwordReg::ESP);
-            self.push_dword(bus, self.regs.dword(DwordReg::EAX));
-            self.push_dword(bus, self.regs.dword(DwordReg::ECX));
-            self.push_dword(bus, self.regs.dword(DwordReg::EDX));
-            self.push_dword(bus, self.regs.dword(DwordReg::EBX));
-            self.push_dword(bus, esp);
-            self.push_dword(bus, self.regs.dword(DwordReg::EBP));
-            self.push_dword(bus, self.regs.dword(DwordReg::ESI));
-            self.push_dword(bus, self.regs.dword(DwordReg::EDI));
+            self.push_dword(bus, self.regs.dword(DwordReg::EAX))?;
+            self.push_dword(bus, self.regs.dword(DwordReg::ECX))?;
+            self.push_dword(bus, self.regs.dword(DwordReg::EDX))?;
+            self.push_dword(bus, self.regs.dword(DwordReg::EBX))?;
+            self.push_dword(bus, esp)?;
+            self.push_dword(bus, self.regs.dword(DwordReg::EBP))?;
+            self.push_dword(bus, self.regs.dword(DwordReg::ESI))?;
+            self.push_dword(bus, self.regs.dword(DwordReg::EDI))?;
         } else {
             let sp = self.regs.word(WordReg::SP);
             let aw = self.regs.word(WordReg::AX);
-            self.push(bus, aw);
+            self.push(bus, aw)?;
             let cw = self.regs.word(WordReg::CX);
-            self.push(bus, cw);
+            self.push(bus, cw)?;
             let dw = self.regs.word(WordReg::DX);
-            self.push(bus, dw);
+            self.push(bus, dw)?;
             let bw = self.regs.word(WordReg::BX);
-            self.push(bus, bw);
-            self.push(bus, sp);
+            self.push(bus, bw)?;
+            self.push(bus, sp)?;
             let bp = self.regs.word(WordReg::BP);
-            self.push(bus, bp);
+            self.push(bus, bp)?;
             let ix = self.regs.word(WordReg::SI);
-            self.push(bus, ix);
+            self.push(bus, ix)?;
             let iy = self.regs.word(WordReg::DI);
-            self.push(bus, iy);
+            self.push(bus, iy)?;
         }
         self.clk(Self::timing(18, 11) + penalty);
+        Ok(())
     }
 
-    fn popa(&mut self, bus: &mut impl common::Bus) {
+    fn popa(&mut self, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
         if self.operand_size_override {
             // Probe the entire stack window before any commit: snapshot
@@ -1343,36 +1200,61 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             } else {
                 self.regs.word(WordReg::SP) as u32
             };
-            let Some(edi) = self.pop_dword(bus) else {
-                return;
+            let edi = match self.pop_dword(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(esi) = self.pop_dword(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let esi = match self.pop_dword(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(ebp) = self.pop_dword(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let ebp = match self.pop_dword(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(popped_esp) = self.pop_dword(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let popped_esp = match self.pop_dword(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(ebx) = self.pop_dword(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let ebx = match self.pop_dword(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(edx) = self.pop_dword(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let edx = match self.pop_dword(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(ecx) = self.pop_dword(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let ecx = match self.pop_dword(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(eax) = self.pop_dword(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let eax = match self.pop_dword(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
             self.regs.set_dword(DwordReg::EDI, edi);
             self.regs.set_dword(DwordReg::ESI, esi);
@@ -1397,36 +1279,61 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             } else {
                 self.regs.word(WordReg::SP) as u32
             };
-            let Some(iy) = self.pop(bus) else {
-                return;
+            let iy = match self.pop(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(ix) = self.pop(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let ix = match self.pop(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(bp) = self.pop(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let bp = match self.pop(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(_discard) = self.pop(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let _discard = match self.pop(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(bw) = self.pop(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let bw = match self.pop(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(dw) = self.pop(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let dw = match self.pop(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(cw) = self.pop(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let cw = match self.pop(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
-            let Some(aw) = self.pop(bus) else {
-                self.commit_sp(saved_sp);
-                return;
+            let aw = match self.pop(bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.commit_sp(saved_sp);
+                    return Err(e);
+                }
             };
             self.regs.set_word(WordReg::DI, iy);
             self.regs.set_word(WordReg::SI, ix);
@@ -1437,28 +1344,25 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.regs.set_word(WordReg::AX, aw);
         }
         self.clk(Self::timing(24, 9) + penalty);
+        Ok(())
     }
 
-    fn bound(&mut self, bus: &mut impl common::Bus) {
+    fn bound(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if modrm >= 0xC0 {
-            return;
+            return Ok(());
         }
         self.calc_ea(modrm, bus);
         if self.operand_size_override {
             let val = self.regs.dword(self.reg_dword(modrm)) as i32;
             let ea_pen = if self.ea & 3 != 0 { 8 } else { 0 };
-            let Some(low) = self.seg_read_dword(bus) else {
-                return;
-            };
-            let Some(high) = self.seg_read_dword_at(bus, 4) else {
-                return;
-            };
+            let low = self.seg_read_dword(bus)?;
+            let high = self.seg_read_dword_at(bus, 4)?;
             let low = low as i32;
             let high = high as i32;
             if val < low || val > high {
                 let sp_pen = self.sp_penalty();
-                self.raise_interrupt(5, bus);
+                self.raise_interrupt(5, bus)?;
                 self.clk(Self::timing(56, 7) + ea_pen + sp_pen);
             } else {
                 self.clk(Self::timing(10, 7) + ea_pen);
@@ -1466,76 +1370,72 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             let val = self.regs.word(self.reg_word(modrm)) as i16;
             let ea_pen = if self.ea & 1 == 1 { 8 } else { 0 };
-            let Some(low) = self.seg_read_word(bus) else {
-                return;
-            };
-            let Some(high) = self.seg_read_word_at(bus, 2) else {
-                return;
-            };
+            let low = self.seg_read_word(bus)?;
+            let high = self.seg_read_word_at(bus, 2)?;
             let low = low as i16;
             let high = high as i16;
             if val < low || val > high {
                 let sp_pen = self.sp_penalty();
-                self.raise_interrupt(5, bus);
+                self.raise_interrupt(5, bus)?;
                 self.clk(Self::timing(56, 7) + ea_pen + sp_pen);
             } else {
                 self.clk(Self::timing(10, 7) + ea_pen);
             }
         }
+        Ok(())
     }
 
-    fn arpl(&mut self, bus: &mut impl common::Bus) {
+    fn arpl(&mut self, bus: &mut impl common::Bus) -> Step {
         if !self.is_protected_mode() || self.is_virtual_mode() {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
 
         let modrm = self.fetch(bus);
-        let Some(dst) = self.get_rm_word(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_word(modrm, bus)?;
         let src_rpl = self.regs.word(self.reg_word(modrm)) & 3;
         let dst_rpl = dst & 3;
         if dst_rpl < src_rpl {
             let result = (dst & !3) | src_rpl;
-            self.putback_rm_word(modrm, result, bus);
+            self.putback_rm_word(modrm, result, bus)?;
             self.flags.zero_val = 0; // ZF=1
         } else {
             self.flags.zero_val = 1; // ZF=0
         }
         self.clk_modrm(modrm, Self::timing(10, 9), Self::timing(11, 9));
+        Ok(())
     }
 
-    fn push_imm16(&mut self, bus: &mut impl common::Bus) {
+    fn push_imm16(&mut self, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
         if self.operand_size_override {
             let val = self.fetchdword(bus);
-            self.push_dword(bus, val);
+            self.push_dword(bus, val)?;
         } else {
             let val = self.fetchword(bus);
-            self.push(bus, val);
+            self.push(bus, val)?;
         }
         self.clk(Self::timing(2, 1) + penalty);
+        Ok(())
     }
 
-    fn push_imm8(&mut self, bus: &mut impl common::Bus) {
+    fn push_imm8(&mut self, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
         if self.operand_size_override {
             let val = self.fetch(bus) as i8 as i32 as u32;
-            self.push_dword(bus, val);
+            self.push_dword(bus, val)?;
         } else {
             let val = self.fetch(bus) as i8 as u16;
-            self.push(bus, val);
+            self.push(bus, val)?;
         }
         self.clk(Self::timing(2, 1) + penalty);
+        Ok(())
     }
 
-    fn imul_r16w_imm16(&mut self, bus: &mut impl common::Bus) {
+    fn imul_r16w_imm16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
-            let Some(src) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_dword(modrm, bus)?;
             let src = src as i32 as i64;
             let imm = self.fetchdword(bus) as i32 as i64;
             let result = src * imm;
@@ -1547,9 +1447,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 0
             };
         } else {
-            let Some(src) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_word(modrm, bus)?;
             let src = src as i16 as i32;
             let imm = self.fetchword(bus) as i16 as i32;
             let result = src * imm;
@@ -1567,14 +1465,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             self.clk_modrm_word(modrm, Self::timing(22, 13), Self::timing(25, 13), 1);
         }
+        Ok(())
     }
 
-    fn imul_r16w_imm8(&mut self, bus: &mut impl common::Bus) {
+    fn imul_r16w_imm8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
-            let Some(src) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_dword(modrm, bus)?;
             let src = src as i32 as i64;
             let imm = self.fetch(bus) as i8 as i64;
             let result = src * imm;
@@ -1586,9 +1483,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 0
             };
         } else {
-            let Some(src) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_word(modrm, bus)?;
             let src = src as i16 as i32;
             let imm = self.fetch(bus) as i8 as i32;
             let result = src * imm;
@@ -1606,6 +1501,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             self.clk_modrm_word(modrm, Self::timing(14, 13), Self::timing(17, 13), 1);
         }
+        Ok(())
     }
 
     fn jcc(&mut self, bus: &mut impl common::Bus, condition: bool) {
@@ -1646,33 +1542,29 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
     }
 
-    fn test_br8(&mut self, bus: &mut impl common::Bus) {
+    fn test_br8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let Some(dst) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte(modrm, bus)?;
         self.alu_and_byte(dst, src);
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(5, 2));
+        Ok(())
     }
 
-    fn test_wr16(&mut self, bus: &mut impl common::Bus) {
+    fn test_wr16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword(modrm, bus)?;
             self.alu_and_dword(dst, src);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(5, 2), 2);
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let Some(dst) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word(modrm, bus)?;
             self.alu_and_word(dst, src);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(5, 2), 1);
         }
+        Ok(())
     }
 
     fn test_al_imm8(&mut self, bus: &mut impl common::Bus) {
@@ -1695,48 +1587,35 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 1));
     }
 
-    fn xchg_br8(&mut self, bus: &mut impl common::Bus) {
+    fn xchg_br8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let reg = self.reg_byte(modrm);
         let reg_val = self.regs.byte(reg);
-        let Some(rm_val) = self.get_rm_byte_for_update(modrm, bus) else {
-            return;
-        };
+        let rm_val = self.get_rm_byte_for_update(modrm, bus)?;
         self.regs.set_byte(reg, rm_val);
-        self.putback_rm_byte(modrm, reg_val, bus);
-        if self.fault_pending {
-            return;
-        }
+        self.putback_rm_byte(modrm, reg_val, bus)?;
         self.clk_modrm(modrm, Self::timing(3, 3), Self::timing(5, 5));
+        Ok(())
     }
 
-    fn xchg_wr16(&mut self, bus: &mut impl common::Bus) {
+    fn xchg_wr16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let reg = self.reg_dword(modrm);
             let reg_val = self.regs.dword(reg);
-            let Some(rm_val) = self.get_rm_dword_for_update(modrm, bus) else {
-                return;
-            };
+            let rm_val = self.get_rm_dword_for_update(modrm, bus)?;
             self.regs.set_dword(reg, rm_val);
-            self.putback_rm_dword(modrm, reg_val, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_dword(modrm, reg_val, bus)?;
             self.clk_modrm_word(modrm, Self::timing(3, 3), Self::timing(5, 5), 4);
         } else {
             let reg = self.reg_word(modrm);
             let reg_val = self.regs.word(reg);
-            let Some(rm_val) = self.get_rm_word_for_update(modrm, bus) else {
-                return;
-            };
+            let rm_val = self.get_rm_word_for_update(modrm, bus)?;
             self.regs.set_word(reg, rm_val);
-            self.putback_rm_word(modrm, reg_val, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_word(modrm, reg_val, bus)?;
             self.clk_modrm_word(modrm, Self::timing(3, 3), Self::timing(5, 5), 2);
         }
+        Ok(())
     }
 
     fn xchg_aw(&mut self, reg: WordReg) {
@@ -1755,61 +1634,58 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(3, 3));
     }
 
-    fn mov_br8(&mut self, bus: &mut impl common::Bus) {
+    fn mov_br8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let val = self.regs.byte(self.reg_byte(modrm));
-        self.put_rm_byte(modrm, val, bus);
+        self.put_rm_byte(modrm, val, bus)?;
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(2, 1));
+        Ok(())
     }
 
-    fn mov_wr16(&mut self, bus: &mut impl common::Bus) {
+    fn mov_wr16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let val = self.regs.dword(self.reg_dword(modrm));
-            self.put_rm_dword(modrm, val, bus);
+            self.put_rm_dword(modrm, val, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(2, 1), 2);
         } else {
             let val = self.regs.word(self.reg_word(modrm));
-            self.put_rm_word(modrm, val, bus);
+            self.put_rm_word(modrm, val, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(2, 1), 1);
         }
+        Ok(())
     }
 
-    fn mov_r8b(&mut self, bus: &mut impl common::Bus) {
+    fn mov_r8b(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
-        let Some(val) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let val = self.get_rm_byte(modrm, bus)?;
         let reg = self.reg_byte(modrm);
         self.regs.set_byte(reg, val);
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(4, 1));
+        Ok(())
     }
 
-    fn mov_r16w(&mut self, bus: &mut impl common::Bus) {
+    fn mov_r16w(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
-            let Some(val) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let val = self.get_rm_dword(modrm, bus)?;
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, val);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(4, 1), 2);
         } else {
-            let Some(val) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let val = self.get_rm_word(modrm, bus)?;
             let reg = self.reg_word(modrm);
             self.regs.set_word(reg, val);
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(4, 1), 1);
         }
+        Ok(())
     }
 
-    fn mov_rm_sreg(&mut self, bus: &mut impl common::Bus) {
+    fn mov_rm_sreg(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let seg_index = (modrm >> 3) & 7;
         if seg_index > 5 {
-            self.raise_fault(6, bus);
-            return;
+            return self.raise_fault(6, bus)?;
         }
         let seg = SegReg32::from_index(seg_index);
         let val = self.sregs[seg as usize];
@@ -1818,44 +1694,39 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.regs.set_dword(reg, val as u32);
             self.clk_modrm_word(modrm, Self::timing(2, 3), Self::timing(2, 3), 2);
         } else {
-            self.put_rm_word(modrm, val, bus);
+            self.put_rm_word(modrm, val, bus)?;
             self.clk_modrm_word(modrm, Self::timing(2, 3), Self::timing(2, 3), 1);
         }
+        Ok(())
     }
 
-    fn mov_sreg_rm(&mut self, bus: &mut impl common::Bus) {
+    fn mov_sreg_rm(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let seg_index = (modrm >> 3) & 7;
         if seg_index > 5 || seg_index == 1 {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
         let val = if self.operand_size_override && modrm >= 0xC0 {
-            let Some(v) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let v = self.get_rm_dword(modrm, bus)?;
             v as u16
         } else {
-            let Some(v) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
-            v
+            self.get_rm_word(modrm, bus)?
         };
         let seg = SegReg32::from_index(seg_index);
-        if !self.load_segment(seg, val, bus) {
-            return;
-        }
+        self.load_segment(seg, val, bus)?;
         if seg == SegReg32::SS {
             self.inhibit_all = 1;
         }
         self.clk_modrm_word(modrm, Self::timing(2, 3), Self::timing(5, 9), 1);
+        Ok(())
     }
 
-    fn lea(&mut self, bus: &mut impl common::Bus) {
+    fn lea(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if modrm >= 0xC0 {
-            self.invalid(bus);
-            return;
+            self.invalid(bus)?;
+            return Ok(());
         }
         self.calc_ea(modrm, bus);
         if self.operand_size_override {
@@ -1868,21 +1739,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.regs.set_word(reg, val);
         }
         self.clk(Self::timing(2, 1));
+        Ok(())
     }
 
-    fn pop_rm(&mut self, bus: &mut impl common::Bus) {
+    fn pop_rm(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let sp_pen = self.sp_penalty();
         if self.operand_size_override {
-            let Some(val) = self.pop_dword(bus) else {
-                return;
-            };
-            self.put_rm_dword(modrm, val, bus);
+            let val = self.pop_dword(bus)?;
+            self.put_rm_dword(modrm, val, bus)?;
         } else {
-            let Some(val) = self.pop(bus) else {
-                return;
-            };
-            self.put_rm_word(modrm, val, bus);
+            let val = self.pop(bus)?;
+            self.put_rm_word(modrm, val, bus)?;
         }
         if modrm >= 0xC0 {
             self.clk(Self::timing(4, 4) + sp_pen);
@@ -1900,6 +1768,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             };
             self.clk(Self::timing(5, 5) + sp_pen + ea_pen);
         }
+        Ok(())
     }
 
     fn cbw(&mut self) {
@@ -1926,7 +1795,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 3));
     }
 
-    fn call_far(&mut self, bus: &mut impl common::Bus) {
+    fn call_far(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.operand_size_override {
             let penalty = self.sp_penalty();
             let offset = self.fetchdword(bus);
@@ -1934,13 +1803,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             let cs = self.sregs[SegReg32::CS as usize];
             let eip = self.ip_upper | self.ip as u32;
             if self.is_protected_mode() && !self.is_virtual_mode() {
-                self.code_descriptor(segment, offset, super::TaskType::Call, cs, eip, bus);
+                self.code_descriptor(segment, offset, super::TaskType::Call, cs, eip, bus)?;
             } else {
-                self.push_dword(bus, cs as u32);
-                self.push_dword(bus, eip);
-                if !self.load_segment(SegReg32::CS, segment, bus) {
-                    return;
-                }
+                self.push_dword(bus, cs as u32)?;
+                self.push_dword(bus, eip)?;
+                self.load_segment(SegReg32::CS, segment, bus)?;
                 self.ip = offset as u16;
                 self.ip_upper = offset & 0xFFFF_0000;
             }
@@ -1968,13 +1835,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     cs,
                     ip as u32,
                     bus,
-                );
+                )?;
             } else {
-                self.push(bus, cs);
-                self.push(bus, ip);
-                if !self.load_segment(SegReg32::CS, segment, bus) {
-                    return;
-                }
+                self.push(bus, cs)?;
+                self.push(bus, ip)?;
+                self.load_segment(SegReg32::CS, segment, bus)?;
                 self.ip = offset;
                 self.ip_upper = 0;
             }
@@ -1989,14 +1854,15 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
             }
         }
+        Ok(())
     }
 
-    fn call_near(&mut self, bus: &mut impl common::Bus) {
+    fn call_near(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.operand_size_override {
             let penalty = self.sp_penalty();
             let disp = self.fetchdword(bus) as i32;
             let return_eip = self.ip_upper | self.ip as u32;
-            self.push_dword(bus, return_eip);
+            self.push_dword(bus, return_eip)?;
             let target = return_eip.wrapping_add(disp as u32);
             self.ip = target as u16;
             self.ip_upper = target & 0xFFFF_0000;
@@ -2013,7 +1879,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             let penalty = self.sp_penalty();
             let disp = self.fetchword(bus) as i16;
-            self.push(bus, self.ip);
+            self.push(bus, self.ip)?;
             self.ip = self.ip.wrapping_add(disp as u16);
             self.ip_upper = 0;
             match CPU_MODEL {
@@ -2027,6 +1893,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
             }
         }
+        Ok(())
     }
 
     fn jmp_near(&mut self, bus: &mut impl common::Bus) {
@@ -2063,16 +1930,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
     }
 
-    fn jmp_far(&mut self, bus: &mut impl common::Bus) {
+    fn jmp_far(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.operand_size_override {
             let offset = self.fetchdword(bus);
             let segment = self.fetchword(bus);
             if self.is_protected_mode() && !self.is_virtual_mode() {
-                self.code_descriptor(segment, offset, super::TaskType::Jmp, 0, 0, bus);
+                self.code_descriptor(segment, offset, super::TaskType::Jmp, 0, 0, bus)?;
             } else {
-                if !self.load_segment(SegReg32::CS, segment, bus) {
-                    return;
-                }
+                self.load_segment(SegReg32::CS, segment, bus)?;
                 self.ip = offset as u16;
                 self.ip_upper = offset & 0xFFFF_0000;
             }
@@ -2090,11 +1955,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             let offset = self.fetchword(bus);
             let segment = self.fetchword(bus);
             if self.is_protected_mode() && !self.is_virtual_mode() {
-                self.code_descriptor(segment, offset as u32, super::TaskType::Jmp, 0, 0, bus);
+                self.code_descriptor(segment, offset as u32, super::TaskType::Jmp, 0, 0, bus)?;
             } else {
-                if !self.load_segment(SegReg32::CS, segment, bus) {
-                    return;
-                }
+                self.load_segment(SegReg32::CS, segment, bus)?;
                 self.ip = offset;
                 self.ip_upper = 0;
             }
@@ -2109,6 +1972,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
             }
         }
+        Ok(())
     }
 
     fn jmp_short(&mut self, bus: &mut impl common::Bus) {
@@ -2126,18 +1990,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
     }
 
-    fn ret_near(&mut self, bus: &mut impl common::Bus) {
+    fn ret_near(&mut self, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
         if self.operand_size_override {
-            let Some(eip) = self.pop_dword(bus) else {
-                return;
-            };
+            let eip = self.pop_dword(bus)?;
             self.ip = eip as u16;
             self.ip_upper = eip & 0xFFFF_0000;
         } else {
-            let Some(ip) = self.pop(bus) else {
-                return;
-            };
+            let ip = self.pop(bus)?;
             self.ip = ip;
             self.ip_upper = 0;
         }
@@ -2151,21 +2011,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 unreachable!("Unhandled CPU_MODEL")
             }
         }
+        Ok(())
     }
 
-    fn ret_near_imm(&mut self, bus: &mut impl common::Bus) {
+    fn ret_near_imm(&mut self, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
         let imm = self.fetchword(bus);
         if self.operand_size_override {
-            let Some(eip) = self.pop_dword(bus) else {
-                return;
-            };
+            let eip = self.pop_dword(bus)?;
             self.ip = eip as u16;
             self.ip_upper = eip & 0xFFFF_0000;
         } else {
-            let Some(ip) = self.pop(bus) else {
-                return;
-            };
+            let ip = self.pop(bus)?;
             self.ip = ip;
             self.ip_upper = 0;
         }
@@ -2186,35 +2043,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 unreachable!("Unhandled CPU_MODEL")
             }
         }
+        Ok(())
     }
 
-    fn ret_far(&mut self, bus: &mut impl common::Bus) {
+    fn ret_far(&mut self, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
 
         if !self.is_protected_mode() || self.is_virtual_mode() {
             if self.operand_size_override {
-                let Some(eip) = self.pop_dword(bus) else {
-                    return;
-                };
-                let Some(cs_dword) = self.pop_dword(bus) else {
-                    return;
-                };
+                let eip = self.pop_dword(bus)?;
+                let cs_dword = self.pop_dword(bus)?;
                 let cs = cs_dword as u16;
-                if !self.load_segment(SegReg32::CS, cs, bus) {
-                    return;
-                }
+                self.load_segment(SegReg32::CS, cs, bus)?;
                 self.ip = eip as u16;
                 self.ip_upper = eip & 0xFFFF_0000;
             } else {
-                let Some(ip) = self.pop(bus) else {
-                    return;
-                };
-                let Some(cs) = self.pop(bus) else {
-                    return;
-                };
-                if !self.load_segment(SegReg32::CS, cs, bus) {
-                    return;
-                }
+                let ip = self.pop(bus)?;
+                let cs = self.pop(bus)?;
+                self.load_segment(SegReg32::CS, cs, bus)?;
                 self.ip = ip;
                 self.ip_upper = 0;
             }
@@ -2228,7 +2074,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     unreachable!("Unhandled CPU_MODEL")
                 }
             }
-            return;
+            return Ok(());
         }
 
         // Protected mode far return.
@@ -2240,49 +2086,38 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let ss_base = self.seg_base(SegReg32::SS);
 
         if self.operand_size_override {
-            let Some(new_eip) = self.read_dword_linear(bus, ss_base.wrapping_add(sp)) else {
-                return;
-            };
-            let Some(new_cs_dword) =
-                self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(4)))
-            else {
-                return;
-            };
+            let new_eip = self.read_dword_linear(bus, ss_base.wrapping_add(sp))?;
+            let new_cs_dword =
+                self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(4)))?;
             let new_cs = new_cs_dword as u16;
 
             let new_rpl = new_cs & 3;
             let old_cpl = self.cpl();
 
             if new_rpl > old_cpl {
-                let Some(new_esp) =
-                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(8)))
-                else {
-                    return;
-                };
-                let Some(new_ss_dword) =
-                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(12)))
-                else {
-                    return;
-                };
+                let new_esp =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(8)))?;
+                let new_ss_dword =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(12)))?;
                 let new_ss = new_ss_dword as u16;
 
                 if let Some((vector, error_code)) =
-                    self.precheck_ss_for_inter_priv_iret(new_ss, new_rpl, bus)
+                    self.precheck_ss_for_inter_priv_iret(new_ss, new_rpl, bus)?
                 {
-                    self.raise_fault_with_code(vector, error_code, bus);
-                    return;
+                    self.raise_fault_with_code(vector, error_code, bus)?;
+                    return Ok(());
                 }
 
                 let saved_cs = self.save_cs_state();
-                if !self.load_cs_for_return(new_cs, new_eip, bus) {
-                    return;
+                if self.load_cs_for_return(new_cs, new_eip, bus).is_err() {
+                    return Err(Fault);
                 }
                 self.ip = new_eip as u16;
                 self.ip_upper = new_eip & 0xFFFF_0000;
 
-                if !self.load_segment(SegReg32::SS, new_ss, bus) {
+                if self.load_segment(SegReg32::SS, new_ss, bus).is_err() {
                     self.restore_cs_state(&saved_cs);
-                    return;
+                    return Err(Fault);
                 }
                 if self.use_esp() {
                     self.regs.set_dword(DwordReg::ESP, new_esp);
@@ -2291,13 +2126,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
 
                 let new_cpl = self.cpl();
-                self.revalidate_data_segment(SegReg32::DS, new_cpl, bus);
-                self.revalidate_data_segment(SegReg32::ES, new_cpl, bus);
-                self.revalidate_data_segment(SegReg32::FS, new_cpl, bus);
-                self.revalidate_data_segment(SegReg32::GS, new_cpl, bus);
+                self.revalidate_data_segment(SegReg32::DS, new_cpl, bus)?;
+                self.revalidate_data_segment(SegReg32::ES, new_cpl, bus)?;
+                self.revalidate_data_segment(SegReg32::FS, new_cpl, bus)?;
+                self.revalidate_data_segment(SegReg32::GS, new_cpl, bus)?;
             } else {
-                if !self.load_cs_for_return(new_cs, new_eip, bus) {
-                    return;
+                if self.load_cs_for_return(new_cs, new_eip, bus).is_err() {
+                    return Err(Fault);
                 }
                 if self.use_esp() {
                     self.regs.set_dword(DwordReg::ESP, sp.wrapping_add(8));
@@ -2308,46 +2143,35 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.ip_upper = new_eip & 0xFFFF_0000;
             }
         } else {
-            let Some(new_ip) = self.read_word_linear(bus, ss_base.wrapping_add(sp)) else {
-                return;
-            };
-            let Some(new_cs) = self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(2)))
-            else {
-                return;
-            };
+            let new_ip = self.read_word_linear(bus, ss_base.wrapping_add(sp))?;
+            let new_cs = self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(2)))?;
 
             let new_rpl = new_cs & 3;
             let old_cpl = self.cpl();
 
             if new_rpl > old_cpl {
-                let Some(new_sp) =
-                    self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(4)))
-                else {
-                    return;
-                };
-                let Some(new_ss) =
-                    self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(6)))
-                else {
-                    return;
-                };
+                let new_sp =
+                    self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(4)))?;
+                let new_ss =
+                    self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(6)))?;
 
                 if let Some((vector, error_code)) =
-                    self.precheck_ss_for_inter_priv_iret(new_ss, new_rpl, bus)
+                    self.precheck_ss_for_inter_priv_iret(new_ss, new_rpl, bus)?
                 {
-                    self.raise_fault_with_code(vector, error_code, bus);
-                    return;
+                    self.raise_fault_with_code(vector, error_code, bus)?;
+                    return Ok(());
                 }
 
                 let saved_cs = self.save_cs_state();
-                if !self.load_cs_for_return(new_cs, new_ip as u32, bus) {
-                    return;
+                if self.load_cs_for_return(new_cs, new_ip as u32, bus).is_err() {
+                    return Err(Fault);
                 }
                 self.ip = new_ip;
                 self.ip_upper = 0;
 
-                if !self.load_segment(SegReg32::SS, new_ss, bus) {
+                if self.load_segment(SegReg32::SS, new_ss, bus).is_err() {
                     self.restore_cs_state(&saved_cs);
-                    return;
+                    return Err(Fault);
                 }
                 if self.use_esp() {
                     self.regs.set_dword(DwordReg::ESP, new_sp as u32);
@@ -2356,13 +2180,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
 
                 let new_cpl = self.cpl();
-                self.revalidate_data_segment(SegReg32::DS, new_cpl, bus);
-                self.revalidate_data_segment(SegReg32::ES, new_cpl, bus);
-                self.revalidate_data_segment(SegReg32::FS, new_cpl, bus);
-                self.revalidate_data_segment(SegReg32::GS, new_cpl, bus);
+                self.revalidate_data_segment(SegReg32::DS, new_cpl, bus)?;
+                self.revalidate_data_segment(SegReg32::ES, new_cpl, bus)?;
+                self.revalidate_data_segment(SegReg32::FS, new_cpl, bus)?;
+                self.revalidate_data_segment(SegReg32::GS, new_cpl, bus)?;
             } else {
-                if !self.load_cs_for_return(new_cs, new_ip as u32, bus) {
-                    return;
+                if self.load_cs_for_return(new_cs, new_ip as u32, bus).is_err() {
+                    return Err(Fault);
                 }
                 if self.use_esp() {
                     self.regs.set_dword(DwordReg::ESP, sp.wrapping_add(4));
@@ -2384,36 +2208,25 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 unreachable!("Unhandled CPU_MODEL")
             }
         }
+        Ok(())
     }
 
-    fn ret_far_imm(&mut self, bus: &mut impl common::Bus) {
+    fn ret_far_imm(&mut self, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
         let imm = self.fetchword(bus);
 
         if !self.is_protected_mode() || self.is_virtual_mode() {
             if self.operand_size_override {
-                let Some(eip) = self.pop_dword(bus) else {
-                    return;
-                };
-                let Some(cs_dword) = self.pop_dword(bus) else {
-                    return;
-                };
+                let eip = self.pop_dword(bus)?;
+                let cs_dword = self.pop_dword(bus)?;
                 let cs = cs_dword as u16;
-                if !self.load_segment(SegReg32::CS, cs, bus) {
-                    return;
-                }
+                self.load_segment(SegReg32::CS, cs, bus)?;
                 self.ip = eip as u16;
                 self.ip_upper = eip & 0xFFFF_0000;
             } else {
-                let Some(ip) = self.pop(bus) else {
-                    return;
-                };
-                let Some(cs) = self.pop(bus) else {
-                    return;
-                };
-                if !self.load_segment(SegReg32::CS, cs, bus) {
-                    return;
-                }
+                let ip = self.pop(bus)?;
+                let cs = self.pop(bus)?;
+                self.load_segment(SegReg32::CS, cs, bus)?;
                 self.ip = ip;
                 self.ip_upper = 0;
             }
@@ -2429,7 +2242,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     unreachable!("Unhandled CPU_MODEL")
                 }
             }
-            return;
+            return Ok(());
         }
 
         // Protected mode far return with immediate.
@@ -2442,14 +2255,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let imm32 = imm as u32;
 
         if self.operand_size_override {
-            let Some(new_eip) = self.read_dword_linear(bus, ss_base.wrapping_add(sp)) else {
-                return;
-            };
-            let Some(new_cs_dword) =
-                self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(4)))
-            else {
-                return;
-            };
+            let new_eip = self.read_dword_linear(bus, ss_base.wrapping_add(sp))?;
+            let new_cs_dword =
+                self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(4)))?;
             let new_cs = new_cs_dword as u16;
 
             let new_rpl = new_cs & 3;
@@ -2457,34 +2265,28 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
             if new_rpl > old_cpl {
                 let sp_ss_base = sp.wrapping_add(8).wrapping_add(imm32);
-                let Some(new_esp) = self.read_dword_linear(bus, ss_base.wrapping_add(sp_ss_base))
-                else {
-                    return;
-                };
-                let Some(new_ss_dword) =
-                    self.read_dword_linear(bus, ss_base.wrapping_add(sp_ss_base.wrapping_add(4)))
-                else {
-                    return;
-                };
+                let new_esp = self.read_dword_linear(bus, ss_base.wrapping_add(sp_ss_base))?;
+                let new_ss_dword =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(sp_ss_base.wrapping_add(4)))?;
                 let new_ss = new_ss_dword as u16;
 
                 if let Some((vector, error_code)) =
-                    self.precheck_ss_for_inter_priv_iret(new_ss, new_rpl, bus)
+                    self.precheck_ss_for_inter_priv_iret(new_ss, new_rpl, bus)?
                 {
-                    self.raise_fault_with_code(vector, error_code, bus);
-                    return;
+                    self.raise_fault_with_code(vector, error_code, bus)?;
+                    return Ok(());
                 }
 
                 let saved_cs = self.save_cs_state();
-                if !self.load_cs_for_return(new_cs, new_eip, bus) {
-                    return;
+                if self.load_cs_for_return(new_cs, new_eip, bus).is_err() {
+                    return Err(Fault);
                 }
                 self.ip = new_eip as u16;
                 self.ip_upper = new_eip & 0xFFFF_0000;
 
-                if !self.load_segment(SegReg32::SS, new_ss, bus) {
+                if self.load_segment(SegReg32::SS, new_ss, bus).is_err() {
                     self.restore_cs_state(&saved_cs);
-                    return;
+                    return Err(Fault);
                 }
                 let adj_esp = new_esp.wrapping_add(imm32);
                 if self.use_esp() {
@@ -2494,14 +2296,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
 
                 let new_cpl = self.cpl();
-                self.revalidate_data_segment(SegReg32::DS, new_cpl, bus);
-                self.revalidate_data_segment(SegReg32::ES, new_cpl, bus);
-                self.revalidate_data_segment(SegReg32::FS, new_cpl, bus);
-                self.revalidate_data_segment(SegReg32::GS, new_cpl, bus);
+                self.revalidate_data_segment(SegReg32::DS, new_cpl, bus)?;
+                self.revalidate_data_segment(SegReg32::ES, new_cpl, bus)?;
+                self.revalidate_data_segment(SegReg32::FS, new_cpl, bus)?;
+                self.revalidate_data_segment(SegReg32::GS, new_cpl, bus)?;
             } else {
                 let new_sp_val = sp.wrapping_add(8).wrapping_add(imm32);
-                if !self.load_cs_for_return(new_cs, new_eip, bus) {
-                    return;
+                if self.load_cs_for_return(new_cs, new_eip, bus).is_err() {
+                    return Err(Fault);
                 }
                 if self.use_esp() {
                     self.regs.set_dword(DwordReg::ESP, new_sp_val);
@@ -2512,46 +2314,35 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.ip_upper = new_eip & 0xFFFF_0000;
             }
         } else {
-            let Some(new_ip) = self.read_word_linear(bus, ss_base.wrapping_add(sp)) else {
-                return;
-            };
-            let Some(new_cs) = self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(2)))
-            else {
-                return;
-            };
+            let new_ip = self.read_word_linear(bus, ss_base.wrapping_add(sp))?;
+            let new_cs = self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(2)))?;
 
             let new_rpl = new_cs & 3;
             let old_cpl = self.cpl();
 
             if new_rpl > old_cpl {
                 let sp_ss_base = sp.wrapping_add(4).wrapping_add(imm32);
-                let Some(new_sp) = self.read_word_linear(bus, ss_base.wrapping_add(sp_ss_base))
-                else {
-                    return;
-                };
-                let Some(new_ss) =
-                    self.read_word_linear(bus, ss_base.wrapping_add(sp_ss_base.wrapping_add(2)))
-                else {
-                    return;
-                };
+                let new_sp = self.read_word_linear(bus, ss_base.wrapping_add(sp_ss_base))?;
+                let new_ss =
+                    self.read_word_linear(bus, ss_base.wrapping_add(sp_ss_base.wrapping_add(2)))?;
 
                 if let Some((vector, error_code)) =
-                    self.precheck_ss_for_inter_priv_iret(new_ss, new_rpl, bus)
+                    self.precheck_ss_for_inter_priv_iret(new_ss, new_rpl, bus)?
                 {
-                    self.raise_fault_with_code(vector, error_code, bus);
-                    return;
+                    self.raise_fault_with_code(vector, error_code, bus)?;
+                    return Ok(());
                 }
 
                 let saved_cs = self.save_cs_state();
-                if !self.load_cs_for_return(new_cs, new_ip as u32, bus) {
-                    return;
+                if self.load_cs_for_return(new_cs, new_ip as u32, bus).is_err() {
+                    return Err(Fault);
                 }
                 self.ip = new_ip;
                 self.ip_upper = 0;
 
-                if !self.load_segment(SegReg32::SS, new_ss, bus) {
+                if self.load_segment(SegReg32::SS, new_ss, bus).is_err() {
                     self.restore_cs_state(&saved_cs);
-                    return;
+                    return Err(Fault);
                 }
                 let adj_sp = new_sp.wrapping_add(imm);
                 if self.use_esp() {
@@ -2561,14 +2352,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
 
                 let new_cpl = self.cpl();
-                self.revalidate_data_segment(SegReg32::DS, new_cpl, bus);
-                self.revalidate_data_segment(SegReg32::ES, new_cpl, bus);
-                self.revalidate_data_segment(SegReg32::FS, new_cpl, bus);
-                self.revalidate_data_segment(SegReg32::GS, new_cpl, bus);
+                self.revalidate_data_segment(SegReg32::DS, new_cpl, bus)?;
+                self.revalidate_data_segment(SegReg32::ES, new_cpl, bus)?;
+                self.revalidate_data_segment(SegReg32::FS, new_cpl, bus)?;
+                self.revalidate_data_segment(SegReg32::GS, new_cpl, bus)?;
             } else {
                 let new_sp_val = sp.wrapping_add(4).wrapping_add(imm32);
-                if !self.load_cs_for_return(new_cs, new_ip as u32, bus) {
-                    return;
+                if self.load_cs_for_return(new_cs, new_ip as u32, bus).is_err() {
+                    return Err(Fault);
                 }
                 if self.use_esp() {
                     self.regs.set_dword(DwordReg::ESP, new_sp_val);
@@ -2590,12 +2381,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 unreachable!("Unhandled CPU_MODEL")
             }
         }
+        Ok(())
     }
 
-    fn pushf(&mut self, bus: &mut impl common::Bus) {
+    fn pushf(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.is_virtual_mode() && self.flags.iopl < 3 {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            self.raise_fault_with_code(13, 0, bus)?;
+            return Ok(());
         }
         let penalty = self.sp_penalty();
         if self.operand_size_override {
@@ -2607,10 +2399,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 0x0002_0000 // VM
             };
             let flags_val = (self.eflags_upper & upper_mask) | self.flags.compress() as u32;
-            self.push_dword(bus, flags_val);
+            self.push_dword(bus, flags_val)?;
         } else {
             let flags_val = self.flags.compress();
-            self.push(bus, flags_val);
+            self.push(bus, flags_val)?;
         }
         let base = match CPU_MODEL {
             CPU_MODEL_386 => 4,
@@ -2624,21 +2416,20 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             _ => unreachable!("Unhandled CPU_MODEL"),
         };
         self.clk(base + penalty);
+        Ok(())
     }
 
-    fn popf(&mut self, bus: &mut impl common::Bus) {
+    fn popf(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.is_virtual_mode() && self.flags.iopl < 3 {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            self.raise_fault_with_code(13, 0, bus)?;
+            return Ok(());
         }
         self.preserve_resume_flag = true;
         let penalty = self.sp_penalty();
         let cpl = self.cpl();
         let pm = self.is_protected_mode();
         if self.operand_size_override {
-            let Some(val) = self.pop_dword(bus) else {
-                return;
-            };
+            let val = self.pop_dword(bus)?;
             self.flags.load_flags(val as u16, cpl, pm);
             // VM (bit 17) is not modifiable via POPFD (only IRET at CPL=0).
             // RF (bit 16) is not modified by POPFD.
@@ -2647,9 +2438,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.eflags_upper = (self.eflags_upper & !0x0004_0000) | (val & 0x0004_0000);
             }
         } else {
-            let Some(val) = self.pop(bus) else {
-                return;
-            };
+            let val = self.pop(bus)?;
             self.flags.load_flags(val, cpl, pm);
         }
         let base = match CPU_MODEL {
@@ -2664,6 +2453,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             _ => unreachable!("Unhandled CPU_MODEL"),
         };
         self.clk(base + penalty);
+        Ok(())
     }
 
     fn sahf(&mut self) {
@@ -2682,21 +2472,20 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 3));
     }
 
-    fn mov_al_moffs(&mut self, bus: &mut impl common::Bus) {
+    fn mov_al_moffs(&mut self, bus: &mut impl common::Bus) -> Step {
         let seg = self.default_seg(SegReg32::DS);
         let offset = if self.address_size_override {
             self.fetchdword(bus)
         } else {
             self.fetchword(bus) as u32
         };
-        let Some(val) = self.read_byte_seg(bus, seg, offset) else {
-            return;
-        };
+        let val = self.read_byte_seg(bus, seg, offset)?;
         self.regs.set_byte(ByteReg::AL, val);
         self.clk(Self::timing(4, 1));
+        Ok(())
     }
 
-    fn mov_aw_moffs(&mut self, bus: &mut impl common::Bus) {
+    fn mov_aw_moffs(&mut self, bus: &mut impl common::Bus) -> Step {
         let seg = self.default_seg(SegReg32::DS);
         let offset = if self.address_size_override {
             self.fetchdword(bus)
@@ -2708,9 +2497,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.eo32 = offset;
         self.ea = self.seg_base(seg).wrapping_add(offset);
         if self.operand_size_override {
-            let Some(val) = self.seg_read_dword(bus) else {
-                return;
-            };
+            let val = self.seg_read_dword(bus)?;
             self.regs.set_dword(DwordReg::EAX, val);
             let penalty = if self.ea & 3 != 0 {
                 Self::timing(4, 3)
@@ -2719,9 +2506,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             };
             self.clk(Self::timing(4, 1) + penalty);
         } else {
-            let Some(val) = self.seg_read_word(bus) else {
-                return;
-            };
+            let val = self.seg_read_word(bus)?;
             self.regs.set_word(WordReg::AX, val);
             let penalty = if self.ea & 1 != 0 {
                 Self::timing(4, 3)
@@ -2730,9 +2515,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             };
             self.clk(Self::timing(4, 1) + penalty);
         }
+        Ok(())
     }
 
-    fn mov_moffs_al(&mut self, bus: &mut impl common::Bus) {
+    fn mov_moffs_al(&mut self, bus: &mut impl common::Bus) -> Step {
         let seg = self.default_seg(SegReg32::DS);
         let al = self.regs.byte(ByteReg::AL);
         let offset = if self.address_size_override {
@@ -2740,11 +2526,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             self.fetchword(bus) as u32
         };
-        self.write_byte_seg(bus, seg, offset, al);
+        self.write_byte_seg(bus, seg, offset, al)?;
         self.clk(Self::timing(2, 1));
+        Ok(())
     }
 
-    fn mov_moffs_aw(&mut self, bus: &mut impl common::Bus) {
+    fn mov_moffs_aw(&mut self, bus: &mut impl common::Bus) -> Step {
         let seg = self.default_seg(SegReg32::DS);
         let offset = if self.address_size_override {
             self.fetchdword(bus)
@@ -2756,7 +2543,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.eo32 = offset;
         self.ea = self.seg_base(seg).wrapping_add(offset);
         if self.operand_size_override {
-            self.seg_write_dword(bus, self.regs.dword(DwordReg::EAX));
+            self.seg_write_dword(bus, self.regs.dword(DwordReg::EAX))?;
             let penalty = if self.ea & 3 != 0 {
                 Self::timing(4, 3)
             } else {
@@ -2764,7 +2551,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             };
             self.clk(Self::timing(2, 1) + penalty);
         } else {
-            self.seg_write_word(bus, self.regs.word(WordReg::AX));
+            self.seg_write_word(bus, self.regs.word(WordReg::AX))?;
             let penalty = if self.ea & 1 != 0 {
                 Self::timing(4, 3)
             } else {
@@ -2772,6 +2559,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             };
             self.clk(Self::timing(2, 1) + penalty);
         }
+        Ok(())
     }
 
     fn mov_byte_reg_imm(&mut self, reg: ByteReg, bus: &mut impl common::Bus) {
@@ -2791,7 +2579,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 1));
     }
 
-    fn mov_rm_imm8(&mut self, bus: &mut impl common::Bus) {
+    fn mov_rm_imm8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if modrm >= 0xC0 {
             let val = self.fetch(bus);
@@ -2800,15 +2588,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             self.calc_ea(modrm, bus);
             let val = self.fetch(bus);
-            let Some(addr) = self.translate_linear(self.ea, true, bus) else {
-                return;
-            };
+            let addr = self.translate_linear(self.ea, true, bus)?;
             bus.write_byte(addr, val);
         }
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(2, 1));
+        Ok(())
     }
 
-    fn mov_rm_imm16(&mut self, bus: &mut impl common::Bus) {
+    fn mov_rm_imm16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             if modrm >= 0xC0 {
@@ -2818,7 +2605,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             } else {
                 self.calc_ea(modrm, bus);
                 let val = self.fetchdword(bus);
-                self.seg_write_dword(bus, val);
+                self.seg_write_dword(bus, val)?;
             }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(2, 1), 2);
         } else {
@@ -2829,17 +2616,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             } else {
                 self.calc_ea(modrm, bus);
                 let val = self.fetchword(bus);
-                self.seg_write_word(bus, val);
+                self.seg_write_word(bus, val)?;
             }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(2, 1), 1);
         }
+        Ok(())
     }
 
-    fn les(&mut self, bus: &mut impl common::Bus) {
+    fn les(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if modrm >= 0xC0 {
-            self.invalid(bus);
-            return;
+            self.invalid(bus)?;
+            return Ok(());
         }
         self.calc_ea(modrm, bus);
         // Snapshot CS:EIP so a fault inside the pointer fetch aborts the
@@ -2851,98 +2639,76 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let initial_ip = self.ip;
         let initial_ip_upper = self.ip_upper;
         if self.operand_size_override {
-            let Some(offset) = self.seg_read_dword(bus) else {
-                return;
-            };
-            let Some(segment) = self.seg_read_word_at(bus, 4) else {
-                return;
-            };
+            let offset = self.seg_read_dword(bus)?;
+            let segment = self.seg_read_word_at(bus, 4)?;
             if self.sregs[SegReg32::CS as usize] != initial_cs
                 || self.ip != initial_ip
                 || self.ip_upper != initial_ip_upper
             {
-                return;
+                return Ok(());
             }
-            if !self.load_segment(SegReg32::ES, segment, bus) {
-                return;
-            }
+            self.load_segment(SegReg32::ES, segment, bus)?;
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, offset);
             self.clk(Self::timing(7, 6));
-            return;
+            return Ok(());
         }
-        let Some(offset) = self.seg_read_word(bus) else {
-            return;
-        };
-        let Some(segment) = self.seg_read_word_at(bus, 2) else {
-            return;
-        };
+        let offset = self.seg_read_word(bus)?;
+        let segment = self.seg_read_word_at(bus, 2)?;
         if self.sregs[SegReg32::CS as usize] != initial_cs
             || self.ip != initial_ip
             || self.ip_upper != initial_ip_upper
         {
-            return;
+            return Ok(());
         }
-        if !self.load_segment(SegReg32::ES, segment, bus) {
-            return;
-        }
+        self.load_segment(SegReg32::ES, segment, bus)?;
         let reg = self.reg_word(modrm);
         self.regs.set_word(reg, offset);
         self.clk(Self::timing(7, 6));
+        Ok(())
     }
 
-    fn lds(&mut self, bus: &mut impl common::Bus) {
+    fn lds(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if modrm >= 0xC0 {
-            self.invalid(bus);
-            return;
+            self.invalid(bus)?;
+            return Ok(());
         }
         self.calc_ea(modrm, bus);
         let initial_cs = self.sregs[SegReg32::CS as usize];
         let initial_ip = self.ip;
         let initial_ip_upper = self.ip_upper;
         if self.operand_size_override {
-            let Some(offset) = self.seg_read_dword(bus) else {
-                return;
-            };
-            let Some(segment) = self.seg_read_word_at(bus, 4) else {
-                return;
-            };
+            let offset = self.seg_read_dword(bus)?;
+            let segment = self.seg_read_word_at(bus, 4)?;
             if self.sregs[SegReg32::CS as usize] != initial_cs
                 || self.ip != initial_ip
                 || self.ip_upper != initial_ip_upper
             {
-                return;
+                return Ok(());
             }
-            if !self.load_segment(SegReg32::DS, segment, bus) {
-                return;
-            }
+            self.load_segment(SegReg32::DS, segment, bus)?;
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, offset);
             self.clk(Self::timing(7, 6));
-            return;
+            return Ok(());
         }
-        let Some(offset) = self.seg_read_word(bus) else {
-            return;
-        };
-        let Some(segment) = self.seg_read_word_at(bus, 2) else {
-            return;
-        };
+        let offset = self.seg_read_word(bus)?;
+        let segment = self.seg_read_word_at(bus, 2)?;
         if self.sregs[SegReg32::CS as usize] != initial_cs
             || self.ip != initial_ip
             || self.ip_upper != initial_ip_upper
         {
-            return;
+            return Ok(());
         }
-        if !self.load_segment(SegReg32::DS, segment, bus) {
-            return;
-        }
+        self.load_segment(SegReg32::DS, segment, bus)?;
         let reg = self.reg_word(modrm);
         self.regs.set_word(reg, offset);
         self.clk(Self::timing(7, 6));
+        Ok(())
     }
 
-    fn enter(&mut self, bus: &mut impl common::Bus) {
+    fn enter(&mut self, bus: &mut impl common::Bus) -> Step {
         let alloc = self.fetchword(bus);
         let level = self.fetch(bus) & 0x1F;
         let operand_size: u32 = if self.operand_size_override { 4 } else { 2 };
@@ -2953,17 +2719,15 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             self.regs.word(WordReg::SP).wrapping_sub(total_bytes as u16) as u32
         };
-        if !self.check_segment_access(SegReg32::SS, final_sp, operand_size, true, bus) {
-            return;
-        }
+        self.check_segment_access(SegReg32::SS, final_sp, operand_size, true, bus)?;
         let probe_linear = self.seg_base(SegReg32::SS).wrapping_add(final_sp);
-        if self.translate_linear(probe_linear, true, bus).is_none() {
-            return;
+        if self.translate_linear(probe_linear, true, bus).is_err() {
+            return Ok(());
         }
         if self.operand_size_override {
             let sp_pen = self.sp_penalty();
             let ebp_val = self.regs.dword(DwordReg::EBP);
-            self.push_dword(bus, ebp_val);
+            self.push_dword(bus, ebp_val)?;
             let frame_ptr = self.regs.dword(DwordReg::ESP);
             if self.use_esp() {
                 if level > 0 {
@@ -2973,12 +2737,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     let mut walk = ebp_val;
                     for _ in 1..level {
                         walk = walk.wrapping_sub(4);
-                        let Some(val) = self.read_dword_seg(bus, SegReg32::SS, walk) else {
-                            return;
-                        };
-                        self.push_dword(bus, val);
+                        let val = self.read_dword_seg(bus, SegReg32::SS, walk)?;
+                        self.push_dword(bus, val)?;
                     }
-                    self.push_dword(bus, frame_ptr);
+                    self.push_dword(bus, frame_ptr)?;
                 }
                 self.regs.set_dword(DwordReg::EBP, frame_ptr);
                 let esp = self.regs.dword(DwordReg::ESP).wrapping_sub(alloc as u32);
@@ -2988,12 +2750,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     let mut walk = ebp_val as u16;
                     for _ in 1..level {
                         walk = walk.wrapping_sub(4);
-                        let Some(val) = self.read_dword_seg(bus, SegReg32::SS, walk as u32) else {
-                            return;
-                        };
-                        self.push_dword(bus, val);
+                        let val = self.read_dword_seg(bus, SegReg32::SS, walk as u32)?;
+                        self.push_dword(bus, val)?;
                     }
-                    self.push_dword(bus, frame_ptr);
+                    self.push_dword(bus, frame_ptr)?;
                 }
                 self.regs.set_dword(DwordReg::EBP, frame_ptr);
                 let sp = self.regs.word(WordReg::SP).wrapping_sub(alloc);
@@ -3010,18 +2770,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             let sp_pen = self.sp_penalty();
             let bp = self.regs.word(WordReg::BP);
-            self.push(bus, bp);
+            self.push(bus, bp)?;
             let frame_ptr = self.regs.word(WordReg::SP);
             if level > 0 {
                 let mut walk = bp;
                 for _ in 1..level {
                     walk = walk.wrapping_sub(2);
-                    let Some(val) = self.read_word_seg(bus, SegReg32::SS, walk as u32) else {
-                        return;
-                    };
-                    self.push(bus, val);
+                    let val = self.read_word_seg(bus, SegReg32::SS, walk as u32)?;
+                    self.push(bus, val)?;
                 }
-                self.push(bus, frame_ptr);
+                self.push(bus, frame_ptr)?;
             }
             self.regs.set_word(WordReg::BP, frame_ptr);
             let sp = self.regs.word(WordReg::SP).wrapping_sub(alloc);
@@ -3035,9 +2793,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.clk(Self::timing(15 + 4 * (l - 1), 17 + 3 * l) + sp_pen);
             }
         }
+        Ok(())
     }
 
-    fn leave(&mut self, bus: &mut impl common::Bus) {
+    fn leave(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.use_esp() {
             let ebp = self.regs.dword(DwordReg::EBP);
             self.regs.set_dword(DwordReg::ESP, ebp);
@@ -3047,102 +2806,80 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
         let penalty = self.sp_penalty();
         if self.operand_size_override {
-            let Some(val) = self.pop_dword(bus) else {
-                return;
-            };
+            let val = self.pop_dword(bus)?;
             self.regs.set_dword(DwordReg::EBP, val);
         } else {
-            let Some(val) = self.pop(bus) else {
-                return;
-            };
+            let val = self.pop(bus)?;
             self.regs.set_word(WordReg::BP, val);
         }
         self.clk(Self::timing(4, 5) + penalty);
+        Ok(())
     }
 
-    fn int3(&mut self, bus: &mut impl common::Bus) {
+    fn int3(&mut self, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
-        self.raise_software_interrupt(3, false, bus);
+        self.raise_software_interrupt(3, false, bus)?;
         self.clk(Self::timing(33, 26) + penalty);
+        Ok(())
     }
 
-    fn int_imm(&mut self, bus: &mut impl common::Bus) {
+    fn int_imm(&mut self, bus: &mut impl common::Bus) -> Step {
         let penalty = self.sp_penalty();
         let vector = self.fetch(bus);
-        self.raise_software_interrupt(vector, true, bus);
+        self.raise_software_interrupt(vector, true, bus)?;
         self.clk(Self::timing(37, 30) + penalty);
+        Ok(())
     }
 
-    fn into(&mut self, bus: &mut impl common::Bus) {
+    fn into(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.flags.of() {
             let penalty = self.sp_penalty();
-            self.raise_software_interrupt(4, false, bus);
+            self.raise_software_interrupt(4, false, bus)?;
             self.clk(Self::timing(35, 28) + penalty);
         } else {
             self.clk(Self::timing(3, 3));
         }
+        Ok(())
     }
 
-    fn iret(&mut self, bus: &mut impl common::Bus) {
+    fn iret(&mut self, bus: &mut impl common::Bus) -> Step {
         self.preserve_resume_flag = true;
         let penalty = self.sp_penalty();
 
         if !self.is_protected_mode() {
             if self.operand_size_override {
-                let Some(eip) = self.pop_dword(bus) else {
-                    return;
-                };
-                let Some(cs_dword) = self.pop_dword(bus) else {
-                    return;
-                };
+                let eip = self.pop_dword(bus)?;
+                let cs_dword = self.pop_dword(bus)?;
                 let cs = cs_dword as u16;
-                let Some(eflags) = self.pop_dword(bus) else {
-                    return;
-                };
-                if !self.load_segment(SegReg32::CS, cs, bus) {
-                    return;
-                }
+                let eflags = self.pop_dword(bus)?;
+                self.load_segment(SegReg32::CS, cs, bus)?;
                 self.ip = eip as u16;
                 self.ip_upper = eip & 0xFFFF_0000;
                 self.flags.load_flags(eflags as u16, 0, false);
             } else {
-                let Some(ip) = self.pop(bus) else {
-                    return;
-                };
-                let Some(cs) = self.pop(bus) else {
-                    return;
-                };
-                let Some(flags_val) = self.pop(bus) else {
-                    return;
-                };
-                if !self.load_segment(SegReg32::CS, cs, bus) {
-                    return;
-                }
+                let ip = self.pop(bus)?;
+                let cs = self.pop(bus)?;
+                let flags_val = self.pop(bus)?;
+                self.load_segment(SegReg32::CS, cs, bus)?;
                 self.ip = ip;
                 self.ip_upper = 0;
                 self.flags.load_flags(flags_val, 0, false);
             }
             self.clk(Self::timing(22, 15) + penalty);
-            return;
+            return Ok(());
         }
 
         if self.is_virtual_mode() {
             if self.flags.iopl < 3 {
-                self.raise_fault_with_code(13, 0, bus);
-                return;
+                self.raise_fault_with_code(13, 0, bus)?;
+                return Ok(());
             }
 
             if self.operand_size_override {
-                let Some(new_eip) = self.pop_dword(bus) else {
-                    return;
-                };
-                let Some(new_cs_dword) = self.pop_dword(bus) else {
-                    return;
-                };
+                let new_eip = self.pop_dword(bus)?;
+                let new_cs_dword = self.pop_dword(bus)?;
                 let new_cs = new_cs_dword as u16;
-                let Some(new_eflags) = self.pop_dword(bus) else {
-                    return;
-                };
+                let new_eflags = self.pop_dword(bus)?;
 
                 self.sregs[SegReg32::CS as usize] = new_cs;
                 self.set_real_segment_cache(SegReg32::CS, new_cs);
@@ -3151,15 +2888,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.flags.load_flags(new_eflags as u16, 3, true);
                 self.eflags_upper = (new_eflags & 0x00FF_0000) | 0x0002_0000;
             } else {
-                let Some(new_ip) = self.pop(bus) else {
-                    return;
-                };
-                let Some(new_cs) = self.pop(bus) else {
-                    return;
-                };
-                let Some(new_flags) = self.pop(bus) else {
-                    return;
-                };
+                let new_ip = self.pop(bus)?;
+                let new_cs = self.pop(bus)?;
+                let new_flags = self.pop(bus)?;
 
                 self.sregs[SegReg32::CS as usize] = new_cs;
                 self.set_real_segment_cache(SegReg32::CS, new_cs);
@@ -3170,21 +2901,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
 
             self.clk(Self::timing(22, 15) + penalty);
-            return;
+            return Ok(());
         }
 
         // Protected mode IRET.
         if self.flags.nt {
             // Task return via back-link in current TSS.
-            let Some(backlink) = self.read_word_linear(bus, self.tr_base) else {
-                return;
-            };
-            self.switch_task(backlink, super::TaskType::Iret, bus);
+            let backlink = self.read_word_linear(bus, self.tr_base)?;
+            self.switch_task(backlink, super::TaskType::Iret, bus)?;
             let flags_val = self.flags.compress();
             let cpl = self.cpl();
             self.flags.load_flags(flags_val, cpl, true);
             self.clk(Self::timing(22, 15) + penalty);
-            return;
+            return Ok(());
         }
 
         let old_cpl = self.cpl();
@@ -3197,58 +2926,32 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let ss_base = self.seg_base(SegReg32::SS);
 
         if self.operand_size_override {
-            let Some(new_eip) = self.read_dword_linear(bus, ss_base.wrapping_add(sp)) else {
-                return;
-            };
-            let Some(new_cs_dword) =
-                self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(4)))
-            else {
-                return;
-            };
+            let new_eip = self.read_dword_linear(bus, ss_base.wrapping_add(sp))?;
+            let new_cs_dword =
+                self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(4)))?;
             let new_cs = new_cs_dword as u16;
-            let Some(new_eflags) =
-                self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(8)))
-            else {
-                return;
-            };
+            let new_eflags =
+                self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(8)))?;
 
             // IRET from CPL0 to virtual-8086 mode.
             // Stack frame: EIP, CS, EFLAGS, ESP, SS, ES, DS, FS, GS.
             if old_cpl == 0 && (new_eflags & 0x0002_0000) != 0 {
-                let Some(new_esp) =
-                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(12)))
-                else {
-                    return;
-                };
-                let Some(new_ss_dword) =
-                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(16)))
-                else {
-                    return;
-                };
+                let new_esp =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(12)))?;
+                let new_ss_dword =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(16)))?;
                 let new_ss = new_ss_dword as u16;
-                let Some(new_es_dword) =
-                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(20)))
-                else {
-                    return;
-                };
+                let new_es_dword =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(20)))?;
                 let new_es = new_es_dword as u16;
-                let Some(new_ds_dword) =
-                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(24)))
-                else {
-                    return;
-                };
+                let new_ds_dword =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(24)))?;
                 let new_ds = new_ds_dword as u16;
-                let Some(new_fs_dword) =
-                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(28)))
-                else {
-                    return;
-                };
+                let new_fs_dword =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(28)))?;
                 let new_fs = new_fs_dword as u16;
-                let Some(new_gs_dword) =
-                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(32)))
-                else {
-                    return;
-                };
+                let new_gs_dword =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(32)))?;
                 let new_gs = new_gs_dword as u16;
 
                 self.flags.load_flags(new_eflags as u16, old_cpl, true);
@@ -3273,59 +2976,37 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.set_real_segment_cache(SegReg32::GS, new_gs);
 
                 self.clk(Self::timing(60, 15) + penalty);
-                return;
+                return Ok(());
             }
 
             let new_rpl = new_cs & 3;
 
             if new_rpl > old_cpl {
-                let Some(new_esp) =
-                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(12)))
-                else {
-                    return;
-                };
-                let Some(new_ss_dword) =
-                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(16)))
-                else {
-                    return;
-                };
+                let new_esp =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(12)))?;
+                let new_ss_dword =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(sp.wrapping_add(16)))?;
                 let new_ss = new_ss_dword as u16;
 
-                let ss_validation = match self.validate_ss_for_iret_return(new_ss, new_rpl, bus) {
-                    None => return,
-                    Some(Err((vector, error_code))) => {
-                        self.raise_fault_with_code(vector, error_code, bus);
-                        return;
+                let ss_validation = match self.validate_ss_for_iret_return(new_ss, new_rpl, bus)? {
+                    Err((vector, error_code)) => {
+                        return self.raise_fault_with_code(vector, error_code, bus);
                     }
-                    Some(Ok(validation)) => validation,
+                    Ok(validation) => validation,
                 };
 
-                let cs_validation = match self.validate_cs_for_return(new_cs, new_eip, bus) {
-                    None => return,
-                    Some(Err((vector, error_code))) => {
-                        self.raise_fault_with_code(vector, error_code, bus);
-                        return;
+                let cs_validation = match self.validate_cs_for_return(new_cs, new_eip, bus)? {
+                    Err((vector, error_code)) => {
+                        return self.raise_fault_with_code(vector, error_code, bus);
                     }
-                    Some(Ok(validation)) => validation,
+                    Ok(validation) => validation,
                 };
 
                 let new_cpl = new_rpl;
-                let Some(ds_decision) = self.check_data_segment_at_cpl(SegReg32::DS, new_cpl, bus)
-                else {
-                    return;
-                };
-                let Some(es_decision) = self.check_data_segment_at_cpl(SegReg32::ES, new_cpl, bus)
-                else {
-                    return;
-                };
-                let Some(fs_decision) = self.check_data_segment_at_cpl(SegReg32::FS, new_cpl, bus)
-                else {
-                    return;
-                };
-                let Some(gs_decision) = self.check_data_segment_at_cpl(SegReg32::GS, new_cpl, bus)
-                else {
-                    return;
-                };
+                let ds_decision = self.check_data_segment_at_cpl(SegReg32::DS, new_cpl, bus)?;
+                let es_decision = self.check_data_segment_at_cpl(SegReg32::ES, new_cpl, bus)?;
+                let fs_decision = self.check_data_segment_at_cpl(SegReg32::FS, new_cpl, bus)?;
+                let gs_decision = self.check_data_segment_at_cpl(SegReg32::GS, new_cpl, bus)?;
 
                 self.flags.load_flags(new_eflags as u16, old_cpl, true);
                 if old_cpl == 0 {
@@ -3339,12 +3020,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     cs_validation.adjusted_selector,
                     cs_validation.descriptor,
                 );
-                let _ = self.set_accessed_bit(cs_validation.adjusted_selector, bus);
+                self.set_accessed_bit(cs_validation.adjusted_selector, bus)?;
                 self.ip = new_eip as u16;
                 self.ip_upper = new_eip & 0xFFFF_0000;
 
                 self.set_loaded_segment_cache(SegReg32::SS, new_ss, ss_validation.descriptor);
-                let _ = self.set_accessed_bit(new_ss, bus);
+                self.set_accessed_bit(new_ss, bus)?;
                 if self.use_esp() {
                     self.regs.set_dword(DwordReg::ESP, new_esp);
                 } else {
@@ -3356,13 +3037,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.apply_data_segment_decision(SegReg32::FS, fs_decision);
                 self.apply_data_segment_decision(SegReg32::GS, gs_decision);
             } else {
-                let cs_validation = match self.validate_cs_for_return(new_cs, new_eip, bus) {
-                    None => return,
-                    Some(Err((vector, error_code))) => {
-                        self.raise_fault_with_code(vector, error_code, bus);
-                        return;
+                let cs_validation = match self.validate_cs_for_return(new_cs, new_eip, bus)? {
+                    Err((vector, error_code)) => {
+                        return self.raise_fault_with_code(vector, error_code, bus);
                     }
-                    Some(Ok(validation)) => validation,
+                    Ok(validation) => validation,
                 };
 
                 self.set_loaded_segment_cache(
@@ -3370,7 +3049,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     cs_validation.adjusted_selector,
                     cs_validation.descriptor,
                 );
-                let _ = self.set_accessed_bit(cs_validation.adjusted_selector, bus);
+                self.set_accessed_bit(cs_validation.adjusted_selector, bus)?;
                 if self.use_esp() {
                     self.regs.set_dword(DwordReg::ESP, sp.wrapping_add(12));
                 } else {
@@ -3386,68 +3065,37 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
             }
         } else {
-            let Some(new_ip) = self.read_word_linear(bus, ss_base.wrapping_add(sp)) else {
-                return;
-            };
-            let Some(new_cs) = self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(2)))
-            else {
-                return;
-            };
-            let Some(new_flags) =
-                self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(4)))
-            else {
-                return;
-            };
+            let new_ip = self.read_word_linear(bus, ss_base.wrapping_add(sp))?;
+            let new_cs = self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(2)))?;
+            let new_flags = self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(4)))?;
 
             let new_rpl = new_cs & 3;
 
             if new_rpl > old_cpl {
-                let Some(new_sp) =
-                    self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(6)))
-                else {
-                    return;
-                };
-                let Some(new_ss) =
-                    self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(8)))
-                else {
-                    return;
+                let new_sp =
+                    self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(6)))?;
+                let new_ss =
+                    self.read_word_linear(bus, ss_base.wrapping_add(sp.wrapping_add(8)))?;
+
+                let ss_validation = match self.validate_ss_for_iret_return(new_ss, new_rpl, bus)? {
+                    Err((vector, error_code)) => {
+                        return self.raise_fault_with_code(vector, error_code, bus);
+                    }
+                    Ok(validation) => validation,
                 };
 
-                let ss_validation = match self.validate_ss_for_iret_return(new_ss, new_rpl, bus) {
-                    None => return,
-                    Some(Err((vector, error_code))) => {
-                        self.raise_fault_with_code(vector, error_code, bus);
-                        return;
+                let cs_validation = match self.validate_cs_for_return(new_cs, new_ip as u32, bus)? {
+                    Err((vector, error_code)) => {
+                        return self.raise_fault_with_code(vector, error_code, bus);
                     }
-                    Some(Ok(validation)) => validation,
-                };
-
-                let cs_validation = match self.validate_cs_for_return(new_cs, new_ip as u32, bus) {
-                    None => return,
-                    Some(Err((vector, error_code))) => {
-                        self.raise_fault_with_code(vector, error_code, bus);
-                        return;
-                    }
-                    Some(Ok(validation)) => validation,
+                    Ok(validation) => validation,
                 };
 
                 let new_cpl = new_rpl;
-                let Some(ds_decision) = self.check_data_segment_at_cpl(SegReg32::DS, new_cpl, bus)
-                else {
-                    return;
-                };
-                let Some(es_decision) = self.check_data_segment_at_cpl(SegReg32::ES, new_cpl, bus)
-                else {
-                    return;
-                };
-                let Some(fs_decision) = self.check_data_segment_at_cpl(SegReg32::FS, new_cpl, bus)
-                else {
-                    return;
-                };
-                let Some(gs_decision) = self.check_data_segment_at_cpl(SegReg32::GS, new_cpl, bus)
-                else {
-                    return;
-                };
+                let ds_decision = self.check_data_segment_at_cpl(SegReg32::DS, new_cpl, bus)?;
+                let es_decision = self.check_data_segment_at_cpl(SegReg32::ES, new_cpl, bus)?;
+                let fs_decision = self.check_data_segment_at_cpl(SegReg32::FS, new_cpl, bus)?;
+                let gs_decision = self.check_data_segment_at_cpl(SegReg32::GS, new_cpl, bus)?;
 
                 self.flags.load_flags(new_flags, old_cpl, true);
 
@@ -3456,12 +3104,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     cs_validation.adjusted_selector,
                     cs_validation.descriptor,
                 );
-                let _ = self.set_accessed_bit(cs_validation.adjusted_selector, bus);
+                self.set_accessed_bit(cs_validation.adjusted_selector, bus)?;
                 self.ip = new_ip;
                 self.ip_upper = 0;
 
                 self.set_loaded_segment_cache(SegReg32::SS, new_ss, ss_validation.descriptor);
-                let _ = self.set_accessed_bit(new_ss, bus);
+                self.set_accessed_bit(new_ss, bus)?;
                 if self.use_esp() {
                     self.regs.set_dword(DwordReg::ESP, new_sp as u32);
                 } else {
@@ -3473,13 +3121,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.apply_data_segment_decision(SegReg32::FS, fs_decision);
                 self.apply_data_segment_decision(SegReg32::GS, gs_decision);
             } else {
-                let cs_validation = match self.validate_cs_for_return(new_cs, new_ip as u32, bus) {
-                    None => return,
-                    Some(Err((vector, error_code))) => {
-                        self.raise_fault_with_code(vector, error_code, bus);
-                        return;
+                let cs_validation = match self.validate_cs_for_return(new_cs, new_ip as u32, bus)? {
+                    Err((vector, error_code)) => {
+                        return self.raise_fault_with_code(vector, error_code, bus);
                     }
-                    Some(Ok(validation)) => validation,
+                    Ok(validation) => validation,
                 };
 
                 self.set_loaded_segment_cache(
@@ -3487,7 +3133,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     cs_validation.adjusted_selector,
                     cs_validation.descriptor,
                 );
-                let _ = self.set_accessed_bit(cs_validation.adjusted_selector, bus);
+                self.set_accessed_bit(cs_validation.adjusted_selector, bus)?;
                 if self.use_esp() {
                     self.regs.set_dword(DwordReg::ESP, sp.wrapping_add(6));
                 } else {
@@ -3500,6 +3146,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
 
         self.clk(Self::timing(22, 15) + penalty);
+        Ok(())
     }
 
     fn loopne(&mut self, bus: &mut impl common::Bus) {
@@ -3610,21 +3257,22 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
     }
 
-    fn in_al_imm(&mut self, bus: &mut impl common::Bus) {
+    fn in_al_imm(&mut self, bus: &mut impl common::Bus) -> Step {
         let port = self.fetch(bus) as u16;
-        if !self.check_io_privilege(port, 1, bus) {
-            return;
+        if self.check_io_privilege(port, 1, bus).is_err() {
+            return Err(Fault);
         }
         let val = bus.io_read_byte(port);
         self.regs.set_byte(ByteReg::AL, val);
         self.clk(Self::timing(12, 14));
+        Ok(())
     }
 
-    fn in_aw_imm(&mut self, bus: &mut impl common::Bus) {
+    fn in_aw_imm(&mut self, bus: &mut impl common::Bus) -> Step {
         let port = self.fetch(bus) as u16;
         let size = if self.operand_size_override { 4 } else { 2 };
-        if !self.check_io_privilege(port, size, bus) {
-            return;
+        if self.check_io_privilege(port, size, bus).is_err() {
+            return Err(Fault);
         }
         if self.operand_size_override {
             let low = bus.io_read_word(port) as u32;
@@ -3635,23 +3283,25 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.regs.set_word(WordReg::AX, val);
         }
         self.clk(Self::timing(12, 14));
+        Ok(())
     }
 
-    fn out_imm_al(&mut self, bus: &mut impl common::Bus) {
+    fn out_imm_al(&mut self, bus: &mut impl common::Bus) -> Step {
         let port = self.fetch(bus) as u16;
-        if !self.check_io_privilege(port, 1, bus) {
-            return;
+        if self.check_io_privilege(port, 1, bus).is_err() {
+            return Err(Fault);
         }
         let val = self.regs.byte(ByteReg::AL);
         bus.io_write_byte(port, val);
         self.clk(Self::timing(10, 16));
+        Ok(())
     }
 
-    fn out_imm_aw(&mut self, bus: &mut impl common::Bus) {
+    fn out_imm_aw(&mut self, bus: &mut impl common::Bus) -> Step {
         let port = self.fetch(bus) as u16;
         let size = if self.operand_size_override { 4 } else { 2 };
-        if !self.check_io_privilege(port, size, bus) {
-            return;
+        if self.check_io_privilege(port, size, bus).is_err() {
+            return Err(Fault);
         }
         if self.operand_size_override {
             let val = self.regs.dword(DwordReg::EAX);
@@ -3662,23 +3312,25 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             bus.io_write_word(port, val);
         }
         self.clk(Self::timing(10, 16));
+        Ok(())
     }
 
-    fn in_al_dw(&mut self, bus: &mut impl common::Bus) {
+    fn in_al_dw(&mut self, bus: &mut impl common::Bus) -> Step {
         let port = self.regs.word(WordReg::DX);
-        if !self.check_io_privilege(port, 1, bus) {
-            return;
+        if self.check_io_privilege(port, 1, bus).is_err() {
+            return Err(Fault);
         }
         let val = bus.io_read_byte(port);
         self.regs.set_byte(ByteReg::AL, val);
         self.clk(Self::timing(13, 14));
+        Ok(())
     }
 
-    fn in_aw_dw(&mut self, bus: &mut impl common::Bus) {
+    fn in_aw_dw(&mut self, bus: &mut impl common::Bus) -> Step {
         let port = self.regs.word(WordReg::DX);
         let size = if self.operand_size_override { 4 } else { 2 };
-        if !self.check_io_privilege(port, size, bus) {
-            return;
+        if self.check_io_privilege(port, size, bus).is_err() {
+            return Err(Fault);
         }
         if self.operand_size_override {
             let low = bus.io_read_word(port) as u32;
@@ -3689,23 +3341,25 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.regs.set_word(WordReg::AX, val);
         }
         self.clk(Self::timing(13, 14));
+        Ok(())
     }
 
-    fn out_dw_al(&mut self, bus: &mut impl common::Bus) {
+    fn out_dw_al(&mut self, bus: &mut impl common::Bus) -> Step {
         let port = self.regs.word(WordReg::DX);
-        if !self.check_io_privilege(port, 1, bus) {
-            return;
+        if self.check_io_privilege(port, 1, bus).is_err() {
+            return Err(Fault);
         }
         let val = self.regs.byte(ByteReg::AL);
         bus.io_write_byte(port, val);
         self.clk(Self::timing(11, 16));
+        Ok(())
     }
 
-    fn out_dw_aw(&mut self, bus: &mut impl common::Bus) {
+    fn out_dw_aw(&mut self, bus: &mut impl common::Bus) -> Step {
         let port = self.regs.word(WordReg::DX);
         let size = if self.operand_size_override { 4 } else { 2 };
-        if !self.check_io_privilege(port, size, bus) {
-            return;
+        if self.check_io_privilege(port, size, bus).is_err() {
+            return Err(Fault);
         }
         if self.operand_size_override {
             let val = self.regs.dword(DwordReg::EAX);
@@ -3716,9 +3370,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             bus.io_write_word(port, val);
         }
         self.clk(Self::timing(11, 16));
+        Ok(())
     }
 
-    fn xlat(&mut self, bus: &mut impl common::Bus) {
+    fn xlat(&mut self, bus: &mut impl common::Bus) -> Step {
         let seg = self.default_seg(SegReg32::DS);
         let offset = if self.address_size_override {
             self.regs
@@ -3729,11 +3384,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 .word(WordReg::BX)
                 .wrapping_add(self.regs.byte(ByteReg::AL) as u16) as u32
         };
-        let Some(val) = self.read_byte_seg(bus, seg, offset) else {
-            return;
-        };
+        let val = self.read_byte_seg(bus, seg, offset)?;
         self.regs.set_byte(ByteReg::AL, val);
         self.clk(Self::timing(5, 4));
+        Ok(())
     }
 
     fn daa(&mut self, _bus: &mut impl common::Bus) {
@@ -3862,23 +3516,25 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 2));
     }
 
-    fn cli(&mut self, bus: &mut impl common::Bus) {
+    fn cli(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.is_protected_mode() && self.cpl() > u16::from(self.flags.iopl) {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            self.raise_fault_with_code(13, 0, bus)?;
+            return Ok(());
         }
         self.flags.if_flag = false;
         self.clk(Self::timing(3, 5));
+        Ok(())
     }
 
-    fn sti(&mut self, bus: &mut impl common::Bus) {
+    fn sti(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.is_protected_mode() && self.cpl() > u16::from(self.flags.iopl) {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            self.raise_fault_with_code(13, 0, bus)?;
+            return Ok(());
         }
         self.flags.if_flag = true;
         self.no_interrupt = 1;
         self.clk(Self::timing(3, 5));
+        Ok(())
     }
 
     fn cld(&mut self) {
@@ -3896,18 +3552,20 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(2, 2));
     }
 
-    fn hlt(&mut self, bus: &mut impl common::Bus) {
+    fn hlt(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.is_protected_mode() && self.cpl() != 0 {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            self.raise_fault_with_code(13, 0, bus)?;
+            return Ok(());
         }
         self.halted = true;
         self.clk(Self::timing(5, 4));
+        Ok(())
     }
 
-    fn invalid(&mut self, bus: &mut impl common::Bus) {
+    fn invalid(&mut self, bus: &mut impl common::Bus) -> Step {
         // #UD (Invalid Opcode, INT 6): introduced with the 80286.
         // The fault pushes CS:IP pointing to the faulting opcode.
-        self.raise_fault(6, bus);
+        self.raise_fault(6, bus)?;
+        Ok(())
     }
 }

--- a/crates/cpu/src/i386/execute.rs
+++ b/crates/cpu/src/i386/execute.rs
@@ -1791,12 +1791,53 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     fn pop_rm(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let sp_pen = self.sp_penalty();
-        if self.operand_size_override {
-            let val = self.pop_dword(bus)?;
-            self.put_rm_dword(modrm, val, bus)?;
+
+        if modrm >= 0xC0 {
+            if self.operand_size_override {
+                let val = self.pop_dword(bus)?;
+                self.put_rm_dword(modrm, val, bus)?;
+            } else {
+                let val = self.pop(bus)?;
+                self.put_rm_word(modrm, val, bus)?;
+            }
         } else {
-            let val = self.pop(bus)?;
-            self.put_rm_word(modrm, val, bus)?;
+            let use_esp = self.use_esp();
+            let old_sp = if use_esp {
+                self.regs.dword(DwordReg::ESP)
+            } else {
+                self.regs.word(WordReg::SP) as u32
+            };
+            let pop_bytes: u32 = if self.operand_size_override { 4 } else { 2 };
+            let new_sp = if use_esp {
+                old_sp.wrapping_add(pop_bytes)
+            } else {
+                (old_sp as u16).wrapping_add(pop_bytes as u16) as u32
+            };
+            let val = if self.operand_size_override {
+                self.read_dword_seg(bus, SegReg32::SS, old_sp)?
+            } else {
+                self.read_word_seg(bus, SegReg32::SS, old_sp)? as u32
+            };
+
+            self.commit_sp(new_sp);
+            self.calc_ea(modrm, bus);
+            let ea_seg = self.ea_seg;
+            let eo32 = self.eo32;
+            self.commit_sp(old_sp);
+
+            self.check_segment_access(ea_seg, eo32, pop_bytes, true, bus)?;
+            let base = self.seg_base(ea_seg);
+            let l0 = base.wrapping_add(eo32);
+            for b in 0..pop_bytes {
+                self.translate_linear(l0.wrapping_add(b), true, bus)?;
+            }
+
+            self.commit_sp(new_sp);
+            if self.operand_size_override {
+                self.write_dword_seg(bus, ea_seg, eo32, val)?;
+            } else {
+                self.write_word_seg(bus, ea_seg, eo32, val as u16)?;
+            }
         }
         if modrm >= 0xC0 {
             self.clk(Self::timing(4, 4) + sp_pen);
@@ -1851,8 +1892,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             if self.is_protected_mode() && !self.is_virtual_mode() {
                 self.code_descriptor(segment, offset, super::TaskType::Call, cs, eip, bus)?;
             } else {
-                self.push_dword(bus, cs as u32)?;
-                self.push_dword(bus, eip)?;
+                self.far_push_real_v86_dword(bus, cs as u32, eip)?;
                 self.load_segment(SegReg32::CS, segment, bus)?;
                 self.ip = offset as u16;
                 self.ip_upper = offset & 0xFFFF_0000;
@@ -1883,8 +1923,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     bus,
                 )?;
             } else {
-                self.push(bus, cs)?;
-                self.push(bus, ip)?;
+                self.far_push_real_v86_word(bus, cs, ip)?;
                 self.load_segment(SegReg32::CS, segment, bus)?;
                 self.ip = offset;
                 self.ip_upper = 0;
@@ -1900,6 +1939,76 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
             }
         }
+        Ok(())
+    }
+
+    /// Probe-then-commit real/V86 far push pair (CS first, then IP).
+    pub(super) fn far_push_real_v86_word(
+        &mut self,
+        bus: &mut impl common::Bus,
+        cs: u16,
+        ip: u16,
+    ) -> Step {
+        let use_esp = self.use_esp();
+        let sp_orig = if use_esp {
+            self.regs.dword(DwordReg::ESP)
+        } else {
+            self.regs.word(WordReg::SP) as u32
+        };
+        let stack_offset = |delta: u32| -> u32 {
+            if use_esp {
+                sp_orig.wrapping_sub(delta)
+            } else {
+                (sp_orig as u16).wrapping_sub(delta as u16) as u32
+            }
+        };
+        let ss_base = self.seg_base(SegReg32::SS);
+        for i in 1..=2u32 {
+            let off = stack_offset(2 * i);
+            self.check_segment_access(SegReg32::SS, off, 2, true, bus)?;
+            let l0 = ss_base.wrapping_add(off);
+            self.translate_linear(l0, true, bus)?;
+            self.translate_linear(l0.wrapping_add(1), true, bus)?;
+        }
+        self.commit_sp(stack_offset(4));
+        self.write_word_seg(bus, SegReg32::SS, stack_offset(2), cs)?;
+        self.write_word_seg(bus, SegReg32::SS, stack_offset(4), ip)?;
+        Ok(())
+    }
+
+    /// 32-bit variant of `far_push_real_v86_word`: pushes CS (zero-extended)
+    /// and EIP as dwords.
+    pub(super) fn far_push_real_v86_dword(
+        &mut self,
+        bus: &mut impl common::Bus,
+        cs: u32,
+        eip: u32,
+    ) -> Step {
+        let use_esp = self.use_esp();
+        let sp_orig = if use_esp {
+            self.regs.dword(DwordReg::ESP)
+        } else {
+            self.regs.word(WordReg::SP) as u32
+        };
+        let stack_offset = |delta: u32| -> u32 {
+            if use_esp {
+                sp_orig.wrapping_sub(delta)
+            } else {
+                (sp_orig as u16).wrapping_sub(delta as u16) as u32
+            }
+        };
+        let ss_base = self.seg_base(SegReg32::SS);
+        for i in 1..=2u32 {
+            let off = stack_offset(4 * i);
+            self.check_segment_access(SegReg32::SS, off, 4, true, bus)?;
+            let l0 = ss_base.wrapping_add(off);
+            for b in 0..4u32 {
+                self.translate_linear(l0.wrapping_add(b), true, bus)?;
+            }
+        }
+        self.commit_sp(stack_offset(8));
+        self.write_dword_seg(bus, SegReg32::SS, stack_offset(4), cs)?;
+        self.write_dword_seg(bus, SegReg32::SS, stack_offset(8), eip)?;
         Ok(())
     }
 
@@ -2787,87 +2896,121 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     fn enter(&mut self, bus: &mut impl common::Bus) -> Step {
         let alloc = self.fetchword(bus);
         let level = self.fetch(bus) & 0x1F;
+        let sp_pen = self.sp_penalty();
         let operand_size: u32 = if self.operand_size_override { 4 } else { 2 };
         let push_count: u32 = if level == 0 { 1 } else { level as u32 + 1 };
-        let total_bytes = push_count * operand_size + alloc as u32;
-        let final_sp = if self.use_esp() {
-            self.regs.dword(DwordReg::ESP).wrapping_sub(total_bytes)
+        let use_esp = self.use_esp();
+        let esp_full = self.regs.dword(DwordReg::ESP);
+        let sp_in = if use_esp {
+            esp_full
         } else {
-            self.regs.word(WordReg::SP).wrapping_sub(total_bytes as u16) as u32
+            esp_full as u16 as u32
         };
-        self.check_segment_access(SegReg32::SS, final_sp, operand_size, true, bus)?;
-        let probe_linear = self.seg_base(SegReg32::SS).wrapping_add(final_sp);
-        if self.translate_linear(probe_linear, true, bus).is_err() {
-            return Ok(());
-        }
-        if self.operand_size_override {
-            let sp_pen = self.sp_penalty();
-            let ebp_val = self.regs.dword(DwordReg::EBP);
-            self.push_dword(bus, ebp_val)?;
-            let frame_ptr = self.regs.dword(DwordReg::ESP);
-            if self.use_esp() {
-                if level > 0 {
-                    // Walk the previous frame chain into a local without
-                    // mutating EBP, so a faulting read leaves EBP at its
-                    // entry value rather than partially walked.
-                    let mut walk = ebp_val;
-                    for _ in 1..level {
-                        walk = walk.wrapping_sub(4);
-                        let val = self.read_dword_seg(bus, SegReg32::SS, walk)?;
-                        self.push_dword(bus, val)?;
-                    }
-                    self.push_dword(bus, frame_ptr)?;
-                }
-                self.regs.set_dword(DwordReg::EBP, frame_ptr);
-                let esp = self.regs.dword(DwordReg::ESP).wrapping_sub(alloc as u32);
-                self.regs.set_dword(DwordReg::ESP, esp);
-            } else {
-                if level > 0 {
-                    let mut walk = ebp_val as u16;
-                    for _ in 1..level {
-                        walk = walk.wrapping_sub(4);
-                        let val = self.read_dword_seg(bus, SegReg32::SS, walk as u32)?;
-                        self.push_dword(bus, val)?;
-                    }
-                    self.push_dword(bus, frame_ptr)?;
-                }
-                self.regs.set_dword(DwordReg::EBP, frame_ptr);
-                let sp = self.regs.word(WordReg::SP).wrapping_sub(alloc);
-                self.regs.set_word(WordReg::SP, sp);
-            }
-            if level == 0 {
-                self.clk(Self::timing(10, 14) + sp_pen);
-            } else if level == 1 {
-                self.clk(Self::timing(12, 17) + sp_pen);
-            } else {
-                let l = level as i32;
-                self.clk(Self::timing(15 + 4 * (l - 1), 17 + 3 * l) + sp_pen);
-            }
+        let bp_in: u32 = if self.operand_size_override {
+            self.regs.dword(DwordReg::EBP)
         } else {
-            let sp_pen = self.sp_penalty();
-            let bp = self.regs.word(WordReg::BP);
-            self.push(bus, bp)?;
-            let frame_ptr = self.regs.word(WordReg::SP);
-            if level > 0 {
-                let mut walk = bp;
-                for _ in 1..level {
-                    walk = walk.wrapping_sub(2);
-                    let val = self.read_word_seg(bus, SegReg32::SS, walk as u32)?;
-                    self.push(bus, val)?;
-                }
-                self.push(bus, frame_ptr)?;
-            }
-            self.regs.set_word(WordReg::BP, frame_ptr);
-            let sp = self.regs.word(WordReg::SP).wrapping_sub(alloc);
-            self.regs.set_word(WordReg::SP, sp);
-            if level == 0 {
-                self.clk(Self::timing(10, 14) + sp_pen);
-            } else if level == 1 {
-                self.clk(Self::timing(12, 17) + sp_pen);
+            self.regs.word(WordReg::BP) as u32
+        };
+        let stack_offset = |delta: u32| -> u32 {
+            if use_esp {
+                sp_in.wrapping_sub(delta)
             } else {
-                let l = level as i32;
-                self.clk(Self::timing(15 + 4 * (l - 1), 17 + 3 * l) + sp_pen);
+                (sp_in as u16).wrapping_sub(delta as u16) as u32
             }
+        };
+
+        // FrameTemp follows the SP-commit wrap rules but also preserves
+        // ESP's upper 16 bits when the stack is 16-bit (B=0).
+        let frame_ptr_value = if use_esp {
+            sp_in.wrapping_sub(operand_size)
+        } else {
+            (esp_full & 0xFFFF_0000) | ((sp_in as u16).wrapping_sub(operand_size as u16) as u32)
+        };
+
+        // Pre-compute every offset the instruction will touch. `level` is
+        // masked to [0, 31] so the buffers are bounded.
+        let mut walk_offsets: [u32; 31] = [0; 31];
+        let chain_count: u32 = if level >= 2 { level as u32 - 1 } else { 0 };
+        if chain_count > 0 {
+            let wrap_walk_16 = !self.operand_size_override || !use_esp;
+            let mut walk = bp_in;
+            for entry in walk_offsets.iter_mut().take(chain_count as usize) {
+                walk = walk.wrapping_sub(operand_size);
+                *entry = if wrap_walk_16 {
+                    walk as u16 as u32
+                } else {
+                    walk
+                };
+            }
+        }
+        let mut push_offsets: [u32; 32] = [0; 32];
+        for k in 0..push_count {
+            push_offsets[k as usize] = stack_offset(operand_size * (k + 1));
+        }
+        let final_sp = stack_offset(operand_size * push_count + alloc as u32);
+
+        // Probe phase. Chain reads (read access); push writes (write); and
+        // the final-SP byte (write, for the alloc-area #PF pre-check).
+        let ss_base = self.seg_base(SegReg32::SS);
+        for k in 0..chain_count {
+            let off = walk_offsets[k as usize];
+            self.check_segment_access(SegReg32::SS, off, operand_size, false, bus)?;
+            let l0 = ss_base.wrapping_add(off);
+            for b in 0..operand_size {
+                self.translate_linear(l0.wrapping_add(b), false, bus)?;
+            }
+        }
+        for k in 0..push_count {
+            let off = push_offsets[k as usize];
+            self.check_segment_access(SegReg32::SS, off, operand_size, true, bus)?;
+            let l0 = ss_base.wrapping_add(off);
+            for b in 0..operand_size {
+                self.translate_linear(l0.wrapping_add(b), true, bus)?;
+            }
+        }
+        self.check_segment_access(SegReg32::SS, final_sp, operand_size, true, bus)?;
+        self.translate_linear(ss_base.wrapping_add(final_sp), true, bus)?;
+
+        // Sequential operation against memory (TLB-hot, cannot fault).
+        if self.operand_size_override {
+            self.write_dword_seg(bus, SegReg32::SS, push_offsets[0], bp_in)?;
+        } else {
+            self.write_word_seg(bus, SegReg32::SS, push_offsets[0], bp_in as u16)?;
+        }
+        for k in 0..chain_count {
+            let read_off = walk_offsets[k as usize];
+            let push_off = push_offsets[(k + 1) as usize];
+            if self.operand_size_override {
+                let val = self.read_dword_seg(bus, SegReg32::SS, read_off)?;
+                self.write_dword_seg(bus, SegReg32::SS, push_off, val)?;
+            } else {
+                let val = self.read_word_seg(bus, SegReg32::SS, read_off)?;
+                self.write_word_seg(bus, SegReg32::SS, push_off, val)?;
+            }
+        }
+        if level > 0 {
+            let frame_off = push_offsets[(push_count - 1) as usize];
+            if self.operand_size_override {
+                self.write_dword_seg(bus, SegReg32::SS, frame_off, frame_ptr_value)?;
+            } else {
+                self.write_word_seg(bus, SegReg32::SS, frame_off, frame_ptr_value as u16)?;
+            }
+        }
+
+        self.commit_sp(final_sp);
+        if self.operand_size_override {
+            self.regs.set_dword(DwordReg::EBP, frame_ptr_value);
+        } else {
+            self.regs.set_word(WordReg::BP, frame_ptr_value as u16);
+        }
+
+        if level == 0 {
+            self.clk(Self::timing(10, 14) + sp_pen);
+        } else if level == 1 {
+            self.clk(Self::timing(12, 17) + sp_pen);
+        } else {
+            let l = level as i32;
+            self.clk(Self::timing(15 + 4 * (l - 1), 17 + 3 * l) + sp_pen);
         }
         Ok(())
     }

--- a/crates/cpu/src/i386/execute.rs
+++ b/crates/cpu/src/i386/execute.rs
@@ -2797,19 +2797,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     }
 
     fn leave(&mut self, bus: &mut impl common::Bus) -> Step {
-        if self.use_esp() {
-            let ebp = self.regs.dword(DwordReg::EBP);
-            self.regs.set_dword(DwordReg::ESP, ebp);
+        let bp_offset = if self.use_esp() {
+            self.regs.dword(DwordReg::EBP)
         } else {
-            let bp = self.regs.word(WordReg::BP);
-            self.regs.set_word(WordReg::SP, bp);
-        }
+            self.regs.word(WordReg::BP) as u32
+        };
         let penalty = self.sp_penalty();
         if self.operand_size_override {
-            let val = self.pop_dword(bus)?;
+            let val = self.read_dword_seg(bus, SegReg32::SS, bp_offset)?;
+            self.commit_sp(bp_offset.wrapping_add(4));
             self.regs.set_dword(DwordReg::EBP, val);
         } else {
-            let val = self.pop(bus)?;
+            let val = self.read_word_seg(bus, SegReg32::SS, bp_offset)?;
+            self.commit_sp(bp_offset.wrapping_add(2));
             self.regs.set_word(WordReg::BP, val);
         }
         self.clk(Self::timing(4, 5) + penalty);

--- a/crates/cpu/src/i386/execute.rs
+++ b/crates/cpu/src/i386/execute.rs
@@ -1156,34 +1156,80 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     }
 
     fn pusha(&mut self, bus: &mut impl common::Bus) -> Step {
+        // Atomic PUSHA: probe writability of all 8 stack slots before
+        // committing SP, so a #PF mid-sequence leaves SP and memory
+        // unchanged from the OS handler's perspective. (Sequential pushes
+        // would commit SP between operations, leaving the saved-V86-ESP
+        // slot of an inter-priv fault frame pointing at a partial state
+        // that the IRET-back would observe.)
         let penalty = self.sp_penalty();
-        if self.operand_size_override {
-            let esp = self.regs.dword(DwordReg::ESP);
-            self.push_dword(bus, self.regs.dword(DwordReg::EAX))?;
-            self.push_dword(bus, self.regs.dword(DwordReg::ECX))?;
-            self.push_dword(bus, self.regs.dword(DwordReg::EDX))?;
-            self.push_dword(bus, self.regs.dword(DwordReg::EBX))?;
-            self.push_dword(bus, esp)?;
-            self.push_dword(bus, self.regs.dword(DwordReg::EBP))?;
-            self.push_dword(bus, self.regs.dword(DwordReg::ESI))?;
-            self.push_dword(bus, self.regs.dword(DwordReg::EDI))?;
+        let use_esp = self.use_esp();
+        let sp_orig = if use_esp {
+            self.regs.dword(DwordReg::ESP)
         } else {
-            let sp = self.regs.word(WordReg::SP);
-            let aw = self.regs.word(WordReg::AX);
-            self.push(bus, aw)?;
-            let cw = self.regs.word(WordReg::CX);
-            self.push(bus, cw)?;
-            let dw = self.regs.word(WordReg::DX);
-            self.push(bus, dw)?;
-            let bw = self.regs.word(WordReg::BX);
-            self.push(bus, bw)?;
-            self.push(bus, sp)?;
-            let bp = self.regs.word(WordReg::BP);
-            self.push(bus, bp)?;
-            let ix = self.regs.word(WordReg::SI);
-            self.push(bus, ix)?;
-            let iy = self.regs.word(WordReg::DI);
-            self.push(bus, iy)?;
+            self.regs.word(WordReg::SP) as u32
+        };
+        let stack_offset = |delta: u32| -> u32 {
+            if use_esp {
+                sp_orig.wrapping_sub(delta)
+            } else {
+                (sp_orig as u16).wrapping_sub(delta as u16) as u32
+            }
+        };
+        let ss_base = self.seg_base(SegReg32::SS);
+
+        if self.operand_size_override {
+            let values = [
+                self.regs.dword(DwordReg::EAX),
+                self.regs.dword(DwordReg::ECX),
+                self.regs.dword(DwordReg::EDX),
+                self.regs.dword(DwordReg::EBX),
+                self.regs.dword(DwordReg::ESP),
+                self.regs.dword(DwordReg::EBP),
+                self.regs.dword(DwordReg::ESI),
+                self.regs.dword(DwordReg::EDI),
+            ];
+            // Probe every byte of every slot before any commit.
+            for i in 1..=8u32 {
+                let offset = stack_offset(4 * i);
+                self.check_segment_access(SegReg32::SS, offset, 4, true, bus)?;
+                let l0 = ss_base.wrapping_add(offset);
+                for b in 0..4u32 {
+                    self.translate_linear(l0.wrapping_add(b), true, bus)?;
+                }
+            }
+            // All slots accessible -- commit SP and do all writes. The
+            // writes go through write_dword_seg which retranslates from
+            // the TLB primed by the probe loop above.
+            self.commit_sp(stack_offset(32));
+            for (i, &val) in values.iter().enumerate() {
+                let offset = stack_offset(4 * (i as u32 + 1));
+                self.write_dword_seg(bus, SegReg32::SS, offset, val)?;
+            }
+        } else {
+            let values = [
+                self.regs.word(WordReg::AX),
+                self.regs.word(WordReg::CX),
+                self.regs.word(WordReg::DX),
+                self.regs.word(WordReg::BX),
+                self.regs.word(WordReg::SP),
+                self.regs.word(WordReg::BP),
+                self.regs.word(WordReg::SI),
+                self.regs.word(WordReg::DI),
+            ];
+            for i in 1..=8u32 {
+                let offset = stack_offset(2 * i);
+                self.check_segment_access(SegReg32::SS, offset, 2, true, bus)?;
+                let l0 = ss_base.wrapping_add(offset);
+                for b in 0..2u32 {
+                    self.translate_linear(l0.wrapping_add(b), true, bus)?;
+                }
+            }
+            self.commit_sp(stack_offset(16));
+            for (i, &val) in values.iter().enumerate() {
+                let offset = stack_offset(2 * (i as u32 + 1));
+                self.write_word_seg(bus, SegReg32::SS, offset, val)?;
+            }
         }
         self.clk(Self::timing(18, 11) + penalty);
         Ok(())
@@ -2877,20 +2923,37 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let penalty = self.sp_penalty();
 
         if !self.is_protected_mode() {
+            let use_esp = self.use_esp();
+            let sp = if use_esp {
+                self.regs.dword(DwordReg::ESP)
+            } else {
+                self.regs.word(WordReg::SP) as u32
+            };
+            let stack_offset = |delta: u32| -> u32 {
+                if use_esp {
+                    sp.wrapping_add(delta)
+                } else {
+                    (sp as u16).wrapping_add(delta as u16) as u32
+                }
+            };
+            let ss_base = self.seg_base(SegReg32::SS);
             if self.operand_size_override {
-                let eip = self.pop_dword(bus)?;
-                let cs_dword = self.pop_dword(bus)?;
-                let cs = cs_dword as u16;
-                let eflags = self.pop_dword(bus)?;
-                self.load_segment(SegReg32::CS, cs, bus)?;
+                let eip = self.read_dword_linear(bus, ss_base.wrapping_add(stack_offset(0)))?;
+                let cs_dword =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(stack_offset(4)))?;
+                let eflags = self.read_dword_linear(bus, ss_base.wrapping_add(stack_offset(8)))?;
+                self.load_segment(SegReg32::CS, cs_dword as u16, bus)?;
+                self.commit_sp(stack_offset(12));
                 self.ip = eip as u16;
                 self.ip_upper = eip & 0xFFFF_0000;
                 self.flags.load_flags(eflags as u16, 0, false);
             } else {
-                let ip = self.pop(bus)?;
-                let cs = self.pop(bus)?;
-                let flags_val = self.pop(bus)?;
+                let ip = self.read_word_linear(bus, ss_base.wrapping_add(stack_offset(0)))?;
+                let cs = self.read_word_linear(bus, ss_base.wrapping_add(stack_offset(2)))?;
+                let flags_val =
+                    self.read_word_linear(bus, ss_base.wrapping_add(stack_offset(4)))?;
                 self.load_segment(SegReg32::CS, cs, bus)?;
+                self.commit_sp(stack_offset(6));
                 self.ip = ip;
                 self.ip_upper = 0;
                 self.flags.load_flags(flags_val, 0, false);
@@ -2905,25 +2968,44 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 return Ok(());
             }
 
+            let use_esp = self.use_esp();
+            let sp = if use_esp {
+                self.regs.dword(DwordReg::ESP)
+            } else {
+                self.regs.word(WordReg::SP) as u32
+            };
+            let stack_offset = |delta: u32| -> u32 {
+                if use_esp {
+                    sp.wrapping_add(delta)
+                } else {
+                    (sp as u16).wrapping_add(delta as u16) as u32
+                }
+            };
+            let ss_base = self.seg_base(SegReg32::SS);
             if self.operand_size_override {
-                let new_eip = self.pop_dword(bus)?;
-                let new_cs_dword = self.pop_dword(bus)?;
+                let new_eip = self.read_dword_linear(bus, ss_base.wrapping_add(stack_offset(0)))?;
+                let new_cs_dword =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(stack_offset(4)))?;
+                let new_eflags =
+                    self.read_dword_linear(bus, ss_base.wrapping_add(stack_offset(8)))?;
                 let new_cs = new_cs_dword as u16;
-                let new_eflags = self.pop_dword(bus)?;
 
                 self.sregs[SegReg32::CS as usize] = new_cs;
                 self.set_real_segment_cache(SegReg32::CS, new_cs);
+                self.commit_sp(stack_offset(12));
                 self.ip = new_eip as u16;
                 self.ip_upper = new_eip & 0xFFFF_0000;
                 self.flags.load_flags(new_eflags as u16, 3, true);
                 self.eflags_upper = (new_eflags & 0x00FF_0000) | 0x0002_0000;
             } else {
-                let new_ip = self.pop(bus)?;
-                let new_cs = self.pop(bus)?;
-                let new_flags = self.pop(bus)?;
+                let new_ip = self.read_word_linear(bus, ss_base.wrapping_add(stack_offset(0)))?;
+                let new_cs = self.read_word_linear(bus, ss_base.wrapping_add(stack_offset(2)))?;
+                let new_flags =
+                    self.read_word_linear(bus, ss_base.wrapping_add(stack_offset(4)))?;
 
                 self.sregs[SegReg32::CS as usize] = new_cs;
                 self.set_real_segment_cache(SegReg32::CS, new_cs);
+                self.commit_sp(stack_offset(6));
                 self.ip = new_ip;
                 self.ip_upper = 0;
                 self.flags.load_flags(new_flags, 3, true);

--- a/crates/cpu/src/i386/execute_0f.rs
+++ b/crates/cpu/src/i386/execute_0f.rs
@@ -265,75 +265,83 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         if self.operand_size_override {
             let bit_offset = self.regs.dword(self.reg_dword(modrm));
             if modrm >= 0xC0 {
-                let mut value = self.regs.dword(self.rm_dword(modrm));
+                let value_before = self.regs.dword(self.rm_dword(modrm));
                 let bit = 1u32 << (bit_offset & 31);
-                self.flags.carry_val = u32::from(value & bit != 0);
+                let mut new_value = value_before;
                 if clear {
-                    value &= !bit;
+                    new_value &= !bit;
                 }
                 if set {
-                    value |= bit;
+                    new_value |= bit;
                 }
                 if toggle {
-                    value ^= bit;
+                    new_value ^= bit;
                 }
-                self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
                 let reg = self.rm_dword(modrm);
-                self.regs.set_dword(reg, value);
+                self.regs.set_dword(reg, new_value);
+                let cf = u32::from(value_before & bit != 0);
+                self.flags.carry_val = cf;
+                self.flags.overflow_val = if cf != 0 { 0x0800 } else { 0 };
             } else {
                 self.calc_ea(modrm, bus);
                 let (offset, bit_index) = self.bit_mem_effective_offset(bit_offset as i32, 32);
-                let mut value = self.read_dword_seg_for_update(bus, self.ea_seg, offset)?;
+                let value_before = self.read_dword_seg_for_update(bus, self.ea_seg, offset)?;
                 let bit = 1u32 << bit_index;
-                self.flags.carry_val = u32::from(value & bit != 0);
+                let mut new_value = value_before;
                 if clear {
-                    value &= !bit;
+                    new_value &= !bit;
                 }
                 if set {
-                    value |= bit;
+                    new_value |= bit;
                 }
                 if toggle {
-                    value ^= bit;
+                    new_value ^= bit;
                 }
-                self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
-                self.write_dword_seg(bus, self.ea_seg, offset, value)?;
+                self.write_dword_seg(bus, self.ea_seg, offset, new_value)?;
+                let cf = u32::from(value_before & bit != 0);
+                self.flags.carry_val = cf;
+                self.flags.overflow_val = if cf != 0 { 0x0800 } else { 0 };
             }
         } else {
             let bit_offset = self.regs.word(self.reg_word(modrm));
             if modrm >= 0xC0 {
-                let mut value = self.regs.word(self.rm_word(modrm));
+                let value_before = self.regs.word(self.rm_word(modrm));
                 let bit = 1u16 << (bit_offset as u32 & 15);
-                self.flags.carry_val = u32::from(value & bit != 0);
+                let mut new_value = value_before;
                 if clear {
-                    value &= !bit;
+                    new_value &= !bit;
                 }
                 if set {
-                    value |= bit;
+                    new_value |= bit;
                 }
                 if toggle {
-                    value ^= bit;
+                    new_value ^= bit;
                 }
-                self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
                 let reg = self.rm_word(modrm);
-                self.regs.set_word(reg, value);
+                self.regs.set_word(reg, new_value);
+                let cf = u32::from(value_before & bit != 0);
+                self.flags.carry_val = cf;
+                self.flags.overflow_val = if cf != 0 { 0x0800 } else { 0 };
             } else {
                 self.calc_ea(modrm, bus);
                 let signed_offset = bit_offset as i16 as i32;
                 let (offset, bit_index) = self.bit_mem_effective_offset(signed_offset, 16);
-                let mut value = self.read_word_seg_for_update(bus, self.ea_seg, offset)?;
+                let value_before = self.read_word_seg_for_update(bus, self.ea_seg, offset)?;
                 let bit = 1u16 << bit_index;
-                self.flags.carry_val = u32::from(value & bit != 0);
+                let mut new_value = value_before;
                 if clear {
-                    value &= !bit;
+                    new_value &= !bit;
                 }
                 if set {
-                    value |= bit;
+                    new_value |= bit;
                 }
                 if toggle {
-                    value ^= bit;
+                    new_value ^= bit;
                 }
-                self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
-                self.write_word_seg(bus, self.ea_seg, offset, value)?;
+                self.write_word_seg(bus, self.ea_seg, offset, new_value)?;
+                let cf = u32::from(value_before & bit != 0);
+                self.flags.carry_val = cf;
+                self.flags.overflow_val = if cf != 0 { 0x0800 } else { 0 };
             }
         }
         self.clk_modrm_word(modrm, register_cycles, memory_cycles, 2);
@@ -355,23 +363,25 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         if self.operand_size_override {
             if modrm >= 0xC0 {
                 let imm = self.fetch(bus) as u32;
-                let mut value = self.regs.dword(self.rm_dword(modrm));
+                let value_before = self.regs.dword(self.rm_dword(modrm));
                 let bit = 1u32 << (imm & 31);
-                self.flags.carry_val = u32::from(value & bit != 0);
+                let mut new_value = value_before;
                 if clear {
-                    value &= !bit;
+                    new_value &= !bit;
                 }
                 if set {
-                    value |= bit;
+                    new_value |= bit;
                 }
                 if toggle {
-                    value ^= bit;
+                    new_value ^= bit;
                 }
-                self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
                 if write_back {
                     let reg = self.rm_dword(modrm);
-                    self.regs.set_dword(reg, value);
+                    self.regs.set_dword(reg, new_value);
                 }
+                let cf = u32::from(value_before & bit != 0);
+                self.flags.carry_val = cf;
+                self.flags.overflow_val = if cf != 0 { 0x0800 } else { 0 };
             } else {
                 self.calc_ea(modrm, bus);
                 let imm = self.fetch(bus) as u32;
@@ -383,65 +393,71 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     } else {
                         self.read_dword_linear(bus, address)
                     };
-                    let mut value = read_result?;
+                    let value_before = read_result?;
                     let bit = 1u32 << bit_index;
-                    self.flags.carry_val = u32::from(value & bit != 0);
+                    let mut new_value = value_before;
                     if clear {
-                        value &= !bit;
+                        new_value &= !bit;
                     }
                     if set {
-                        value |= bit;
+                        new_value |= bit;
                     }
                     if toggle {
-                        value ^= bit;
+                        new_value ^= bit;
                     }
-                    self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
                     if write_back {
-                        self.write_dword_linear(bus, address, value)?;
+                        self.write_dword_linear(bus, address, new_value)?;
                     }
+                    let cf = u32::from(value_before & bit != 0);
+                    self.flags.carry_val = cf;
+                    self.flags.overflow_val = if cf != 0 { 0x0800 } else { 0 };
                 } else {
                     let read_result = if write_back {
                         self.seg_read_dword_for_update(bus)
                     } else {
                         self.seg_read_dword(bus)
                     };
-                    let mut value = read_result?;
+                    let value_before = read_result?;
                     let bit = 1u32 << bit_index;
-                    self.flags.carry_val = u32::from(value & bit != 0);
+                    let mut new_value = value_before;
                     if clear {
-                        value &= !bit;
+                        new_value &= !bit;
                     }
                     if set {
-                        value |= bit;
+                        new_value |= bit;
                     }
                     if toggle {
-                        value ^= bit;
+                        new_value ^= bit;
                     }
-                    self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
                     if write_back {
-                        self.seg_write_dword(bus, value)?;
+                        self.seg_write_dword(bus, new_value)?;
                     }
+                    let cf = u32::from(value_before & bit != 0);
+                    self.flags.carry_val = cf;
+                    self.flags.overflow_val = if cf != 0 { 0x0800 } else { 0 };
                 }
             }
         } else if modrm >= 0xC0 {
             let imm = self.fetch(bus) as u32;
-            let mut value = self.regs.word(self.rm_word(modrm));
+            let value_before = self.regs.word(self.rm_word(modrm));
             let bit = 1u16 << (imm & 15);
-            self.flags.carry_val = u32::from(value & bit != 0);
+            let mut new_value = value_before;
             if clear {
-                value &= !bit;
+                new_value &= !bit;
             }
             if set {
-                value |= bit;
+                new_value |= bit;
             }
             if toggle {
-                value ^= bit;
+                new_value ^= bit;
             }
-            self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
             if write_back {
                 let reg = self.rm_word(modrm);
-                self.regs.set_word(reg, value);
+                self.regs.set_word(reg, new_value);
             }
+            let cf = u32::from(value_before & bit != 0);
+            self.flags.carry_val = cf;
+            self.flags.overflow_val = if cf != 0 { 0x0800 } else { 0 };
         } else {
             self.calc_ea(modrm, bus);
             let imm = self.fetch(bus) as u32;
@@ -453,44 +469,48 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 } else {
                     self.read_word_linear(bus, address)
                 };
-                let mut value = read_result?;
+                let value_before = read_result?;
                 let bit = 1u16 << bit_index;
-                self.flags.carry_val = u32::from(value & bit != 0);
+                let mut new_value = value_before;
                 if clear {
-                    value &= !bit;
+                    new_value &= !bit;
                 }
                 if set {
-                    value |= bit;
+                    new_value |= bit;
                 }
                 if toggle {
-                    value ^= bit;
+                    new_value ^= bit;
                 }
-                self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
                 if write_back {
-                    self.write_word_linear(bus, address, value)?;
+                    self.write_word_linear(bus, address, new_value)?;
                 }
+                let cf = u32::from(value_before & bit != 0);
+                self.flags.carry_val = cf;
+                self.flags.overflow_val = if cf != 0 { 0x0800 } else { 0 };
             } else {
                 let read_result = if write_back {
                     self.seg_read_word_for_update(bus)
                 } else {
                     self.seg_read_word(bus)
                 };
-                let mut value = read_result?;
+                let value_before = read_result?;
                 let bit = 1u16 << bit_index;
-                self.flags.carry_val = u32::from(value & bit != 0);
+                let mut new_value = value_before;
                 if clear {
-                    value &= !bit;
+                    new_value &= !bit;
                 }
                 if set {
-                    value |= bit;
+                    new_value |= bit;
                 }
                 if toggle {
-                    value ^= bit;
+                    new_value ^= bit;
                 }
-                self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
                 if write_back {
-                    self.seg_write_word(bus, value)?;
+                    self.seg_write_word(bus, new_value)?;
                 }
+                let cf = u32::from(value_before & bit != 0);
+                self.flags.carry_val = cf;
+                self.flags.overflow_val = if cf != 0 { 0x0800 } else { 0 };
             }
         }
 
@@ -1583,14 +1603,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     }
 
     fn xadd_byte(&mut self, bus: &mut impl common::Bus) -> Step {
-        // XADD r/m8,r8 - exchange and add.
         let modrm = self.fetch(bus);
         let src_reg = self.reg_byte(modrm);
         let src = self.regs.byte(src_reg);
         let dst = self.get_rm_byte_for_update(modrm, bus)?;
         let result = self.alu_add_byte(dst, src);
-        self.regs.set_byte(src_reg, dst);
-        self.putback_rm_byte(modrm, result, bus)?;
+        if modrm >= 0xC0 {
+            self.regs.set_byte(src_reg, dst);
+            self.putback_rm_byte(modrm, result, bus)?;
+        } else {
+            self.putback_rm_byte(modrm, result, bus)?;
+            self.regs.set_byte(src_reg, dst);
+        }
         self.clk_modrm(modrm, 3, 4);
         Ok(())
     }
@@ -1603,15 +1627,25 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             let src = self.regs.dword(src_reg);
             let dst = self.get_rm_dword_for_update(modrm, bus)?;
             let result = self.alu_add_dword(dst, src);
-            self.regs.set_dword(src_reg, dst);
-            self.putback_rm_dword(modrm, result, bus)?;
+            if modrm >= 0xC0 {
+                self.regs.set_dword(src_reg, dst);
+                self.putback_rm_dword(modrm, result, bus)?;
+            } else {
+                self.putback_rm_dword(modrm, result, bus)?;
+                self.regs.set_dword(src_reg, dst);
+            }
         } else {
             let src_reg = self.reg_word(modrm);
             let src = self.regs.word(src_reg);
             let dst = self.get_rm_word_for_update(modrm, bus)?;
             let result = self.alu_add_word(dst, src);
-            self.regs.set_word(src_reg, dst);
-            self.putback_rm_word(modrm, result, bus)?;
+            if modrm >= 0xC0 {
+                self.regs.set_word(src_reg, dst);
+                self.putback_rm_word(modrm, result, bus)?;
+            } else {
+                self.putback_rm_word(modrm, result, bus)?;
+                self.regs.set_word(src_reg, dst);
+            }
         }
         self.clk_modrm(modrm, 3, 4);
         Ok(())

--- a/crates/cpu/src/i386/execute_0f.rs
+++ b/crates/cpu/src/i386/execute_0f.rs
@@ -1,8 +1,8 @@
-use super::{CPU_MODEL_386, CPU_MODEL_486, I386};
+use super::{CPU_MODEL_386, CPU_MODEL_486, I386, Step};
 use crate::{ByteReg, DwordReg, SegReg32, WordReg};
 
 impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
-    pub(super) fn extended_0f(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn extended_0f(&mut self, bus: &mut impl common::Bus) -> Step {
         let sub = self.fetch(bus);
         if self.lock_prefix {
             let lockable = matches!(
@@ -13,60 +13,61 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 | 0xC0 | 0xC1 // XADD (486+)
             );
             if !lockable {
-                self.raise_fault(6, bus);
-                return;
+                self.raise_fault(6, bus)?;
+                return Ok(());
             }
         }
         match sub {
-            0x00 => self.group_0f00(bus),
-            0x01 => self.group_0f01(bus),
-            0x02 => self.lar(bus),
-            0x03 => self.lsl_instr(bus),
-            0x06 => self.clts(bus),
-            0x08 if CPU_MODEL >= CPU_MODEL_486 => self.invd(bus),
-            0x09 if CPU_MODEL >= CPU_MODEL_486 => self.wbinvd(bus),
+            0x00 => self.group_0f00(bus)?,
+            0x01 => self.group_0f01(bus)?,
+            0x02 => self.lar(bus)?,
+            0x03 => self.lsl_instr(bus)?,
+            0x06 => self.clts(bus)?,
+            0x08 if CPU_MODEL >= CPU_MODEL_486 => self.invd(bus)?,
+            0x09 if CPU_MODEL >= CPU_MODEL_486 => self.wbinvd(bus)?,
 
-            0x20 => self.mov_r32_cr(bus),
-            0x21 => self.mov_r32_dr(bus),
-            0x22 => self.mov_cr_r32(bus),
-            0x23 => self.mov_dr_r32(bus),
+            0x20 => self.mov_r32_cr(bus)?,
+            0x21 => self.mov_r32_dr(bus)?,
+            0x22 => self.mov_cr_r32(bus)?,
+            0x23 => self.mov_dr_r32(bus)?,
 
             0x80..=0x8F => self.jcc_near(sub & 0x0F, bus),
-            0x90..=0x9F => self.setcc(sub & 0x0F, bus),
+            0x90..=0x9F => self.setcc(sub & 0x0F, bus)?,
 
-            0xA0 => self.push_seg(SegReg32::FS, bus),
-            0xA1 => self.pop_seg(SegReg32::FS, bus),
-            0xA3 => self.bt_reg(bus),
-            0xA4 => self.shld_imm(bus),
-            0xA5 => self.shld_cl(bus),
-            0xA8 => self.push_seg(SegReg32::GS, bus),
-            0xA9 => self.pop_seg(SegReg32::GS, bus),
-            0xAB => self.bts_reg(bus),
-            0xAC => self.shrd_imm(bus),
-            0xAD => self.shrd_cl(bus),
-            0xAF => self.imul_reg_rm(bus),
+            0xA0 => self.push_seg(SegReg32::FS, bus)?,
+            0xA1 => self.pop_seg(SegReg32::FS, bus)?,
+            0xA3 => self.bt_reg(bus)?,
+            0xA4 => self.shld_imm(bus)?,
+            0xA5 => self.shld_cl(bus)?,
+            0xA8 => self.push_seg(SegReg32::GS, bus)?,
+            0xA9 => self.pop_seg(SegReg32::GS, bus)?,
+            0xAB => self.bts_reg(bus)?,
+            0xAC => self.shrd_imm(bus)?,
+            0xAD => self.shrd_cl(bus)?,
+            0xAF => self.imul_reg_rm(bus)?,
 
-            0xB2 => self.lss(bus),
-            0xB3 => self.btr_reg(bus),
-            0xB4 => self.lfs(bus),
-            0xB5 => self.lgs(bus),
-            0xB6 => self.movzx_rm8(bus),
-            0xB7 => self.movzx_rm16(bus),
-            0xBA => self.group_ba(bus),
-            0xBB => self.btc_reg(bus),
-            0xBC => self.bsf(bus),
-            0xBD => self.bsr(bus),
-            0xB0 if CPU_MODEL >= CPU_MODEL_486 => self.cmpxchg_byte(bus),
-            0xB1 if CPU_MODEL >= CPU_MODEL_486 => self.cmpxchg_word(bus),
-            0xBE => self.movsx_rm8(bus),
-            0xBF => self.movsx_rm16(bus),
+            0xB2 => self.lss(bus)?,
+            0xB3 => self.btr_reg(bus)?,
+            0xB4 => self.lfs(bus)?,
+            0xB5 => self.lgs(bus)?,
+            0xB6 => self.movzx_rm8(bus)?,
+            0xB7 => self.movzx_rm16(bus)?,
+            0xBA => self.group_ba(bus)?,
+            0xBB => self.btc_reg(bus)?,
+            0xBC => self.bsf(bus)?,
+            0xBD => self.bsr(bus)?,
+            0xB0 if CPU_MODEL >= CPU_MODEL_486 => self.cmpxchg_byte(bus)?,
+            0xB1 if CPU_MODEL >= CPU_MODEL_486 => self.cmpxchg_word(bus)?,
+            0xBE => self.movsx_rm8(bus)?,
+            0xBF => self.movsx_rm16(bus)?,
 
-            0xC0 if CPU_MODEL >= CPU_MODEL_486 => self.xadd_byte(bus),
-            0xC1 if CPU_MODEL >= CPU_MODEL_486 => self.xadd_word(bus),
+            0xC0 if CPU_MODEL >= CPU_MODEL_486 => self.xadd_byte(bus)?,
+            0xC1 if CPU_MODEL >= CPU_MODEL_486 => self.xadd_word(bus)?,
             0xC8..=0xCF if CPU_MODEL >= CPU_MODEL_486 => self.bswap(sub),
 
-            _ => self.raise_fault(6, bus),
+            _ => self.raise_fault(6, bus)?,
         }
+        Ok(())
     }
 
     #[inline(always)]
@@ -92,13 +93,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
     }
 
-    fn clts(&mut self, bus: &mut impl common::Bus) {
+    fn clts(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.is_protected_mode() && self.cpl() != 0 {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            self.raise_fault_with_code(13, 0, bus)?;
+            return Ok(());
         }
         self.cr0 &= !0x0000_0008;
         self.clk(Self::timing(5, 7));
+        Ok(())
     }
 
     fn jcc_near(&mut self, cc: u8, bus: &mut impl common::Bus) {
@@ -143,11 +145,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
     }
 
-    fn setcc(&mut self, cc: u8, bus: &mut impl common::Bus) {
+    fn setcc(&mut self, cc: u8, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let taken = self.cond(cc);
         let value = if taken { 1 } else { 0 };
-        self.put_rm_byte(modrm, value, bus);
+        self.put_rm_byte(modrm, value, bus)?;
         match CPU_MODEL {
             CPU_MODEL_386 => self.clk_modrm(modrm, 4, 5),
             CPU_MODEL_486 => {
@@ -159,6 +161,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
             _ => unreachable!("Unhandled CPU_MODEL"),
         }
+        Ok(())
     }
 
     #[inline(always)]
@@ -181,7 +184,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         (offset, bit_index)
     }
 
-    fn bt_reg(&mut self, bus: &mut impl common::Bus) {
+    fn bt_reg(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let bit_offset = self.regs.dword(self.reg_dword(modrm));
@@ -191,9 +194,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             } else {
                 self.calc_ea(modrm, bus);
                 let (offset, bit_index) = self.bit_mem_effective_offset(bit_offset as i32, 32);
-                let Some(value) = self.read_dword_seg(bus, self.ea_seg, offset) else {
-                    return;
-                };
+                let value = self.read_dword_seg(bus, self.ea_seg, offset)?;
                 self.flags.carry_val = (value >> bit_index) & 1;
             }
         } else {
@@ -205,18 +206,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.calc_ea(modrm, bus);
                 let signed_offset = bit_offset as i16 as i32;
                 let (offset, bit_index) = self.bit_mem_effective_offset(signed_offset, 16);
-                let Some(value) = self.read_word_seg(bus, self.ea_seg, offset) else {
-                    return;
-                };
+                let value = self.read_word_seg(bus, self.ea_seg, offset)?;
                 let value = value as u32;
                 self.flags.carry_val = (value >> bit_index) & 1;
             }
         }
         self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
         self.clk_modrm_word(modrm, Self::timing(3, 3), Self::timing(12, 8), 2);
+        Ok(())
     }
 
-    fn bts_reg(&mut self, bus: &mut impl common::Bus) {
+    fn bts_reg(&mut self, bus: &mut impl common::Bus) -> Step {
         self.bit_modify_reg(
             bus,
             false,
@@ -224,10 +224,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             false,
             Self::timing(6, 6),
             Self::timing(13, 13),
-        );
+        )?;
+        Ok(())
     }
 
-    fn btr_reg(&mut self, bus: &mut impl common::Bus) {
+    fn btr_reg(&mut self, bus: &mut impl common::Bus) -> Step {
         self.bit_modify_reg(
             bus,
             true,
@@ -235,10 +236,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             false,
             Self::timing(6, 6),
             Self::timing(13, 13),
-        );
+        )?;
+        Ok(())
     }
 
-    fn btc_reg(&mut self, bus: &mut impl common::Bus) {
+    fn btc_reg(&mut self, bus: &mut impl common::Bus) -> Step {
         self.bit_modify_reg(
             bus,
             false,
@@ -246,7 +248,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             true,
             Self::timing(6, 6),
             Self::timing(13, 13),
-        );
+        )?;
+        Ok(())
     }
 
     fn bit_modify_reg(
@@ -257,7 +260,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         toggle: bool,
         register_cycles: i32,
         memory_cycles: i32,
-    ) {
+    ) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let bit_offset = self.regs.dword(self.reg_dword(modrm));
@@ -280,10 +283,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             } else {
                 self.calc_ea(modrm, bus);
                 let (offset, bit_index) = self.bit_mem_effective_offset(bit_offset as i32, 32);
-                let Some(mut value) = self.read_dword_seg_for_update(bus, self.ea_seg, offset)
-                else {
-                    return;
-                };
+                let mut value = self.read_dword_seg_for_update(bus, self.ea_seg, offset)?;
                 let bit = 1u32 << bit_index;
                 self.flags.carry_val = u32::from(value & bit != 0);
                 if clear {
@@ -296,7 +296,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     value ^= bit;
                 }
                 self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
-                self.write_dword_seg(bus, self.ea_seg, offset, value);
+                self.write_dword_seg(bus, self.ea_seg, offset, value)?;
             }
         } else {
             let bit_offset = self.regs.word(self.reg_word(modrm));
@@ -320,10 +320,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.calc_ea(modrm, bus);
                 let signed_offset = bit_offset as i16 as i32;
                 let (offset, bit_index) = self.bit_mem_effective_offset(signed_offset, 16);
-                let Some(mut value) = self.read_word_seg_for_update(bus, self.ea_seg, offset)
-                else {
-                    return;
-                };
+                let mut value = self.read_word_seg_for_update(bus, self.ea_seg, offset)?;
                 let bit = 1u16 << bit_index;
                 self.flags.carry_val = u32::from(value & bit != 0);
                 if clear {
@@ -336,10 +333,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     value ^= bit;
                 }
                 self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
-                self.write_word_seg(bus, self.ea_seg, offset, value);
+                self.write_word_seg(bus, self.ea_seg, offset, value)?;
             }
         }
         self.clk_modrm_word(modrm, register_cycles, memory_cycles, 2);
+        Ok(())
     }
 
     fn bit_modify_imm(
@@ -350,7 +348,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         toggle: bool,
         register_cycles: i32,
         memory_cycles: i32,
-    ) {
+    ) -> Step {
         let modrm = self.fetch(bus);
         let write_back = clear || set || toggle;
 
@@ -385,9 +383,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     } else {
                         self.read_dword_linear(bus, address)
                     };
-                    let Some(mut value) = read_result else {
-                        return;
-                    };
+                    let mut value = read_result?;
                     let bit = 1u32 << bit_index;
                     self.flags.carry_val = u32::from(value & bit != 0);
                     if clear {
@@ -401,7 +397,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     }
                     self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
                     if write_back {
-                        self.write_dword_linear(bus, address, value);
+                        self.write_dword_linear(bus, address, value)?;
                     }
                 } else {
                     let read_result = if write_back {
@@ -409,9 +405,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     } else {
                         self.seg_read_dword(bus)
                     };
-                    let Some(mut value) = read_result else {
-                        return;
-                    };
+                    let mut value = read_result?;
                     let bit = 1u32 << bit_index;
                     self.flags.carry_val = u32::from(value & bit != 0);
                     if clear {
@@ -425,7 +419,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     }
                     self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
                     if write_back {
-                        self.seg_write_dword(bus, value);
+                        self.seg_write_dword(bus, value)?;
                     }
                 }
             }
@@ -459,9 +453,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 } else {
                     self.read_word_linear(bus, address)
                 };
-                let Some(mut value) = read_result else {
-                    return;
-                };
+                let mut value = read_result?;
                 let bit = 1u16 << bit_index;
                 self.flags.carry_val = u32::from(value & bit != 0);
                 if clear {
@@ -475,7 +467,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
                 self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
                 if write_back {
-                    self.write_word_linear(bus, address, value);
+                    self.write_word_linear(bus, address, value)?;
                 }
             } else {
                 let read_result = if write_back {
@@ -483,9 +475,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 } else {
                     self.seg_read_word(bus)
                 };
-                let Some(mut value) = read_result else {
-                    return;
-                };
+                let mut value = read_result?;
                 let bit = 1u16 << bit_index;
                 self.flags.carry_val = u32::from(value & bit != 0);
                 if clear {
@@ -499,19 +489,20 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
                 self.flags.overflow_val = if self.flags.carry_val != 0 { 0x0800 } else { 0 };
                 if write_back {
-                    self.seg_write_word(bus, value);
+                    self.seg_write_word(bus, value)?;
                 }
             }
         }
 
         self.clk_modrm_word(modrm, register_cycles, memory_cycles, 2);
+        Ok(())
     }
 
-    fn group_ba(&mut self, bus: &mut impl common::Bus) {
+    fn group_ba(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.lock_prefix && (modrm >> 3) & 7 == 4 {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
         self.ip = self.ip.wrapping_sub(1);
         match (modrm >> 3) & 7 {
@@ -522,7 +513,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 false,
                 Self::timing(3, 3),
                 Self::timing(6, 3),
-            ),
+            )?,
             5 => self.bit_modify_imm(
                 bus,
                 false,
@@ -530,7 +521,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 false,
                 Self::timing(6, 6),
                 Self::timing(8, 8),
-            ),
+            )?,
             6 => self.bit_modify_imm(
                 bus,
                 true,
@@ -538,7 +529,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 false,
                 Self::timing(6, 6),
                 Self::timing(8, 8),
-            ),
+            )?,
             7 => self.bit_modify_imm(
                 bus,
                 false,
@@ -546,18 +537,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 true,
                 Self::timing(6, 6),
                 Self::timing(8, 8),
-            ),
-            _ => self.raise_fault(6, bus),
+            )?,
+            _ => self.raise_fault(6, bus)?,
         }
+        Ok(())
     }
 
-    fn shld_imm(&mut self, bus: &mut impl common::Bus) {
+    fn shld_imm(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword(modrm, bus)?;
             let count = self.fetch(bus) & 0x1F;
             if count != 0 {
                 let result = (dst << count) | (src >> (32 - count));
@@ -565,14 +555,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.flags.overflow_val = ((result >> 31) & 1) ^ self.flags.carry_val;
                 self.flags.aux_val = 0x10;
                 self.flags.set_szpf_dword(result);
-                self.putback_rm_dword(modrm, result, bus);
+                self.putback_rm_dword(modrm, result, bus)?;
             }
             self.clk_modrm_word(modrm, Self::timing(3, 2), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm)) as u32;
-            let Some(dst) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word(modrm, bus)?;
             let dst = dst as u32;
             let count = self.fetch(bus) & 0x1F;
             if count != 0 {
@@ -591,19 +579,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.flags.overflow_val = ((result >> 15) & 1) ^ self.flags.carry_val;
                 self.flags.aux_val = 0x10;
                 self.flags.set_szpf_word(result);
-                self.putback_rm_word(modrm, result as u16, bus);
+                self.putback_rm_word(modrm, result as u16, bus)?;
             }
             self.clk_modrm_word(modrm, Self::timing(3, 2), Self::timing(7, 3), 2);
         }
+        Ok(())
     }
 
-    fn shld_cl(&mut self, bus: &mut impl common::Bus) {
+    fn shld_cl(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword(modrm, bus)?;
             let count = self.regs.byte(ByteReg::CL) & 0x1F;
             if count != 0 {
                 let result = (dst << count) | (src >> (32 - count));
@@ -611,14 +598,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.flags.overflow_val = ((result >> 31) & 1) ^ self.flags.carry_val;
                 self.flags.aux_val = 0x10;
                 self.flags.set_szpf_dword(result);
-                self.putback_rm_dword(modrm, result, bus);
+                self.putback_rm_dword(modrm, result, bus)?;
             }
             self.clk_modrm_word(modrm, Self::timing(3, 3), Self::timing(7, 4), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm)) as u32;
-            let Some(dst) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word(modrm, bus)?;
             let dst = dst as u32;
             let count = self.regs.byte(ByteReg::CL) & 0x1F;
             if count != 0 {
@@ -637,19 +622,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.flags.overflow_val = ((result >> 15) & 1) ^ self.flags.carry_val;
                 self.flags.aux_val = 0x10;
                 self.flags.set_szpf_word(result);
-                self.putback_rm_word(modrm, result as u16, bus);
+                self.putback_rm_word(modrm, result as u16, bus)?;
             }
             self.clk_modrm_word(modrm, Self::timing(3, 3), Self::timing(7, 4), 2);
         }
+        Ok(())
     }
 
-    fn shrd_imm(&mut self, bus: &mut impl common::Bus) {
+    fn shrd_imm(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword(modrm, bus)?;
             let count = self.fetch(bus) & 0x1F;
             if count != 0 {
                 let result = (dst >> count) | (src << (32 - count));
@@ -657,14 +641,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.flags.overflow_val = ((result >> 31) ^ (result >> 30)) & 1;
                 self.flags.aux_val = 0x10;
                 self.flags.set_szpf_dword(result);
-                self.putback_rm_dword(modrm, result, bus);
+                self.putback_rm_dword(modrm, result, bus)?;
             }
             self.clk_modrm_word(modrm, Self::timing(3, 2), Self::timing(7, 3), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm)) as u32;
-            let Some(dst) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word(modrm, bus)?;
             let dst = dst as u32;
             let count = self.fetch(bus) & 0x1F;
             if count != 0 {
@@ -685,19 +667,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.flags.overflow_val = ((result >> 15) ^ (result >> 14)) & 1;
                 self.flags.aux_val = 0x10;
                 self.flags.set_szpf_word(result);
-                self.putback_rm_word(modrm, result as u16, bus);
+                self.putback_rm_word(modrm, result as u16, bus)?;
             }
             self.clk_modrm_word(modrm, Self::timing(3, 2), Self::timing(7, 3), 2);
         }
+        Ok(())
     }
 
-    fn shrd_cl(&mut self, bus: &mut impl common::Bus) {
+    fn shrd_cl(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword(modrm, bus)?;
             let count = self.regs.byte(ByteReg::CL) & 0x1F;
             if count != 0 {
                 let result = (dst >> count) | (src << (32 - count));
@@ -705,14 +686,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.flags.overflow_val = ((result >> 31) ^ (result >> 30)) & 1;
                 self.flags.aux_val = 0x10;
                 self.flags.set_szpf_dword(result);
-                self.putback_rm_dword(modrm, result, bus);
+                self.putback_rm_dword(modrm, result, bus)?;
             }
             self.clk_modrm_word(modrm, Self::timing(3, 3), Self::timing(7, 4), 4);
         } else {
             let src = self.regs.word(self.reg_word(modrm)) as u32;
-            let Some(dst) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word(modrm, bus)?;
             let dst = dst as u32;
             let count = self.regs.byte(ByteReg::CL) & 0x1F;
             if count != 0 {
@@ -733,18 +712,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.flags.overflow_val = ((result >> 15) ^ (result >> 14)) & 1;
                 self.flags.aux_val = 0x10;
                 self.flags.set_szpf_word(result);
-                self.putback_rm_word(modrm, result as u16, bus);
+                self.putback_rm_word(modrm, result as u16, bus)?;
             }
             self.clk_modrm_word(modrm, Self::timing(3, 3), Self::timing(7, 4), 2);
         }
+        Ok(())
     }
 
-    fn imul_reg_rm(&mut self, bus: &mut impl common::Bus) {
+    fn imul_reg_rm(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.operand_size_override {
-            let Some(src) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_dword(modrm, bus)?;
             let src = src as i32 as i64;
             let dst = self.regs.dword(self.reg_dword(modrm)) as i32 as i64;
             let result = dst * src;
@@ -754,9 +732,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.flags.overflow_val = self.flags.carry_val;
             self.clk_modrm_word(modrm, Self::timing(38, 13), Self::timing(41, 13), 2);
         } else {
-            let Some(src) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let src = self.get_rm_word(modrm, bus)?;
             let src = src as i16 as i32;
             let dst = self.regs.word(self.reg_word(modrm)) as i16 as i32;
             let result = dst * src;
@@ -766,13 +742,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.flags.overflow_val = self.flags.carry_val;
             self.clk_modrm_word(modrm, Self::timing(22, 13), Self::timing(25, 13), 2);
         }
+        Ok(())
     }
 
-    fn lss(&mut self, bus: &mut impl common::Bus) {
+    fn lss(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if modrm >= 0xC0 {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
 
         self.calc_ea(modrm, bus);
@@ -783,51 +760,40 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let initial_ip = self.ip;
         let initial_ip_upper = self.ip_upper;
         if self.operand_size_override {
-            let Some(offset) = self.seg_read_dword(bus) else {
-                return;
-            };
-            let Some(seg) = self.seg_read_word_at(bus, 4) else {
-                return;
-            };
+            let offset = self.seg_read_dword(bus)?;
+            let seg = self.seg_read_word_at(bus, 4)?;
             if self.sregs[SegReg32::CS as usize] != initial_cs
                 || self.ip != initial_ip
                 || self.ip_upper != initial_ip_upper
             {
-                return;
+                return Ok(());
             }
-            if !self.load_segment(SegReg32::SS, seg, bus) {
-                return;
-            }
+            self.load_segment(SegReg32::SS, seg, bus)?;
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, offset);
         } else {
-            let Some(offset) = self.seg_read_word(bus) else {
-                return;
-            };
-            let Some(seg) = self.seg_read_word_at(bus, 2) else {
-                return;
-            };
+            let offset = self.seg_read_word(bus)?;
+            let seg = self.seg_read_word_at(bus, 2)?;
             if self.sregs[SegReg32::CS as usize] != initial_cs
                 || self.ip != initial_ip
                 || self.ip_upper != initial_ip_upper
             {
-                return;
+                return Ok(());
             }
-            if !self.load_segment(SegReg32::SS, seg, bus) {
-                return;
-            }
+            self.load_segment(SegReg32::SS, seg, bus)?;
             let reg = self.reg_word(modrm);
             self.regs.set_word(reg, offset);
         }
         self.inhibit_all = 1;
         self.clk(Self::timing(7, 6));
+        Ok(())
     }
 
-    fn lfs(&mut self, bus: &mut impl common::Bus) {
+    fn lfs(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if modrm >= 0xC0 {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
 
         self.calc_ea(modrm, bus);
@@ -835,50 +801,39 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let initial_ip = self.ip;
         let initial_ip_upper = self.ip_upper;
         if self.operand_size_override {
-            let Some(offset) = self.seg_read_dword(bus) else {
-                return;
-            };
-            let Some(seg) = self.seg_read_word_at(bus, 4) else {
-                return;
-            };
+            let offset = self.seg_read_dword(bus)?;
+            let seg = self.seg_read_word_at(bus, 4)?;
             if self.sregs[SegReg32::CS as usize] != initial_cs
                 || self.ip != initial_ip
                 || self.ip_upper != initial_ip_upper
             {
-                return;
+                return Ok(());
             }
-            if !self.load_segment(SegReg32::FS, seg, bus) {
-                return;
-            }
+            self.load_segment(SegReg32::FS, seg, bus)?;
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, offset);
         } else {
-            let Some(offset) = self.seg_read_word(bus) else {
-                return;
-            };
-            let Some(seg) = self.seg_read_word_at(bus, 2) else {
-                return;
-            };
+            let offset = self.seg_read_word(bus)?;
+            let seg = self.seg_read_word_at(bus, 2)?;
             if self.sregs[SegReg32::CS as usize] != initial_cs
                 || self.ip != initial_ip
                 || self.ip_upper != initial_ip_upper
             {
-                return;
+                return Ok(());
             }
-            if !self.load_segment(SegReg32::FS, seg, bus) {
-                return;
-            }
+            self.load_segment(SegReg32::FS, seg, bus)?;
             let reg = self.reg_word(modrm);
             self.regs.set_word(reg, offset);
         }
         self.clk(Self::timing(7, 6));
+        Ok(())
     }
 
-    fn lgs(&mut self, bus: &mut impl common::Bus) {
+    fn lgs(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if modrm >= 0xC0 {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
 
         self.calc_ea(modrm, bus);
@@ -886,50 +841,37 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let initial_ip = self.ip;
         let initial_ip_upper = self.ip_upper;
         if self.operand_size_override {
-            let Some(offset) = self.seg_read_dword(bus) else {
-                return;
-            };
-            let Some(seg) = self.seg_read_word_at(bus, 4) else {
-                return;
-            };
+            let offset = self.seg_read_dword(bus)?;
+            let seg = self.seg_read_word_at(bus, 4)?;
             if self.sregs[SegReg32::CS as usize] != initial_cs
                 || self.ip != initial_ip
                 || self.ip_upper != initial_ip_upper
             {
-                return;
+                return Ok(());
             }
-            if !self.load_segment(SegReg32::GS, seg, bus) {
-                return;
-            }
+            self.load_segment(SegReg32::GS, seg, bus)?;
             let reg = self.reg_dword(modrm);
             self.regs.set_dword(reg, offset);
         } else {
-            let Some(offset) = self.seg_read_word(bus) else {
-                return;
-            };
-            let Some(seg) = self.seg_read_word_at(bus, 2) else {
-                return;
-            };
+            let offset = self.seg_read_word(bus)?;
+            let seg = self.seg_read_word_at(bus, 2)?;
             if self.sregs[SegReg32::CS as usize] != initial_cs
                 || self.ip != initial_ip
                 || self.ip_upper != initial_ip_upper
             {
-                return;
+                return Ok(());
             }
-            if !self.load_segment(SegReg32::GS, seg, bus) {
-                return;
-            }
+            self.load_segment(SegReg32::GS, seg, bus)?;
             let reg = self.reg_word(modrm);
             self.regs.set_word(reg, offset);
         }
         self.clk(Self::timing(7, 6));
+        Ok(())
     }
 
-    fn movzx_rm8(&mut self, bus: &mut impl common::Bus) {
+    fn movzx_rm8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
-        let Some(value) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let value = self.get_rm_byte(modrm, bus)?;
         let value = value as u32;
         if self.operand_size_override {
             let reg = self.reg_dword(modrm);
@@ -939,13 +881,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.regs.set_word(reg, value as u16);
         }
         self.clk_modrm(modrm, Self::timing(3, 3), Self::timing(6, 3));
+        Ok(())
     }
 
-    fn movzx_rm16(&mut self, bus: &mut impl common::Bus) {
+    fn movzx_rm16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
-        let Some(value) = self.get_rm_word(modrm, bus) else {
-            return;
-        };
+        let value = self.get_rm_word(modrm, bus)?;
         let value = value as u32;
         if self.operand_size_override {
             let reg = self.reg_dword(modrm);
@@ -955,13 +896,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.regs.set_word(reg, value as u16);
         }
         self.clk_modrm_word(modrm, Self::timing(3, 3), Self::timing(6, 3), 1);
+        Ok(())
     }
 
-    fn movsx_rm8(&mut self, bus: &mut impl common::Bus) {
+    fn movsx_rm8(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
-        let Some(value) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let value = self.get_rm_byte(modrm, bus)?;
         let value = value as i8 as i32;
         if self.operand_size_override {
             let reg = self.reg_dword(modrm);
@@ -971,13 +911,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.regs.set_word(reg, value as u16);
         }
         self.clk_modrm(modrm, Self::timing(3, 3), Self::timing(6, 3));
+        Ok(())
     }
 
-    fn movsx_rm16(&mut self, bus: &mut impl common::Bus) {
+    fn movsx_rm16(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
-        let Some(value) = self.get_rm_word(modrm, bus) else {
-            return;
-        };
+        let value = self.get_rm_word(modrm, bus)?;
         let value = value as i16 as i32;
         if self.operand_size_override {
             let reg = self.reg_dword(modrm);
@@ -987,15 +926,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.regs.set_word(reg, value as u16);
         }
         self.clk_modrm_word(modrm, Self::timing(3, 3), Self::timing(6, 3), 1);
+        Ok(())
     }
 
-    fn bsf(&mut self, bus: &mut impl common::Bus) {
+    fn bsf(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let n: u32;
         if self.operand_size_override {
-            let Some(value) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let value = self.get_rm_dword(modrm, bus)?;
             if value == 0 {
                 self.flags.zero_val = 0;
                 n = 32;
@@ -1007,9 +945,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 n = index + 1;
             }
         } else {
-            let Some(value) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let value = self.get_rm_word(modrm, bus)?;
             if value == 0 {
                 self.flags.zero_val = 0;
                 n = 16;
@@ -1028,15 +964,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 unreachable!("Unhandled CPU_MODEL")
             }
         }
+        Ok(())
     }
 
-    fn bsr(&mut self, bus: &mut impl common::Bus) {
+    fn bsr(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let n: u32;
         if self.operand_size_override {
-            let Some(value) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let value = self.get_rm_dword(modrm, bus)?;
             if value == 0 {
                 self.flags.zero_val = 0;
                 n = 32;
@@ -1048,9 +983,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 n = value.leading_zeros() + 1;
             }
         } else {
-            let Some(value) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let value = self.get_rm_word(modrm, bus)?;
             if value == 0 {
                 self.flags.zero_val = 0;
                 n = 16;
@@ -1069,65 +1002,61 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 unreachable!("Unhandled CPU_MODEL")
             }
         }
+        Ok(())
     }
 
-    fn group_0f00(&mut self, bus: &mut impl common::Bus) {
+    fn group_0f00(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if !self.is_protected_mode() || self.is_virtual_mode() {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
         match (modrm >> 3) & 7 {
             0 => {
                 // SLDT
                 if self.operand_size_override && modrm >= 0xC0 {
-                    self.put_rm_dword(modrm, self.ldtr as u32, bus);
+                    self.put_rm_dword(modrm, self.ldtr as u32, bus)?;
                 } else {
-                    self.put_rm_word(modrm, self.ldtr, bus);
+                    self.put_rm_word(modrm, self.ldtr, bus)?;
                 }
                 self.clk_modrm(modrm, Self::timing(2, 2), Self::timing(3, 3));
             }
             1 => {
                 // STR
                 if self.operand_size_override && modrm >= 0xC0 {
-                    self.put_rm_dword(modrm, self.tr as u32, bus);
+                    self.put_rm_dword(modrm, self.tr as u32, bus)?;
                 } else {
-                    self.put_rm_word(modrm, self.tr, bus);
+                    self.put_rm_word(modrm, self.tr, bus)?;
                 }
                 self.clk_modrm(modrm, Self::timing(2, 2), Self::timing(3, 3));
             }
             2 => {
                 // LLDT
                 if self.cpl() != 0 {
-                    self.raise_fault_with_code(13, 0, bus);
-                    return;
+                    self.raise_fault_with_code(13, 0, bus)?;
+                    return Ok(());
                 }
-                let Some(selector) = self.get_rm_word(modrm, bus) else {
-                    return;
-                };
+                let selector = self.get_rm_word(modrm, bus)?;
                 if selector & 0xFFFC == 0 {
                     self.ldtr = selector;
                     self.ldtr_base = 0;
                     self.ldtr_limit = 0;
                 } else {
                     if selector & 0x0004 != 0 {
-                        self.raise_fault_with_code(13, selector & 0xFFFC, bus);
-                        return;
+                        self.raise_fault_with_code(13, selector & 0xFFFC, bus)?;
+                        return Ok(());
                     }
-                    let Some(descriptor) = self.decode_descriptor(selector, bus) else {
-                        if !self.fault_pending {
-                            self.raise_fault_with_code(13, selector & 0xFFFC, bus);
-                        }
-                        return;
+                    let Some(descriptor) = self.decode_descriptor(selector, bus)? else {
+                        return self.raise_fault_with_code(13, selector & 0xFFFC, bus);
                     };
                     let desc_type = descriptor.rights & 0x0F;
                     if descriptor.rights & 0x10 != 0 || desc_type != 0x02 {
-                        self.raise_fault_with_code(13, selector & 0xFFFC, bus);
-                        return;
+                        self.raise_fault_with_code(13, selector & 0xFFFC, bus)?;
+                        return Ok(());
                     }
                     if descriptor.rights & 0x80 == 0 {
-                        self.raise_fault_with_code(11, selector & 0xFFFC, bus);
-                        return;
+                        self.raise_fault_with_code(11, selector & 0xFFFC, bus)?;
+                        return Ok(());
                     }
                     self.ldtr = selector;
                     self.ldtr_base = descriptor.base;
@@ -1138,48 +1067,41 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             3 => {
                 // LTR - accepts available 286 TSS (type 1) and available 386 TSS (type 9)
                 if self.cpl() != 0 {
-                    self.raise_fault_with_code(13, 0, bus);
-                    return;
+                    self.raise_fault_with_code(13, 0, bus)?;
+                    return Ok(());
                 }
-                let Some(selector) = self.get_rm_word(modrm, bus) else {
-                    return;
-                };
+                let selector = self.get_rm_word(modrm, bus)?;
                 if selector & 0xFFFC == 0 {
-                    self.raise_fault_with_code(13, 0, bus);
-                    return;
+                    self.raise_fault_with_code(13, 0, bus)?;
+                    return Ok(());
                 }
                 if selector & 0x0004 != 0 {
-                    self.raise_fault_with_code(13, selector & 0xFFFC, bus);
-                    return;
+                    self.raise_fault_with_code(13, selector & 0xFFFC, bus)?;
+                    return Ok(());
                 }
-                let Some(descriptor) = self.decode_descriptor(selector, bus) else {
-                    if !self.fault_pending {
-                        self.raise_fault_with_code(13, selector & 0xFFFC, bus);
-                    }
-                    return;
+                let Some(descriptor) = self.decode_descriptor(selector, bus)? else {
+                    return self.raise_fault_with_code(13, selector & 0xFFFC, bus);
                 };
                 let desc_type = descriptor.rights & 0x0F;
                 if descriptor.rights & 0x10 != 0 || (desc_type != 0x01 && desc_type != 0x09) {
-                    self.raise_fault_with_code(13, selector & 0xFFFC, bus);
-                    return;
+                    self.raise_fault_with_code(13, selector & 0xFFFC, bus)?;
+                    return Ok(());
                 }
                 if descriptor.rights & 0x80 == 0 {
-                    self.raise_fault_with_code(11, selector & 0xFFFC, bus);
-                    return;
+                    self.raise_fault_with_code(11, selector & 0xFFFC, bus)?;
+                    return Ok(());
                 }
                 let min_limit: u32 = if desc_type == 0x09 { 103 } else { 43 };
                 if descriptor.limit < min_limit {
-                    self.raise_fault_with_code(10, selector & 0xFFFC, bus);
-                    return;
+                    self.raise_fault_with_code(10, selector & 0xFFFC, bus)?;
+                    return Ok(());
                 }
                 // Probe the descriptor byte's physical address before any TR
                 // commit, so a fault during the busy-bit RMW leaves TR
                 // unchanged and the instruction is restartable.
                 let busy_bit_phys = if let Some(addr) = self.descriptor_addr_checked(selector) {
                     let linear = addr.wrapping_add(5);
-                    let Some(phys) = self.translate_linear(linear, true, bus) else {
-                        return;
-                    };
+                    let phys = self.translate_linear(linear, true, bus)?;
                     Some(phys)
                 } else {
                     None
@@ -1196,72 +1118,65 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
             4 => {
                 // VERR
-                let Some(selector) = self.get_rm_word(modrm, bus) else {
-                    return;
-                };
+                let selector = self.get_rm_word(modrm, bus)?;
                 let readable = self.verr_accessible(selector, bus);
                 self.flags.zero_val = if readable { 0 } else { 1 };
                 self.clk_modrm(modrm, Self::timing(14, 11), Self::timing(16, 11));
             }
             5 => {
                 // VERW
-                let Some(selector) = self.get_rm_word(modrm, bus) else {
-                    return;
-                };
+                let selector = self.get_rm_word(modrm, bus)?;
                 let writable = self.selector_accessible(selector, true, bus);
                 self.flags.zero_val = if writable { 0 } else { 1 };
                 self.clk_modrm(modrm, Self::timing(14, 11), Self::timing(16, 11));
             }
-            _ => self.raise_fault(6, bus),
+            _ => self.raise_fault(6, bus)?,
         }
+        Ok(())
     }
 
-    fn group_0f01(&mut self, bus: &mut impl common::Bus) {
+    fn group_0f01(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         match (modrm >> 3) & 7 {
             0 => {
                 // SGDT - store full 32-bit base on 386
                 if modrm >= 0xC0 {
-                    self.raise_fault(6, bus);
-                    return;
+                    self.raise_fault(6, bus)?;
+                    return Ok(());
                 }
                 self.calc_ea(modrm, bus);
                 let gdt_limit = self.gdt_limit;
                 let gdt_base = self.gdt_base;
-                self.write_word_linear(bus, self.seg_addr(0), gdt_limit);
-                self.write_dword_linear(bus, self.seg_addr(2), gdt_base);
+                self.write_word_linear(bus, self.seg_addr(0), gdt_limit)?;
+                self.write_dword_linear(bus, self.seg_addr(2), gdt_base)?;
                 self.clk(Self::timing(11, 10));
             }
             1 => {
                 // SIDT - store full 32-bit base on 386
                 if modrm >= 0xC0 {
-                    self.raise_fault(6, bus);
-                    return;
+                    self.raise_fault(6, bus)?;
+                    return Ok(());
                 }
                 self.calc_ea(modrm, bus);
                 let idt_limit = self.idt_limit;
                 let idt_base = self.idt_base;
-                self.write_word_linear(bus, self.seg_addr(0), idt_limit);
-                self.write_dword_linear(bus, self.seg_addr(2), idt_base);
+                self.write_word_linear(bus, self.seg_addr(0), idt_limit)?;
+                self.write_dword_linear(bus, self.seg_addr(2), idt_base)?;
                 self.clk(Self::timing(12, 10));
             }
             2 => {
                 // LGDT - load full 32-bit base on 386
                 if modrm >= 0xC0 {
-                    self.raise_fault(6, bus);
-                    return;
+                    self.raise_fault(6, bus)?;
+                    return Ok(());
                 }
                 if self.is_protected_mode() && self.cpl() != 0 {
-                    self.raise_fault_with_code(13, 0, bus);
-                    return;
+                    self.raise_fault_with_code(13, 0, bus)?;
+                    return Ok(());
                 }
                 self.calc_ea(modrm, bus);
-                let Some(limit) = self.read_word_linear(bus, self.seg_addr(0)) else {
-                    return;
-                };
-                let Some(base) = self.read_dword_linear(bus, self.seg_addr(2)) else {
-                    return;
-                };
+                let limit = self.read_word_linear(bus, self.seg_addr(0))?;
+                let base = self.read_dword_linear(bus, self.seg_addr(2))?;
                 self.gdt_base = base;
                 self.gdt_limit = limit;
                 self.clk(Self::timing(11, 12));
@@ -1269,20 +1184,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             3 => {
                 // LIDT - load full 32-bit base on 386
                 if modrm >= 0xC0 {
-                    self.raise_fault(6, bus);
-                    return;
+                    self.raise_fault(6, bus)?;
+                    return Ok(());
                 }
                 if self.is_protected_mode() && self.cpl() != 0 {
-                    self.raise_fault_with_code(13, 0, bus);
-                    return;
+                    self.raise_fault_with_code(13, 0, bus)?;
+                    return Ok(());
                 }
                 self.calc_ea(modrm, bus);
-                let Some(limit) = self.read_word_linear(bus, self.seg_addr(0)) else {
-                    return;
-                };
-                let Some(base) = self.read_dword_linear(bus, self.seg_addr(2)) else {
-                    return;
-                };
+                let limit = self.read_word_linear(bus, self.seg_addr(0))?;
+                let base = self.read_dword_linear(bus, self.seg_addr(2))?;
                 self.idt_base = base;
                 self.idt_limit = limit;
                 self.clk(Self::timing(12, 12));
@@ -1303,31 +1214,29 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                         self.regs.set_word(reg, mws);
                     }
                 } else {
-                    self.put_rm_word(modrm, mws, bus);
+                    self.put_rm_word(modrm, mws, bus)?;
                 }
                 self.clk_modrm(modrm, Self::timing(2, 2), Self::timing(3, 3));
             }
             6 => {
                 // LMSW - only writes low 4 bits of CR0 (PE/MP/EM/TS), cannot clear PE
                 if self.is_protected_mode() && self.cpl() != 0 {
-                    self.raise_fault_with_code(13, 0, bus);
-                    return;
+                    self.raise_fault_with_code(13, 0, bus)?;
+                    return Ok(());
                 }
-                let Some(value) = self.get_rm_word(modrm, bus) else {
-                    return;
-                };
+                let value = self.get_rm_word(modrm, bus)?;
                 self.cr0 = (self.cr0 & 0xFFFF_FFF0) | (value as u32 & 0x000F) | (self.cr0 & 1);
                 self.clk_modrm(modrm, Self::timing(10, 13), Self::timing(13, 13));
             }
             7 if CPU_MODEL >= CPU_MODEL_486 => {
                 // INVLPG - invalidate TLB entry for the given memory address.
                 if modrm >= 0xC0 {
-                    self.raise_fault(6, bus);
-                    return;
+                    self.raise_fault(6, bus)?;
+                    return Ok(());
                 }
                 if self.is_protected_mode() && self.cpl() != 0 {
-                    self.raise_fault_with_code(13, 0, bus);
-                    return;
+                    self.raise_fault_with_code(13, 0, bus)?;
+                    return Ok(());
                 }
                 self.calc_ea(modrm, bus);
                 let linear = self.ea;
@@ -1339,22 +1248,21 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.fetch_page_valid = false;
                 self.clk(Self::timing(0, 12));
             }
-            _ => self.raise_fault(6, bus),
+            _ => self.raise_fault(6, bus)?,
         }
+        Ok(())
     }
 
-    fn lar(&mut self, bus: &mut impl common::Bus) {
+    fn lar(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if !self.is_protected_mode() || self.is_virtual_mode() {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
-        let Some(selector) = self.get_rm_word(modrm, bus) else {
-            return;
-        };
+        let selector = self.get_rm_word(modrm, bus)?;
         self.flags.zero_val = 1; // ZF=0: invalid by default
         if selector & 0xFFFC != 0
-            && let Some(descriptor) = self.decode_descriptor(selector, bus)
+            && let Ok(Some(descriptor)) = self.decode_descriptor(selector, bus)
         {
             let rights = descriptor.rights;
             let desc_type = rights & 0x1F;
@@ -1389,20 +1297,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
         }
         self.clk_modrm(modrm, Self::timing(14, 11), Self::timing(16, 11));
+        Ok(())
     }
 
-    fn lsl_instr(&mut self, bus: &mut impl common::Bus) {
+    fn lsl_instr(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if !self.is_protected_mode() || self.is_virtual_mode() {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
-        let Some(selector) = self.get_rm_word(modrm, bus) else {
-            return;
-        };
+        let selector = self.get_rm_word(modrm, bus)?;
         self.flags.zero_val = 1; // ZF=0: invalid by default
         if selector & 0xFFFC != 0
-            && let Some(descriptor) = self.decode_descriptor(selector, bus)
+            && let Ok(Some(descriptor)) = self.decode_descriptor(selector, bus)
         {
             let rights = descriptor.rights;
             let desc_type = rights & 0x1F;
@@ -1435,13 +1342,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
         }
         self.clk_modrm(modrm, Self::timing(14, 10), Self::timing(16, 10));
+        Ok(())
     }
 
     fn verr_accessible(&mut self, selector: u16, bus: &mut impl common::Bus) -> bool {
         if selector & 0xFFFC == 0 {
             return false;
         }
-        let Some(descriptor) = self.decode_descriptor(selector, bus) else {
+        let Ok(Some(descriptor)) = self.decode_descriptor(selector, bus) else {
             return false;
         };
         let rights = descriptor.rights;
@@ -1466,7 +1374,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         if selector & 0xFFFC == 0 {
             return false;
         }
-        let Some(descriptor) = self.decode_descriptor(selector, bus) else {
+        let Ok(Some(descriptor)) = self.decode_descriptor(selector, bus) else {
             return false;
         };
         let rights = descriptor.rights;
@@ -1486,10 +1394,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     }
 
     /// MOV r32, CRn (0F 20) - read from control register.
-    fn mov_r32_cr(&mut self, bus: &mut impl common::Bus) {
+    fn mov_r32_cr(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.is_protected_mode() && self.cpl() != 0 {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            self.raise_fault_with_code(13, 0, bus)?;
+            return Ok(());
         }
         let modrm = self.fetch(bus);
         let cr_num = (modrm >> 3) & 7;
@@ -1498,20 +1406,21 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             2 => self.cr2,
             3 => self.cr3,
             _ => {
-                self.raise_fault(6, bus);
-                return;
+                self.raise_fault(6, bus)?;
+                return Ok(());
             }
         };
         let reg = self.rm_dword(modrm);
         self.regs.set_dword(reg, value);
         self.clk(Self::timing(6, 4));
+        Ok(())
     }
 
     /// MOV r32, DRn (0F 21) - read from debug register.
-    fn mov_r32_dr(&mut self, bus: &mut impl common::Bus) {
+    fn mov_r32_dr(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.is_protected_mode() && self.cpl() != 0 {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            self.raise_fault_with_code(13, 0, bus)?;
+            return Ok(());
         }
         let modrm = self.fetch(bus);
         let dr_num = (modrm >> 3) & 7;
@@ -1529,16 +1438,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let reg = self.rm_dword(modrm);
         self.regs.set_dword(reg, value);
         self.clk(Self::timing(22, 9));
+        Ok(())
     }
 
     /// MOV CRn, r32 (0F 22) - write to control register.
     /// On a 386, CR0 writable bits are: PE(0), MP(1), EM(2), TS(3), ET(4), PG(31).
     /// On a 486, NE(5), WP(16), AM(18), NW(29) and CD(30) are also writable.
     /// Other bits are reserved and always read as 0.
-    fn mov_cr_r32(&mut self, bus: &mut impl common::Bus) {
+    fn mov_cr_r32(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.is_protected_mode() && self.cpl() != 0 {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            self.raise_fault_with_code(13, 0, bus)?;
+            return Ok(());
         }
         let modrm = self.fetch(bus);
         let cr_num = (modrm >> 3) & 7;
@@ -1568,16 +1478,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.clk(Self::timing(5, 4));
             }
             _ => {
-                self.raise_fault(6, bus);
+                self.raise_fault(6, bus)?;
             }
         }
+        Ok(())
     }
 
     /// MOV DRn, r32 (0F 23) - write to debug register.
-    fn mov_dr_r32(&mut self, bus: &mut impl common::Bus) {
+    fn mov_dr_r32(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.is_protected_mode() && self.cpl() != 0 {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            self.raise_fault_with_code(13, 0, bus)?;
+            return Ok(());
         }
         let modrm = self.fetch(bus);
         let dr_num = (modrm >> 3) & 7;
@@ -1594,26 +1505,29 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             _ => unreachable!(),
         }
         self.clk(Self::timing(22, 10));
+        Ok(())
     }
 
-    fn invd(&mut self, bus: &mut impl common::Bus) {
+    fn invd(&mut self, bus: &mut impl common::Bus) -> Step {
         // INVD - invalidate cache (no cache simulation, but still #GP at
         // CPL != 0 or in VM86, per 80486 PRM Chapter 26).
         if self.is_protected_mode() && (self.is_virtual_mode() || self.cpl() != 0) {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            self.raise_fault_with_code(13, 0, bus)?;
+            return Ok(());
         }
         self.clk(4);
+        Ok(())
     }
 
-    fn wbinvd(&mut self, bus: &mut impl common::Bus) {
+    fn wbinvd(&mut self, bus: &mut impl common::Bus) -> Step {
         // WBINVD - write-back and invalidate cache (no cache simulation,
         // but still #GP at CPL != 0 or in VM86 per 80486 PRM Chapter 26).
         if self.is_protected_mode() && (self.is_virtual_mode() || self.cpl() != 0) {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            self.raise_fault_with_code(13, 0, bus)?;
+            return Ok(());
         }
         self.clk(5);
+        Ok(())
     }
 
     fn bswap(&mut self, opcode: u8) {
@@ -1624,108 +1538,82 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(1);
     }
 
-    fn cmpxchg_byte(&mut self, bus: &mut impl common::Bus) {
+    fn cmpxchg_byte(&mut self, bus: &mut impl common::Bus) -> Step {
         // CMPXCHG r/m8,r8 - compare AL with r/m8; if equal, load r8 into r/m8.
         let modrm = self.fetch(bus);
         let src = self.regs.byte(self.reg_byte(modrm));
-        let Some(dst) = self.get_rm_byte_for_update(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte_for_update(modrm, bus)?;
         let al = self.regs.byte(ByteReg::AL);
         self.alu_sub_byte(al, dst);
         if self.flags.zf() {
-            self.putback_rm_byte(modrm, src, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_byte(modrm, src, bus)?;
         } else {
             self.regs.set_byte(ByteReg::AL, dst);
         }
         self.clk_modrm(modrm, 6, 7);
+        Ok(())
     }
 
-    fn cmpxchg_word(&mut self, bus: &mut impl common::Bus) {
+    fn cmpxchg_word(&mut self, bus: &mut impl common::Bus) -> Step {
         // CMPXCHG r/m16,r16 or CMPXCHG r/m32,r32 (with operand-size override).
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src = self.regs.dword(self.reg_dword(modrm));
-            let Some(dst) = self.get_rm_dword_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword_for_update(modrm, bus)?;
             let eax = self.regs.dword(DwordReg::EAX);
             self.alu_sub_dword(eax, dst);
             if self.flags.zf() {
-                self.putback_rm_dword(modrm, src, bus);
-                if self.fault_pending {
-                    return;
-                }
+                self.putback_rm_dword(modrm, src, bus)?;
             } else {
                 self.regs.set_dword(DwordReg::EAX, dst);
             }
         } else {
             let src = self.regs.word(self.reg_word(modrm));
-            let Some(dst) = self.get_rm_word_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word_for_update(modrm, bus)?;
             let ax = self.regs.word(WordReg::AX);
             self.alu_sub_word(ax, dst);
             if self.flags.zf() {
-                self.putback_rm_word(modrm, src, bus);
-                if self.fault_pending {
-                    return;
-                }
+                self.putback_rm_word(modrm, src, bus)?;
             } else {
                 self.regs.set_word(WordReg::AX, dst);
             }
         }
         self.clk_modrm(modrm, 6, 7);
+        Ok(())
     }
 
-    fn xadd_byte(&mut self, bus: &mut impl common::Bus) {
+    fn xadd_byte(&mut self, bus: &mut impl common::Bus) -> Step {
         // XADD r/m8,r8 - exchange and add.
         let modrm = self.fetch(bus);
         let src_reg = self.reg_byte(modrm);
         let src = self.regs.byte(src_reg);
-        let Some(dst) = self.get_rm_byte_for_update(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte_for_update(modrm, bus)?;
         let result = self.alu_add_byte(dst, src);
         self.regs.set_byte(src_reg, dst);
-        self.putback_rm_byte(modrm, result, bus);
-        if self.fault_pending {
-            return;
-        }
+        self.putback_rm_byte(modrm, result, bus)?;
         self.clk_modrm(modrm, 3, 4);
+        Ok(())
     }
 
-    fn xadd_word(&mut self, bus: &mut impl common::Bus) {
+    fn xadd_word(&mut self, bus: &mut impl common::Bus) -> Step {
         // XADD r/m16,r16 or XADD r/m32,r32 (with operand-size override).
         let modrm = self.fetch(bus);
         if self.operand_size_override {
             let src_reg = self.reg_dword(modrm);
             let src = self.regs.dword(src_reg);
-            let Some(dst) = self.get_rm_dword_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword_for_update(modrm, bus)?;
             let result = self.alu_add_dword(dst, src);
             self.regs.set_dword(src_reg, dst);
-            self.putback_rm_dword(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_dword(modrm, result, bus)?;
         } else {
             let src_reg = self.reg_word(modrm);
             let src = self.regs.word(src_reg);
-            let Some(dst) = self.get_rm_word_for_update(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word_for_update(modrm, bus)?;
             let result = self.alu_add_word(dst, src);
             self.regs.set_word(src_reg, dst);
-            self.putback_rm_word(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_word(modrm, result, bus)?;
         }
         self.clk_modrm(modrm, 3, 4);
+        Ok(())
     }
 }

--- a/crates/cpu/src/i386/execute_group.rs
+++ b/crates/cpu/src/i386/execute_group.rs
@@ -865,8 +865,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     let cs = self.sregs[SegReg32::CS as usize];
                     let old_eip = self.ip_upper | self.ip as u32;
                     if !self.is_protected_mode() || self.is_virtual_mode() {
-                        self.push_dword(bus, cs as u32)?;
-                        self.push_dword(bus, old_eip)?;
+                        self.far_push_real_v86_dword(bus, cs as u32, old_eip)?;
                         self.load_segment(SegReg32::CS, segment, bus)?;
                         self.ip = offset as u16;
                         self.ip_upper = offset & 0xFFFF_0000;
@@ -900,8 +899,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     let cs = self.sregs[SegReg32::CS as usize];
                     let old_eip = self.ip_upper | self.ip as u32;
                     if !self.is_protected_mode() || self.is_virtual_mode() {
-                        self.push(bus, cs)?;
-                        self.push(bus, old_eip as u16)?;
+                        self.far_push_real_v86_word(bus, cs, old_eip as u16)?;
                         self.load_segment(SegReg32::CS, segment, bus)?;
                         self.ip = offset;
                         self.ip_upper = 0;

--- a/crates/cpu/src/i386/execute_group.rs
+++ b/crates/cpu/src/i386/execute_group.rs
@@ -1,4 +1,4 @@
-use super::{CPU_MODEL_386, CPU_MODEL_486, I386};
+use super::{CPU_MODEL_386, CPU_MODEL_486, I386, Step};
 use crate::{ByteReg, DwordReg, SegReg32, WordReg};
 
 impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
@@ -29,24 +29,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     }
 
     /// Group 0x80: ALU r/m8, imm8
-    pub(super) fn group_80(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_80(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let extension = (modrm >> 3) & 7;
         if self.lock_prefix && extension == 7 {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
-        let Some(dst) = (if extension == 7 {
+        let dst = (if extension == 7 {
             self.get_rm_byte(modrm, bus)
         } else {
             self.get_rm_byte_for_update(modrm, bus)
-        }) else {
-            return;
-        };
+        })?;
         let src = self.fetch(bus);
-        if self.fault_pending {
-            return;
-        }
         let result = match extension {
             0 => self.alu_add_byte(dst, src),
             1 => self.alu_or_byte(dst, src),
@@ -64,39 +59,32 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             7 => {
                 self.alu_sub_byte(dst, src);
                 self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(5, 2));
-                return;
+                return Ok(());
             }
             _ => unreachable!(),
         };
         if extension != 7 {
-            self.putback_rm_byte(modrm, result, bus);
-            if self.fault_pending {
-                return;
-            }
+            self.putback_rm_byte(modrm, result, bus)?;
         }
         self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(7, 3));
+        Ok(())
     }
 
     /// Group 0x81: ALU r/m16, imm16
-    pub(super) fn group_81(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_81(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let extension = (modrm >> 3) & 7;
         if self.lock_prefix && extension == 7 {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
         if self.operand_size_override {
-            let Some(dst) = (if extension == 7 {
+            let dst = (if extension == 7 {
                 self.get_rm_dword(modrm, bus)
             } else {
                 self.get_rm_dword_for_update(modrm, bus)
-            }) else {
-                return;
-            };
+            })?;
             let src = self.fetchdword(bus);
-            if self.fault_pending {
-                return;
-            }
             let result = match extension {
                 0 => self.alu_add_dword(dst, src),
                 1 => self.alu_or_dword(dst, src),
@@ -114,29 +102,21 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 7 => {
                     self.alu_sub_dword(dst, src);
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(5, 2), 2);
-                    return;
+                    return Ok(());
                 }
                 _ => unreachable!(),
             };
             if extension != 7 {
-                self.putback_rm_dword(modrm, result, bus);
-                if self.fault_pending {
-                    return;
-                }
+                self.putback_rm_dword(modrm, result, bus)?;
             }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
-            let Some(dst) = (if extension == 7 {
+            let dst = (if extension == 7 {
                 self.get_rm_word(modrm, bus)
             } else {
                 self.get_rm_word_for_update(modrm, bus)
-            }) else {
-                return;
-            };
+            })?;
             let src = self.fetchword(bus);
-            if self.fault_pending {
-                return;
-            }
             let result = match extension {
                 0 => self.alu_add_word(dst, src),
                 1 => self.alu_or_word(dst, src),
@@ -154,45 +134,39 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 7 => {
                     self.alu_sub_word(dst, src);
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(5, 2), 1);
-                    return;
+                    return Ok(());
                 }
                 _ => unreachable!(),
             };
             if extension != 7 {
-                self.putback_rm_word(modrm, result, bus);
-                if self.fault_pending {
-                    return;
-                }
+                self.putback_rm_word(modrm, result, bus)?;
             }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
+        Ok(())
     }
 
     /// Group 0x82: ALU r/m8, imm8 (same as 0x80)
-    pub(super) fn group_82(&mut self, bus: &mut impl common::Bus) {
-        self.group_80(bus);
+    pub(super) fn group_82(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.group_80(bus)?;
+        Ok(())
     }
 
     /// Group 0x83: ALU r/m16, sign-extended imm8
-    pub(super) fn group_83(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_83(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let extension = (modrm >> 3) & 7;
         if self.lock_prefix && extension == 7 {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
         if self.operand_size_override {
-            let Some(dst) = (if extension == 7 {
+            let dst = (if extension == 7 {
                 self.get_rm_dword(modrm, bus)
             } else {
                 self.get_rm_dword_for_update(modrm, bus)
-            }) else {
-                return;
-            };
+            })?;
             let src = self.fetch(bus) as i8 as i32 as u32;
-            if self.fault_pending {
-                return;
-            }
             let result = match extension {
                 0 => self.alu_add_dword(dst, src),
                 1 => self.alu_or_dword(dst, src),
@@ -210,29 +184,21 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 7 => {
                     self.alu_sub_dword(dst, src);
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(5, 2), 2);
-                    return;
+                    return Ok(());
                 }
                 _ => unreachable!(),
             };
             if extension != 7 {
-                self.putback_rm_dword(modrm, result, bus);
-                if self.fault_pending {
-                    return;
-                }
+                self.putback_rm_dword(modrm, result, bus)?;
             }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 4);
         } else {
-            let Some(dst) = (if extension == 7 {
+            let dst = (if extension == 7 {
                 self.get_rm_word(modrm, bus)
             } else {
                 self.get_rm_word_for_update(modrm, bus)
-            }) else {
-                return;
-            };
+            })?;
             let src = self.fetch(bus) as i8 as u16;
-            if self.fault_pending {
-                return;
-            }
             let result = match extension {
                 0 => self.alu_add_word(dst, src),
                 1 => self.alu_or_word(dst, src),
@@ -250,26 +216,22 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 7 => {
                     self.alu_sub_word(dst, src);
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(5, 2), 1);
-                    return;
+                    return Ok(());
                 }
                 _ => unreachable!(),
             };
             if extension != 7 {
-                self.putback_rm_word(modrm, result, bus);
-                if self.fault_pending {
-                    return;
-                }
+                self.putback_rm_word(modrm, result, bus)?;
             }
             self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(7, 3), 2);
         }
+        Ok(())
     }
 
     /// Group 0xC0: shift/rotate r/m8, imm8
-    pub(super) fn group_c0(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_c0(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
-        let Some(dst) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte(modrm, bus)?;
         let count = self.fetch(bus);
         let extension = (modrm >> 3) & 7;
         let result = match extension {
@@ -283,20 +245,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             7 => self.alu_sar_byte(dst, count),
             _ => unreachable!(),
         };
-        self.putback_rm_byte(modrm, result, bus);
+        self.putback_rm_byte(modrm, result, bus)?;
         let (register_cycles, memory_cycles) = Self::shift_group_timing(extension, 0);
         self.clk_modrm(modrm, register_cycles, memory_cycles);
+        Ok(())
     }
 
     /// Group 0xC1: shift/rotate r/m16, imm8
-    pub(super) fn group_c1(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_c1(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let extension = (modrm >> 3) & 7;
         let (register_cycles, memory_cycles) = Self::shift_group_timing(extension, 0);
         if self.operand_size_override {
-            let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword(modrm, bus)?;
             let count = self.fetch(bus);
             let result = match extension {
                 0 => self.alu_rol_dword(dst, count),
@@ -309,12 +270,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 7 => self.alu_sar_dword(dst, count),
                 _ => unreachable!(),
             };
-            self.putback_rm_dword(modrm, result, bus);
+            self.putback_rm_dword(modrm, result, bus)?;
             self.clk_modrm_word(modrm, register_cycles, memory_cycles, 4);
         } else {
-            let Some(dst) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word(modrm, bus)?;
             let count = self.fetch(bus);
             let result = match extension {
                 0 => self.alu_rol_word(dst, count),
@@ -327,17 +286,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 7 => self.alu_sar_word(dst, count),
                 _ => unreachable!(),
             };
-            self.putback_rm_word(modrm, result, bus);
+            self.putback_rm_word(modrm, result, bus)?;
             self.clk_modrm_word(modrm, register_cycles, memory_cycles, 2);
         }
+        Ok(())
     }
 
     /// Group 0xD0: shift/rotate r/m8, 1
-    pub(super) fn group_d0(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_d0(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
-        let Some(dst) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte(modrm, bus)?;
         let extension = (modrm >> 3) & 7;
         let result = match extension {
             0 => self.alu_rol_byte(dst, 1),
@@ -350,20 +308,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             7 => self.alu_sar_byte(dst, 1),
             _ => unreachable!(),
         };
-        self.putback_rm_byte(modrm, result, bus);
+        self.putback_rm_byte(modrm, result, bus)?;
         let (register_cycles, memory_cycles) = Self::shift_group_timing(extension, 1);
         self.clk_modrm(modrm, register_cycles, memory_cycles);
+        Ok(())
     }
 
     /// Group 0xD1: shift/rotate r/m16, 1
-    pub(super) fn group_d1(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_d1(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let extension = (modrm >> 3) & 7;
         let (register_cycles, memory_cycles) = Self::shift_group_timing(extension, 1);
         if self.operand_size_override {
-            let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword(modrm, bus)?;
             let result = match extension {
                 0 => self.alu_rol_dword(dst, 1),
                 1 => self.alu_ror_dword(dst, 1),
@@ -375,12 +332,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 7 => self.alu_sar_dword(dst, 1),
                 _ => unreachable!(),
             };
-            self.putback_rm_dword(modrm, result, bus);
+            self.putback_rm_dword(modrm, result, bus)?;
             self.clk_modrm_word(modrm, register_cycles, memory_cycles, 4);
         } else {
-            let Some(dst) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word(modrm, bus)?;
             let result = match extension {
                 0 => self.alu_rol_word(dst, 1),
                 1 => self.alu_ror_word(dst, 1),
@@ -392,17 +347,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 7 => self.alu_sar_word(dst, 1),
                 _ => unreachable!(),
             };
-            self.putback_rm_word(modrm, result, bus);
+            self.putback_rm_word(modrm, result, bus)?;
             self.clk_modrm_word(modrm, register_cycles, memory_cycles, 2);
         }
+        Ok(())
     }
 
     /// Group 0xD2: shift/rotate r/m8, CL
-    pub(super) fn group_d2(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_d2(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
-        let Some(dst) = self.get_rm_byte(modrm, bus) else {
-            return;
-        };
+        let dst = self.get_rm_byte(modrm, bus)?;
         let count = self.regs.byte(ByteReg::CL);
         let extension = (modrm >> 3) & 7;
         let result = match extension {
@@ -416,21 +370,20 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             7 => self.alu_sar_byte(dst, count),
             _ => unreachable!(),
         };
-        self.putback_rm_byte(modrm, result, bus);
+        self.putback_rm_byte(modrm, result, bus)?;
         let (register_cycles, memory_cycles) = Self::shift_group_timing(extension, 2);
         self.clk_modrm(modrm, register_cycles, memory_cycles);
+        Ok(())
     }
 
     /// Group 0xD3: shift/rotate r/m16, CL
-    pub(super) fn group_d3(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_d3(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let count = self.regs.byte(ByteReg::CL);
         let extension = (modrm >> 3) & 7;
         let (register_cycles, memory_cycles) = Self::shift_group_timing(extension, 2);
         if self.operand_size_override {
-            let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_dword(modrm, bus)?;
             let result = match extension {
                 0 => self.alu_rol_dword(dst, count),
                 1 => self.alu_ror_dword(dst, count),
@@ -442,12 +395,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 7 => self.alu_sar_dword(dst, count),
                 _ => unreachable!(),
             };
-            self.putback_rm_dword(modrm, result, bus);
+            self.putback_rm_dword(modrm, result, bus)?;
             self.clk_modrm_word(modrm, register_cycles, memory_cycles, 4);
         } else {
-            let Some(dst) = self.get_rm_word(modrm, bus) else {
-                return;
-            };
+            let dst = self.get_rm_word(modrm, bus)?;
             let result = match extension {
                 0 => self.alu_rol_word(dst, count),
                 1 => self.alu_ror_word(dst, count),
@@ -459,51 +410,44 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 7 => self.alu_sar_word(dst, count),
                 _ => unreachable!(),
             };
-            self.putback_rm_word(modrm, result, bus);
+            self.putback_rm_word(modrm, result, bus)?;
             self.clk_modrm_word(modrm, register_cycles, memory_cycles, 2);
         }
+        Ok(())
     }
 
     /// Group 0xF6: various byte operations
-    pub(super) fn group_f6(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_f6(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let op = (modrm >> 3) & 7;
         if self.lock_prefix && !matches!(op, 2 | 3) {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
         match op {
             0 | 1 => {
                 // TEST r/m8, imm8
-                let Some(dst) = self.get_rm_byte(modrm, bus) else {
-                    return;
-                };
+                let dst = self.get_rm_byte(modrm, bus)?;
                 let src = self.fetch(bus);
                 self.alu_and_byte(dst, src);
                 self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(5, 2));
             }
             2 => {
                 // NOT r/m8
-                let Some(dst) = self.get_rm_byte(modrm, bus) else {
-                    return;
-                };
-                self.putback_rm_byte(modrm, !dst, bus);
+                let dst = self.get_rm_byte(modrm, bus)?;
+                self.putback_rm_byte(modrm, !dst, bus)?;
                 self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 3));
             }
             3 => {
                 // NEG r/m8
-                let Some(dst) = self.get_rm_byte(modrm, bus) else {
-                    return;
-                };
+                let dst = self.get_rm_byte(modrm, bus)?;
                 let result = self.alu_neg_byte(dst);
-                self.putback_rm_byte(modrm, result, bus);
+                self.putback_rm_byte(modrm, result, bus)?;
                 self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 3));
             }
             4 => {
                 // MUL r/m8 (unsigned)
-                let Some(src) = self.get_rm_byte(modrm, bus) else {
-                    return;
-                };
+                let src = self.get_rm_byte(modrm, bus)?;
                 let al = self.regs.byte(ByteReg::AL);
                 let result = al as u16 * src as u16;
                 self.regs.set_word(WordReg::AX, result);
@@ -513,9 +457,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
             5 => {
                 // IMUL r/m8 (signed)
-                let Some(src) = self.get_rm_byte(modrm, bus) else {
-                    return;
-                };
+                let src = self.get_rm_byte(modrm, bus)?;
                 let src = src as i8 as i16;
                 let al = self.regs.byte(ByteReg::AL) as i8 as i16;
                 let result = al * src;
@@ -528,19 +470,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
             6 => {
                 // DIV r/m8 (unsigned)
-                let Some(src) = self.get_rm_byte(modrm, bus) else {
-                    return;
-                };
+                let src = self.get_rm_byte(modrm, bus)?;
                 let src = src as u16;
                 if src == 0 {
-                    self.raise_fault(0, bus);
-                    return;
+                    self.raise_fault(0, bus)?;
+                    return Ok(());
                 }
                 let aw = self.regs.word(WordReg::AX);
                 let quotient = aw / src;
                 if quotient > 0xFF {
-                    self.raise_fault(0, bus);
-                    return;
+                    self.raise_fault(0, bus)?;
+                    return Ok(());
                 }
                 let remainder = aw % src;
                 self.regs.set_byte(ByteReg::AL, quotient as u8);
@@ -553,22 +493,20 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
             7 => {
                 // IDIV r/m8 (signed)
-                let Some(src) = self.get_rm_byte(modrm, bus) else {
-                    return;
-                };
+                let src = self.get_rm_byte(modrm, bus)?;
                 let src = src as i8 as i16;
                 if src == 0 {
-                    self.raise_fault(0, bus);
-                    return;
+                    self.raise_fault(0, bus)?;
+                    return Ok(());
                 }
                 let aw = self.regs.word(WordReg::AX) as i16;
                 let Some(quotient) = aw.checked_div(src) else {
-                    self.raise_fault(0, bus);
-                    return;
+                    self.raise_fault(0, bus)?;
+                    return Ok(());
                 };
                 if !(-128..=127).contains(&quotient) {
-                    self.raise_fault(0, bus);
-                    return;
+                    self.raise_fault(0, bus)?;
+                    return Ok(());
                 }
                 let remainder = aw.checked_rem(src).unwrap_or(0);
                 self.regs.set_byte(ByteReg::AL, quotient as u8);
@@ -581,49 +519,42 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
             _ => unreachable!(),
         }
+        Ok(())
     }
 
     /// Group 0xF7: various word operations
-    pub(super) fn group_f7(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_f7(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         let op = (modrm >> 3) & 7;
         if self.lock_prefix && !matches!(op, 2 | 3) {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
         if self.operand_size_override {
             match op {
                 0 | 1 => {
                     // TEST r/m32, imm32
-                    let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                        return;
-                    };
+                    let dst = self.get_rm_dword(modrm, bus)?;
                     let src = self.fetchdword(bus);
                     self.alu_and_dword(dst, src);
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(5, 2), 2);
                 }
                 2 => {
                     // NOT r/m32
-                    let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                        return;
-                    };
-                    self.putback_rm_dword(modrm, !dst, bus);
+                    let dst = self.get_rm_dword(modrm, bus)?;
+                    self.putback_rm_dword(modrm, !dst, bus)?;
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 3), 4);
                 }
                 3 => {
                     // NEG r/m32
-                    let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                        return;
-                    };
+                    let dst = self.get_rm_dword(modrm, bus)?;
                     let result = self.alu_neg_dword(dst);
-                    self.putback_rm_dword(modrm, result, bus);
+                    self.putback_rm_dword(modrm, result, bus)?;
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 3), 4);
                 }
                 4 => {
                     // MUL r/m32 (unsigned)
-                    let Some(src) = self.get_rm_dword(modrm, bus) else {
-                        return;
-                    };
+                    let src = self.get_rm_dword(modrm, bus)?;
                     let eax = self.regs.dword(DwordReg::EAX);
                     let result = eax as u64 * src as u64;
                     self.regs.set_dword(DwordReg::EAX, result as u32);
@@ -634,9 +565,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
                 5 => {
                     // IMUL r/m32 (signed)
-                    let Some(src) = self.get_rm_dword(modrm, bus) else {
-                        return;
-                    };
+                    let src = self.get_rm_dword(modrm, bus)?;
                     let src = src as i32 as i64;
                     let eax = self.regs.dword(DwordReg::EAX) as i32 as i64;
                     let result = eax * src;
@@ -649,21 +578,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
                 6 => {
                     // DIV r/m32 (unsigned)
-                    let Some(src) = self.get_rm_dword(modrm, bus) else {
-                        return;
-                    };
+                    let src = self.get_rm_dword(modrm, bus)?;
                     let src = src as u64;
                     if src == 0 {
-                        self.raise_fault(0, bus);
-                        return;
+                        self.raise_fault(0, bus)?;
+                        return Ok(());
                     }
                     let edx = self.regs.dword(DwordReg::EDX) as u64;
                     let eax = self.regs.dword(DwordReg::EAX) as u64;
                     let dividend = (edx << 32) | eax;
                     let quotient = dividend / src;
                     if quotient > u32::MAX as u64 {
-                        self.raise_fault(0, bus);
-                        return;
+                        self.raise_fault(0, bus)?;
+                        return Ok(());
                     }
                     let remainder = dividend % src;
                     self.regs.set_dword(DwordReg::EAX, quotient as u32);
@@ -676,24 +603,22 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
                 7 => {
                     // IDIV r/m32 (signed)
-                    let Some(src) = self.get_rm_dword(modrm, bus) else {
-                        return;
-                    };
+                    let src = self.get_rm_dword(modrm, bus)?;
                     let src = src as i32 as i64;
                     if src == 0 {
-                        self.raise_fault(0, bus);
-                        return;
+                        self.raise_fault(0, bus)?;
+                        return Ok(());
                     }
                     let edx = self.regs.dword(DwordReg::EDX) as u64;
                     let eax = self.regs.dword(DwordReg::EAX) as u64;
                     let dividend = ((edx << 32) | eax) as i64;
                     let Some(quotient) = dividend.checked_div(src) else {
-                        self.raise_fault(0, bus);
-                        return;
+                        self.raise_fault(0, bus)?;
+                        return Ok(());
                     };
                     if !((i32::MIN as i64)..=(i32::MAX as i64)).contains(&quotient) {
-                        self.raise_fault(0, bus);
-                        return;
+                        self.raise_fault(0, bus)?;
+                        return Ok(());
                     }
                     let remainder = dividend.checked_rem(src).unwrap_or(0);
                     self.regs.set_dword(DwordReg::EAX, quotient as u32);
@@ -710,35 +635,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             match op {
                 0 | 1 => {
                     // TEST r/m16, imm16
-                    let Some(dst) = self.get_rm_word(modrm, bus) else {
-                        return;
-                    };
+                    let dst = self.get_rm_word(modrm, bus)?;
                     let src = self.fetchword(bus);
                     self.alu_and_word(dst, src);
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(5, 2), 1);
                 }
                 2 => {
                     // NOT r/m16
-                    let Some(dst) = self.get_rm_word(modrm, bus) else {
-                        return;
-                    };
-                    self.putback_rm_word(modrm, !dst, bus);
+                    let dst = self.get_rm_word(modrm, bus)?;
+                    self.putback_rm_word(modrm, !dst, bus)?;
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 3), 2);
                 }
                 3 => {
                     // NEG r/m16
-                    let Some(dst) = self.get_rm_word(modrm, bus) else {
-                        return;
-                    };
+                    let dst = self.get_rm_word(modrm, bus)?;
                     let result = self.alu_neg_word(dst);
-                    self.putback_rm_word(modrm, result, bus);
+                    self.putback_rm_word(modrm, result, bus)?;
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 3), 2);
                 }
                 4 => {
                     // MUL r/m16 (unsigned)
-                    let Some(src) = self.get_rm_word(modrm, bus) else {
-                        return;
-                    };
+                    let src = self.get_rm_word(modrm, bus)?;
                     let aw = self.regs.word(WordReg::AX);
                     let result = aw as u32 * src as u32;
                     self.regs.set_word(WordReg::AX, result as u16);
@@ -749,9 +666,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
                 5 => {
                     // IMUL r/m16 (signed)
-                    let Some(src) = self.get_rm_word(modrm, bus) else {
-                        return;
-                    };
+                    let src = self.get_rm_word(modrm, bus)?;
                     let src = src as i16 as i32;
                     let aw = self.regs.word(WordReg::AX) as i16 as i32;
                     let result = aw * src;
@@ -765,21 +680,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
                 6 => {
                     // DIV r/m16 (unsigned)
-                    let Some(src) = self.get_rm_word(modrm, bus) else {
-                        return;
-                    };
+                    let src = self.get_rm_word(modrm, bus)?;
                     let src = src as u32;
                     if src == 0 {
-                        self.raise_fault(0, bus);
-                        return;
+                        self.raise_fault(0, bus)?;
+                        return Ok(());
                     }
                     let dw = self.regs.word(WordReg::DX) as u32;
                     let aw = self.regs.word(WordReg::AX) as u32;
                     let dividend = (dw << 16) | aw;
                     let quotient = dividend / src;
                     if quotient > 0xFFFF {
-                        self.raise_fault(0, bus);
-                        return;
+                        self.raise_fault(0, bus)?;
+                        return Ok(());
                     }
                     let remainder = dividend % src;
                     self.regs.set_word(WordReg::AX, quotient as u16);
@@ -792,24 +705,22 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
                 7 => {
                     // IDIV r/m16 (signed)
-                    let Some(src) = self.get_rm_word(modrm, bus) else {
-                        return;
-                    };
+                    let src = self.get_rm_word(modrm, bus)?;
                     let src = src as i16 as i32;
                     if src == 0 {
-                        self.raise_fault(0, bus);
-                        return;
+                        self.raise_fault(0, bus)?;
+                        return Ok(());
                     }
                     let dw = self.regs.word(WordReg::DX) as u32;
                     let aw = self.regs.word(WordReg::AX) as u32;
                     let dividend = ((dw << 16) | aw) as i32;
                     let Some(quotient) = dividend.checked_div(src) else {
-                        self.raise_fault(0, bus);
-                        return;
+                        self.raise_fault(0, bus)?;
+                        return Ok(());
                     };
                     if !(-32768..=32767).contains(&quotient) {
-                        self.raise_fault(0, bus);
-                        return;
+                        self.raise_fault(0, bus)?;
+                        return Ok(());
                     }
                     let remainder = dividend.checked_rem(src).unwrap_or(0);
                     self.regs.set_word(WordReg::AX, quotient as u16);
@@ -823,101 +734,73 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 _ => unreachable!(),
             }
         }
+        Ok(())
     }
 
     /// Group 0xFE: INC/DEC r/m8
-    pub(super) fn group_fe(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_fe(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.lock_prefix && (modrm >> 3) & 7 >= 2 {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
         match (modrm >> 3) & 7 {
             0 => {
                 // INC r/m8
-                let Some(dst) = self.get_rm_byte_for_update(modrm, bus) else {
-                    return;
-                };
+                let dst = self.get_rm_byte_for_update(modrm, bus)?;
                 let result = self.alu_inc_byte(dst);
-                self.putback_rm_byte(modrm, result, bus);
-                if self.fault_pending {
-                    return;
-                }
+                self.putback_rm_byte(modrm, result, bus)?;
                 self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 3));
             }
             1 => {
                 // DEC r/m8
-                let Some(dst) = self.get_rm_byte_for_update(modrm, bus) else {
-                    return;
-                };
+                let dst = self.get_rm_byte_for_update(modrm, bus)?;
                 let result = self.alu_dec_byte(dst);
-                self.putback_rm_byte(modrm, result, bus);
-                if self.fault_pending {
-                    return;
-                }
+                self.putback_rm_byte(modrm, result, bus)?;
                 self.clk_modrm(modrm, Self::timing(2, 1), Self::timing(6, 3));
             }
             _ => {
                 self.clk(Self::timing(2, 1));
             }
         }
+        Ok(())
     }
 
     /// Group 0xFF: various word operations
-    pub(super) fn group_ff(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn group_ff(&mut self, bus: &mut impl common::Bus) -> Step {
         let modrm = self.fetch(bus);
         if self.lock_prefix && (modrm >> 3) & 7 >= 2 {
-            self.raise_fault(6, bus);
-            return;
+            self.raise_fault(6, bus)?;
+            return Ok(());
         }
         match (modrm >> 3) & 7 {
             0 => {
                 if self.operand_size_override {
                     // INC r/m32
-                    let Some(dst) = self.get_rm_dword_for_update(modrm, bus) else {
-                        return;
-                    };
+                    let dst = self.get_rm_dword_for_update(modrm, bus)?;
                     let result = self.alu_inc_dword(dst);
-                    self.putback_rm_dword(modrm, result, bus);
-                    if self.fault_pending {
-                        return;
-                    }
+                    self.putback_rm_dword(modrm, result, bus)?;
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 3), 4);
                 } else {
                     // INC r/m16
-                    let Some(dst) = self.get_rm_word_for_update(modrm, bus) else {
-                        return;
-                    };
+                    let dst = self.get_rm_word_for_update(modrm, bus)?;
                     let result = self.alu_inc_word(dst);
-                    self.putback_rm_word(modrm, result, bus);
-                    if self.fault_pending {
-                        return;
-                    }
+                    self.putback_rm_word(modrm, result, bus)?;
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 3), 2);
                 }
             }
             1 => {
                 if self.operand_size_override {
                     // DEC r/m32
-                    let Some(dst) = self.get_rm_dword_for_update(modrm, bus) else {
-                        return;
-                    };
+                    let dst = self.get_rm_dword_for_update(modrm, bus)?;
                     let result = self.alu_dec_dword(dst);
-                    self.putback_rm_dword(modrm, result, bus);
-                    if self.fault_pending {
-                        return;
-                    }
+                    self.putback_rm_dword(modrm, result, bus)?;
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 3), 4);
                 } else {
                     // DEC r/m16
-                    let Some(dst) = self.get_rm_word_for_update(modrm, bus) else {
-                        return;
-                    };
+                    let dst = self.get_rm_word_for_update(modrm, bus)?;
                     let result = self.alu_dec_word(dst);
-                    self.putback_rm_word(modrm, result, bus);
-                    if self.fault_pending {
-                        return;
-                    }
+                    self.putback_rm_word(modrm, result, bus)?;
                     self.clk_modrm_word(modrm, Self::timing(2, 1), Self::timing(6, 3), 2);
                 }
             }
@@ -925,11 +808,9 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 if self.operand_size_override {
                     // CALL r/m32 (near indirect)
                     let sp_pen = self.sp_penalty();
-                    let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                        return;
-                    };
+                    let dst = self.get_rm_dword(modrm, bus)?;
                     let return_eip = self.ip_upper | self.ip as u32;
-                    self.push_dword(bus, return_eip);
+                    self.push_dword(bus, return_eip)?;
                     self.ip = dst as u16;
                     self.ip_upper = dst & 0xFFFF_0000;
                     match CPU_MODEL {
@@ -950,10 +831,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 } else {
                     // CALL r/m16 (near indirect)
                     let sp_pen = self.sp_penalty();
-                    let Some(dst) = self.get_rm_word(modrm, bus) else {
-                        return;
-                    };
-                    self.push(bus, self.ip);
+                    let dst = self.get_rm_word(modrm, bus)?;
+                    self.push(bus, self.ip)?;
                     self.ip = dst;
                     self.ip_upper = 0;
                     match CPU_MODEL {
@@ -975,26 +854,20 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
             3 => {
                 if modrm >= 0xC0 {
-                    return;
+                    return Ok(());
                 }
                 if self.operand_size_override {
                     // CALL m16:32 (far indirect)
                     let sp_pen = self.sp_penalty();
                     self.calc_ea(modrm, bus);
-                    let Some(offset) = self.seg_read_dword(bus) else {
-                        return;
-                    };
-                    let Some(segment) = self.seg_read_word_at(bus, 4) else {
-                        return;
-                    };
+                    let offset = self.seg_read_dword(bus)?;
+                    let segment = self.seg_read_word_at(bus, 4)?;
                     let cs = self.sregs[SegReg32::CS as usize];
                     let old_eip = self.ip_upper | self.ip as u32;
                     if !self.is_protected_mode() || self.is_virtual_mode() {
-                        self.push_dword(bus, cs as u32);
-                        self.push_dword(bus, old_eip);
-                        if !self.load_segment(SegReg32::CS, segment, bus) {
-                            return;
-                        }
+                        self.push_dword(bus, cs as u32)?;
+                        self.push_dword(bus, old_eip)?;
+                        self.load_segment(SegReg32::CS, segment, bus)?;
                         self.ip = offset as u16;
                         self.ip_upper = offset & 0xFFFF_0000;
                     } else {
@@ -1005,7 +878,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                             cs,
                             old_eip,
                             bus,
-                        );
+                        )?;
                     }
                     match CPU_MODEL {
                         CPU_MODEL_386 => {
@@ -1022,20 +895,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     // CALL m16:16 (far indirect)
                     let sp_pen = self.sp_penalty();
                     self.calc_ea(modrm, bus);
-                    let Some(offset) = self.seg_read_word(bus) else {
-                        return;
-                    };
-                    let Some(segment) = self.seg_read_word_at(bus, 2) else {
-                        return;
-                    };
+                    let offset = self.seg_read_word(bus)?;
+                    let segment = self.seg_read_word_at(bus, 2)?;
                     let cs = self.sregs[SegReg32::CS as usize];
                     let old_eip = self.ip_upper | self.ip as u32;
                     if !self.is_protected_mode() || self.is_virtual_mode() {
-                        self.push(bus, cs);
-                        self.push(bus, old_eip as u16);
-                        if !self.load_segment(SegReg32::CS, segment, bus) {
-                            return;
-                        }
+                        self.push(bus, cs)?;
+                        self.push(bus, old_eip as u16)?;
+                        self.load_segment(SegReg32::CS, segment, bus)?;
                         self.ip = offset;
                         self.ip_upper = 0;
                     } else {
@@ -1046,7 +913,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                             cs,
                             old_eip,
                             bus,
-                        );
+                        )?;
                     }
                     match CPU_MODEL {
                         CPU_MODEL_386 => {
@@ -1064,9 +931,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             4 => {
                 if self.operand_size_override {
                     // JMP r/m32 (near indirect)
-                    let Some(dst) = self.get_rm_dword(modrm, bus) else {
-                        return;
-                    };
+                    let dst = self.get_rm_dword(modrm, bus)?;
                     self.ip = dst as u16;
                     self.ip_upper = dst & 0xFFFF_0000;
                     match CPU_MODEL {
@@ -1086,9 +951,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                     }
                 } else {
                     // JMP r/m16 (near indirect)
-                    let Some(dst) = self.get_rm_word(modrm, bus) else {
-                        return;
-                    };
+                    let dst = self.get_rm_word(modrm, bus)?;
                     self.ip = dst;
                     self.ip_upper = 0;
                     match CPU_MODEL {
@@ -1110,25 +973,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
             5 => {
                 if modrm >= 0xC0 {
-                    return;
+                    return Ok(());
                 }
                 if self.operand_size_override {
                     // JMP m16:32 (far indirect)
                     self.calc_ea(modrm, bus);
-                    let Some(offset) = self.seg_read_dword(bus) else {
-                        return;
-                    };
-                    let Some(segment) = self.seg_read_word_at(bus, 4) else {
-                        return;
-                    };
+                    let offset = self.seg_read_dword(bus)?;
+                    let segment = self.seg_read_word_at(bus, 4)?;
                     if !self.is_protected_mode() || self.is_virtual_mode() {
-                        if !self.load_segment(SegReg32::CS, segment, bus) {
-                            return;
-                        }
+                        self.load_segment(SegReg32::CS, segment, bus)?;
                         self.ip = offset as u16;
                         self.ip_upper = offset & 0xFFFF_0000;
                     } else {
-                        self.code_descriptor(segment, offset, super::TaskType::Jmp, 0, 0, bus);
+                        self.code_descriptor(segment, offset, super::TaskType::Jmp, 0, 0, bus)?;
                     }
                     match CPU_MODEL {
                         CPU_MODEL_386 => {
@@ -1144,16 +1001,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 } else {
                     // JMP m16:16 (far indirect)
                     self.calc_ea(modrm, bus);
-                    let Some(offset) = self.seg_read_word(bus) else {
-                        return;
-                    };
-                    let Some(segment) = self.seg_read_word_at(bus, 2) else {
-                        return;
-                    };
+                    let offset = self.seg_read_word(bus)?;
+                    let segment = self.seg_read_word_at(bus, 2)?;
                     if !self.is_protected_mode() || self.is_virtual_mode() {
-                        if !self.load_segment(SegReg32::CS, segment, bus) {
-                            return;
-                        }
+                        self.load_segment(SegReg32::CS, segment, bus)?;
                         self.ip = offset;
                         self.ip_upper = 0;
                     } else {
@@ -1164,7 +1015,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                             0,
                             0,
                             bus,
-                        );
+                        )?;
                     }
                     match CPU_MODEL {
                         CPU_MODEL_386 => {
@@ -1183,10 +1034,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 if self.operand_size_override {
                     // PUSH r/m32 (7 is undocumented alias)
                     let sp_pen = self.sp_penalty();
-                    let Some(val) = self.get_rm_dword(modrm, bus) else {
-                        return;
-                    };
-                    self.push_dword(bus, val);
+                    let val = self.get_rm_dword(modrm, bus)?;
+                    self.push_dword(bus, val)?;
                     if modrm >= 0xC0 {
                         self.clk(Self::timing(5, 1) + sp_pen);
                     } else {
@@ -1200,10 +1049,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 } else {
                     // PUSH r/m16 (7 is undocumented alias)
                     let sp_pen = self.sp_penalty();
-                    let Some(val) = self.get_rm_word(modrm, bus) else {
-                        return;
-                    };
-                    self.push(bus, val);
+                    let val = self.get_rm_word(modrm, bus)?;
+                    self.push(bus, val)?;
                     if modrm >= 0xC0 {
                         self.clk(Self::timing(5, 1) + sp_pen);
                     } else {
@@ -1220,5 +1067,6 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.clk(Self::timing(2, 1));
             }
         }
+        Ok(())
     }
 }

--- a/crates/cpu/src/i386/fpu.rs
+++ b/crates/cpu/src/i386/fpu.rs
@@ -1,6 +1,6 @@
 use softfloat::{ExceptionFlags, Fp80, FpClass, Precision, RoundingMode};
 
-use super::I386;
+use super::{I386, Step};
 
 const TAG_VALID: u16 = 0b00;
 const TAG_ZERO: u16 = 0b01;
@@ -172,14 +172,15 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_update_es();
     }
 
-    pub(super) fn fpu_raise_exception(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_raise_exception(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.state.cr0 & 0x20 != 0 {
             // NE=1: native #MF (vector 16)
-            self.raise_fault(16, bus);
+            self.raise_fault(16, bus)?;
         } else {
             // NE=0: DOS-compatible, signal via FERR#
             bus.signal_fpu_error();
         }
+        Ok(())
     }
 
     pub(super) fn fpu_update_pointers(&mut self, esc_bits: u8, modrm: u8, has_memory: bool) {
@@ -193,27 +194,27 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
     }
 
-    pub(super) fn fpu_read_u16(&mut self, bus: &mut impl common::Bus) -> Option<u16> {
+    pub(super) fn fpu_read_u16(&mut self, bus: &mut impl common::Bus) -> Step<u16> {
         self.read_word_linear(bus, self.ea)
     }
 
-    pub(super) fn fpu_read_u32(&mut self, bus: &mut impl common::Bus) -> Option<u32> {
+    pub(super) fn fpu_read_u32(&mut self, bus: &mut impl common::Bus) -> Step<u32> {
         let ea = self.ea;
         let lo = self.read_word_linear(bus, ea)? as u32;
         let hi = self.read_word_linear(bus, ea.wrapping_add(2))? as u32;
-        Some(lo | (hi << 16))
+        Ok(lo | (hi << 16))
     }
 
-    pub(super) fn fpu_read_u64(&mut self, bus: &mut impl common::Bus) -> Option<u64> {
+    pub(super) fn fpu_read_u64(&mut self, bus: &mut impl common::Bus) -> Step<u64> {
         let ea = self.ea;
         let w0 = self.read_word_linear(bus, ea)? as u64;
         let w1 = self.read_word_linear(bus, ea.wrapping_add(2))? as u64;
         let w2 = self.read_word_linear(bus, ea.wrapping_add(4))? as u64;
         let w3 = self.read_word_linear(bus, ea.wrapping_add(6))? as u64;
-        Some(w0 | (w1 << 16) | (w2 << 32) | (w3 << 48))
+        Ok(w0 | (w1 << 16) | (w2 << 32) | (w3 << 48))
     }
 
-    pub(super) fn fpu_read_tbyte(&mut self, bus: &mut impl common::Bus) -> Option<[u8; 10]> {
+    pub(super) fn fpu_read_tbyte(&mut self, bus: &mut impl common::Bus) -> Step<[u8; 10]> {
         let ea = self.ea;
         // Translate every byte first so a partial fault doesn't mutate the
         // FPU stack via fpu_push later.
@@ -225,21 +226,21 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         for (i, byte) in bytes.iter_mut().enumerate() {
             *byte = bus.read_byte(phys[i]);
         }
-        Some(bytes)
+        Ok(bytes)
     }
 
-    pub(super) fn fpu_write_u16(&mut self, bus: &mut impl common::Bus, value: u16) -> Option<()> {
+    pub(super) fn fpu_write_u16(&mut self, bus: &mut impl common::Bus, value: u16) -> Step {
         let ea = self.ea;
         self.write_word_linear(bus, ea, value)
     }
 
-    pub(super) fn fpu_write_u32(&mut self, bus: &mut impl common::Bus, value: u32) -> Option<()> {
+    pub(super) fn fpu_write_u32(&mut self, bus: &mut impl common::Bus, value: u32) -> Step {
         let ea = self.ea;
         self.write_word_linear(bus, ea, value as u16)?;
         self.write_word_linear(bus, ea.wrapping_add(2), (value >> 16) as u16)
     }
 
-    pub(super) fn fpu_write_u64(&mut self, bus: &mut impl common::Bus, value: u64) -> Option<()> {
+    pub(super) fn fpu_write_u64(&mut self, bus: &mut impl common::Bus, value: u64) -> Step {
         let ea = self.ea;
         self.write_word_linear(bus, ea, value as u16)?;
         self.write_word_linear(bus, ea.wrapping_add(2), (value >> 16) as u16)?;
@@ -247,11 +248,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.write_word_linear(bus, ea.wrapping_add(6), (value >> 48) as u16)
     }
 
-    pub(super) fn fpu_write_tbyte(
-        &mut self,
-        bus: &mut impl common::Bus,
-        bytes: &[u8; 10],
-    ) -> Option<()> {
+    pub(super) fn fpu_write_tbyte(&mut self, bus: &mut impl common::Bus, bytes: &[u8; 10]) -> Step {
         let ea = self.ea;
         // Translate every byte first; only commit writes once all
         // translations succeed so a fault leaves the destination
@@ -263,7 +260,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         for (i, &byte) in bytes.iter().enumerate() {
             bus.write_byte(phys[i], byte);
         }
-        Some(())
+        Ok(())
     }
 
     pub(super) fn fpu_init(&mut self) {

--- a/crates/cpu/src/i386/fpu_dispatch.rs
+++ b/crates/cpu/src/i386/fpu_dispatch.rs
@@ -99,8 +99,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             match reg {
                 0 => self.fpu_fld_m32(bus)?,
                 1 => self.clk(Self::timing(2, 2)), // reserved
-                2 => self.fpu_fst_m32(bus),
-                3 => self.fpu_fstp_m32(bus),
+                2 => self.fpu_fst_m32(bus)?,
+                3 => self.fpu_fstp_m32(bus)?,
                 4 => self.fpu_fldenv(bus),
                 5 => self.fpu_fldcw(bus)?,
                 6 => self.fpu_fnstenv(bus),
@@ -276,8 +276,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             match reg {
                 0 => self.fpu_fild_m32(bus)?,
                 1 => self.clk(Self::timing(2, 2)), // reserved
-                2 => self.fpu_fist_m32(bus),
-                3 => self.fpu_fistp_m32(bus),
+                2 => self.fpu_fist_m32(bus)?,
+                3 => self.fpu_fistp_m32(bus)?,
                 4 => self.clk(Self::timing(2, 2)), // reserved
                 5 => self.fpu_fld_m80(bus)?,
                 6 => self.clk(Self::timing(2, 2)), // reserved
@@ -343,8 +343,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             match reg {
                 0 => self.fpu_fld_m64(bus)?,
                 1 => self.clk(Self::timing(2, 2)), // reserved
-                2 => self.fpu_fst_m64(bus),
-                3 => self.fpu_fstp_m64(bus),
+                2 => self.fpu_fst_m64(bus)?,
+                3 => self.fpu_fstp_m64(bus)?,
                 4 => self.fpu_frstor(bus)?,
                 5 => self.clk(Self::timing(2, 2)), // reserved
                 6 => self.fpu_fnsave(bus)?,
@@ -432,8 +432,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             match reg {
                 0 => self.fpu_fild_m16(bus)?,
                 1 => self.clk(Self::timing(2, 2)), // reserved
-                2 => self.fpu_fist_m16(bus),
-                3 => self.fpu_fistp_m16(bus),
+                2 => self.fpu_fist_m16(bus)?,
+                3 => self.fpu_fistp_m16(bus)?,
                 4 => self.fpu_fbld(bus)?,
                 5 => self.fpu_fild_m64(bus)?,
                 6 => self.fpu_fbstp(bus),

--- a/crates/cpu/src/i386/fpu_dispatch.rs
+++ b/crates/cpu/src/i386/fpu_dispatch.rs
@@ -1,17 +1,15 @@
-use super::I386;
+use super::{I386, Step};
 
 impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
-    pub(super) fn fpu_escape(&mut self, opcode: u8, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_escape(&mut self, opcode: u8, bus: &mut impl common::Bus) -> Step {
         // CR0.EM=1 -> #NM
         if self.cr0 & 0x04 != 0 {
-            self.raise_fault(7, bus);
-            return;
+            return self.raise_fault(7, bus);
         }
 
         // CR0.TS=1 -> #NM
         if self.cr0 & 0x08 != 0 {
-            self.raise_fault(7, bus);
-            return;
+            return self.raise_fault(7, bus);
         }
 
         let modrm = self.fetch(bus);
@@ -19,8 +17,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
         // ES=1 -> deliver pending exception before executing
         if self.fpu_es_pending() {
-            self.fpu_raise_exception(bus);
-            return;
+            return self.fpu_raise_exception(bus);
         }
 
         if has_memory {
@@ -29,49 +26,49 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
         let esc_bits = opcode & 7;
         match esc_bits {
-            0 => self.fpu_esc_d8(modrm, has_memory, bus),
-            1 => self.fpu_esc_d9(modrm, has_memory, bus),
-            2 => self.fpu_esc_da(modrm, has_memory, bus),
-            3 => self.fpu_esc_db(modrm, has_memory, bus),
-            4 => self.fpu_esc_dc(modrm, has_memory, bus),
-            5 => self.fpu_esc_dd(modrm, has_memory, bus),
-            6 => self.fpu_esc_de(modrm, has_memory, bus),
-            7 => self.fpu_esc_df(modrm, has_memory, bus),
+            0 => self.fpu_esc_d8(modrm, has_memory, bus)?,
+            1 => self.fpu_esc_d9(modrm, has_memory, bus)?,
+            2 => self.fpu_esc_da(modrm, has_memory, bus)?,
+            3 => self.fpu_esc_db(modrm, has_memory, bus)?,
+            4 => self.fpu_esc_dc(modrm, has_memory, bus)?,
+            5 => self.fpu_esc_dd(modrm, has_memory, bus)?,
+            6 => self.fpu_esc_de(modrm, has_memory, bus)?,
+            7 => self.fpu_esc_df(modrm, has_memory, bus)?,
             _ => unreachable!(),
         }
+        Ok(())
     }
 
-    pub(super) fn fpu_wait(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_wait(&mut self, bus: &mut impl common::Bus) -> Step {
         // CR0.MP=1 AND CR0.TS=1 -> #NM
         if self.cr0 & 0x02 != 0 && self.cr0 & 0x08 != 0 {
-            self.raise_fault(7, bus);
-            return;
+            return self.raise_fault(7, bus);
         }
 
         // ES=1 -> deliver pending exception
         if self.fpu_es_pending() {
-            self.fpu_raise_exception(bus);
-            return;
+            return self.fpu_raise_exception(bus);
         }
 
         self.clk(Self::timing(6, 1));
+        Ok(())
     }
 
     // D8: Single-precision arithmetic
-    fn fpu_esc_d8(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) {
+    fn fpu_esc_d8(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) -> Step {
         let reg = (modrm >> 3) & 7;
         self.fpu_update_pointers(0, modrm, has_memory);
 
         if has_memory {
             match reg {
-                0 => self.fpu_fadd_m32(bus),
-                1 => self.fpu_fmul_m32(bus),
-                2 => self.fpu_fcom_m32(bus),
-                3 => self.fpu_fcomp_m32(bus),
-                4 => self.fpu_fsub_m32(bus),
-                5 => self.fpu_fsubr_m32(bus),
-                6 => self.fpu_fdiv_m32(bus),
-                7 => self.fpu_fdivr_m32(bus),
+                0 => self.fpu_fadd_m32(bus)?,
+                1 => self.fpu_fmul_m32(bus)?,
+                2 => self.fpu_fcom_m32(bus)?,
+                3 => self.fpu_fcomp_m32(bus)?,
+                4 => self.fpu_fsub_m32(bus)?,
+                5 => self.fpu_fsubr_m32(bus)?,
+                6 => self.fpu_fdiv_m32(bus)?,
+                7 => self.fpu_fdivr_m32(bus)?,
                 _ => unreachable!(),
             }
         } else {
@@ -88,10 +85,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 _ => unreachable!(),
             }
         }
+        Ok(())
     }
 
     // D9: Load/Store, Transcendentals, Control
-    fn fpu_esc_d9(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) {
+    fn fpu_esc_d9(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) -> Step {
         if has_memory {
             let reg = (modrm >> 3) & 7;
             // Control instructions don't update FIP/FDP: FLDENV(4), FLDCW(5), FSTENV(6), FSTCW(7)
@@ -99,12 +97,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.fpu_update_pointers(1, modrm, true);
             }
             match reg {
-                0 => self.fpu_fld_m32(bus),
+                0 => self.fpu_fld_m32(bus)?,
                 1 => self.clk(Self::timing(2, 2)), // reserved
                 2 => self.fpu_fst_m32(bus),
                 3 => self.fpu_fstp_m32(bus),
                 4 => self.fpu_fldenv(bus),
-                5 => self.fpu_fldcw(bus),
+                5 => self.fpu_fldcw(bus)?,
                 6 => self.fpu_fnstenv(bus),
                 7 => self.fpu_fnstcw(bus),
                 _ => unreachable!(),
@@ -241,23 +239,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 }
             }
         }
+        Ok(())
     }
 
     // DA: 32-bit integer arithmetic
-    fn fpu_esc_da(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) {
+    fn fpu_esc_da(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) -> Step {
         let reg = (modrm >> 3) & 7;
         self.fpu_update_pointers(2, modrm, has_memory);
 
         if has_memory {
             match reg {
-                0 => self.fpu_fiadd_m32(bus),
-                1 => self.fpu_fimul_m32(bus),
-                2 => self.fpu_ficom_m32(bus),
-                3 => self.fpu_ficomp_m32(bus),
-                4 => self.fpu_fisub_m32(bus),
-                5 => self.fpu_fisubr_m32(bus),
-                6 => self.fpu_fidiv_m32(bus),
-                7 => self.fpu_fidivr_m32(bus),
+                0 => self.fpu_fiadd_m32(bus)?,
+                1 => self.fpu_fimul_m32(bus)?,
+                2 => self.fpu_ficom_m32(bus)?,
+                3 => self.fpu_ficomp_m32(bus)?,
+                4 => self.fpu_fisub_m32(bus)?,
+                5 => self.fpu_fisubr_m32(bus)?,
+                6 => self.fpu_fidiv_m32(bus)?,
+                7 => self.fpu_fidivr_m32(bus)?,
                 _ => unreachable!(),
             }
         } else {
@@ -266,20 +265,21 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 _ => self.clk(Self::timing(2, 2)), // reserved
             }
         }
+        Ok(())
     }
 
     // DB: 32-bit integer load/store, extended load/store
-    fn fpu_esc_db(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) {
+    fn fpu_esc_db(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) -> Step {
         if has_memory {
             let reg = (modrm >> 3) & 7;
             self.fpu_update_pointers(3, modrm, true);
             match reg {
-                0 => self.fpu_fild_m32(bus),
+                0 => self.fpu_fild_m32(bus)?,
                 1 => self.clk(Self::timing(2, 2)), // reserved
                 2 => self.fpu_fist_m32(bus),
                 3 => self.fpu_fistp_m32(bus),
                 4 => self.clk(Self::timing(2, 2)), // reserved
-                5 => self.fpu_fld_m80(bus),
+                5 => self.fpu_fld_m80(bus)?,
                 6 => self.clk(Self::timing(2, 2)), // reserved
                 7 => self.fpu_fstp_m80(bus),
                 _ => unreachable!(),
@@ -295,23 +295,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 _ => self.clk(Self::timing(2, 2)), // reserved
             }
         }
+        Ok(())
     }
 
     // DC: Double-precision arithmetic
-    fn fpu_esc_dc(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) {
+    fn fpu_esc_dc(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) -> Step {
         let reg = (modrm >> 3) & 7;
         self.fpu_update_pointers(4, modrm, has_memory);
 
         if has_memory {
             match reg {
-                0 => self.fpu_fadd_m64(bus),
-                1 => self.fpu_fmul_m64(bus),
-                2 => self.fpu_fcom_m64(bus),
-                3 => self.fpu_fcomp_m64(bus),
-                4 => self.fpu_fsub_m64(bus),
-                5 => self.fpu_fsubr_m64(bus),
-                6 => self.fpu_fdiv_m64(bus),
-                7 => self.fpu_fdivr_m64(bus),
+                0 => self.fpu_fadd_m64(bus)?,
+                1 => self.fpu_fmul_m64(bus)?,
+                2 => self.fpu_fcom_m64(bus)?,
+                3 => self.fpu_fcomp_m64(bus)?,
+                4 => self.fpu_fsub_m64(bus)?,
+                5 => self.fpu_fsubr_m64(bus)?,
+                6 => self.fpu_fdiv_m64(bus)?,
+                7 => self.fpu_fdivr_m64(bus)?,
                 _ => unreachable!(),
             }
         } else {
@@ -327,10 +328,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 _ => self.clk(Self::timing(2, 2)), // reserved (2,3 in register form)
             }
         }
+        Ok(())
     }
 
     // DD: Double-precision memory, stack management
-    fn fpu_esc_dd(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) {
+    fn fpu_esc_dd(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) -> Step {
         if has_memory {
             let reg = (modrm >> 3) & 7;
             // FRSTOR(4), FSAVE(6), FSTSW(7) are control-ish, but FRSTOR/FSAVE do update
@@ -339,13 +341,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.fpu_update_pointers(5, modrm, true);
             }
             match reg {
-                0 => self.fpu_fld_m64(bus),
+                0 => self.fpu_fld_m64(bus)?,
                 1 => self.clk(Self::timing(2, 2)), // reserved
                 2 => self.fpu_fst_m64(bus),
                 3 => self.fpu_fstp_m64(bus),
-                4 => self.fpu_frstor(bus),
+                4 => self.fpu_frstor(bus)?,
                 5 => self.clk(Self::timing(2, 2)), // reserved
-                6 => self.fpu_fnsave(bus),
+                6 => self.fpu_fnsave(bus)?,
                 7 => self.fpu_fnstsw_m16(bus),
                 _ => unreachable!(),
             }
@@ -379,23 +381,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 _ => self.clk(Self::timing(2, 2)), // reserved
             }
         }
+        Ok(())
     }
 
     // DE: 16-bit integer arithmetic, pop variants
-    fn fpu_esc_de(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) {
+    fn fpu_esc_de(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) -> Step {
         let reg = (modrm >> 3) & 7;
         self.fpu_update_pointers(6, modrm, has_memory);
 
         if has_memory {
             match reg {
-                0 => self.fpu_fiadd_m16(bus),
-                1 => self.fpu_fimul_m16(bus),
-                2 => self.fpu_ficom_m16(bus),
-                3 => self.fpu_ficomp_m16(bus),
-                4 => self.fpu_fisub_m16(bus),
-                5 => self.fpu_fisubr_m16(bus),
-                6 => self.fpu_fidiv_m16(bus),
-                7 => self.fpu_fidivr_m16(bus),
+                0 => self.fpu_fiadd_m16(bus)?,
+                1 => self.fpu_fimul_m16(bus)?,
+                2 => self.fpu_ficom_m16(bus)?,
+                3 => self.fpu_ficomp_m16(bus)?,
+                4 => self.fpu_fisub_m16(bus)?,
+                5 => self.fpu_fisubr_m16(bus)?,
+                6 => self.fpu_fidiv_m16(bus)?,
+                7 => self.fpu_fidivr_m16(bus)?,
                 _ => unreachable!(),
             }
         } else {
@@ -418,20 +421,21 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 _ => self.clk(Self::timing(2, 2)), // reserved
             }
         }
+        Ok(())
     }
 
     // DF: 16/64-bit integer, BCD, status word
-    fn fpu_esc_df(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) {
+    fn fpu_esc_df(&mut self, modrm: u8, has_memory: bool, bus: &mut impl common::Bus) -> Step {
         if has_memory {
             let reg = (modrm >> 3) & 7;
             self.fpu_update_pointers(7, modrm, true);
             match reg {
-                0 => self.fpu_fild_m16(bus),
+                0 => self.fpu_fild_m16(bus)?,
                 1 => self.clk(Self::timing(2, 2)), // reserved
                 2 => self.fpu_fist_m16(bus),
                 3 => self.fpu_fistp_m16(bus),
-                4 => self.fpu_fbld(bus),
-                5 => self.fpu_fild_m64(bus),
+                4 => self.fpu_fbld(bus)?,
+                5 => self.fpu_fild_m64(bus)?,
                 6 => self.fpu_fbstp(bus),
                 7 => self.fpu_fistp_m64(bus),
                 _ => unreachable!(),
@@ -443,5 +447,6 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 _ => self.clk(Self::timing(2, 2)), // reserved
             }
         }
+        Ok(())
     }
 }

--- a/crates/cpu/src/i386/fpu_ops.rs
+++ b/crates/cpu/src/i386/fpu_ops.rs
@@ -119,48 +119,44 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(14, 4));
     }
 
-    pub(super) fn fpu_fst_m32(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_fst_m32(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.fpu_check_underflow(0) {
             let masked = self.state.fpu.control_word & 1 != 0;
             if masked {
                 let bits = Fp80::INDEFINITE
                     .to_f32(self.fpu_rounding_mode(), &mut ExceptionFlags::default());
-                if self.fpu_write_u32(bus, bits.to_bits()).is_err() {
-                    return;
-                }
+                self.fpu_write_u32(bus, bits.to_bits())?;
             }
             self.clk(Self::timing(44, 7));
+            return Ok(());
         }
         let val = self.fpu_st(0);
         let mut ef = ExceptionFlags::default();
         let f = val.to_f32(self.fpu_rounding_mode(), &mut ef);
         self.fpu_check_result(&ef);
-        if self.fpu_write_u32(bus, f.to_bits()).is_err() {
-            return;
-        }
+        self.fpu_write_u32(bus, f.to_bits())?;
         self.clk(Self::timing(44, 7));
+        Ok(())
     }
 
-    pub(super) fn fpu_fst_m64(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_fst_m64(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.fpu_check_underflow(0) {
             let masked = self.state.fpu.control_word & 1 != 0;
             if masked {
                 let bits = Fp80::INDEFINITE
                     .to_f64(self.fpu_rounding_mode(), &mut ExceptionFlags::default());
-                if self.fpu_write_u64(bus, bits.to_bits()).is_err() {
-                    return;
-                }
+                self.fpu_write_u64(bus, bits.to_bits())?;
             }
             self.clk(Self::timing(45, 8));
+            return Ok(());
         }
         let val = self.fpu_st(0);
         let mut ef = ExceptionFlags::default();
         let f = val.to_f64(self.fpu_rounding_mode(), &mut ef);
         self.fpu_check_result(&ef);
-        if self.fpu_write_u64(bus, f.to_bits()).is_err() {
-            return;
-        }
+        self.fpu_write_u64(bus, f.to_bits())?;
         self.clk(Self::timing(45, 8));
+        Ok(())
     }
 
     pub(super) fn fpu_fst_sti(&mut self, i: u8) {
@@ -177,14 +173,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(11, 3));
     }
 
-    pub(super) fn fpu_fstp_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_fst_m32(bus);
+    pub(super) fn fpu_fstp_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_fst_m32(bus)?;
         self.fpu_pop();
+        Ok(())
     }
 
-    pub(super) fn fpu_fstp_m64(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_fst_m64(bus);
+    pub(super) fn fpu_fstp_m64(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_fst_m64(bus)?;
         self.fpu_pop();
+        Ok(())
     }
 
     pub(super) fn fpu_fstp_m80(&mut self, bus: &mut impl common::Bus) {
@@ -238,51 +236,52 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         Ok(())
     }
 
-    pub(super) fn fpu_fist_m16(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_fist_m16(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.fpu_check_underflow(0) {
             let masked = self.state.fpu.control_word & 1 != 0;
-            if masked && self.fpu_write_u16(bus, 0x8000u16).is_err() {
-                return;
+            if masked {
+                self.fpu_write_u16(bus, 0x8000u16)?;
             }
             self.clk(Self::timing(82, 29));
+            return Ok(());
         }
         let val = self.fpu_st(0);
         let mut ef = ExceptionFlags::default();
         let i = val.to_i16(self.fpu_rounding_mode(), &mut ef);
         self.fpu_check_result(&ef);
-        if self.fpu_write_u16(bus, i as u16).is_err() {
-            return;
-        }
+        self.fpu_write_u16(bus, i as u16)?;
         self.clk(Self::timing(82, 29));
+        Ok(())
     }
 
-    pub(super) fn fpu_fist_m32(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_fist_m32(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.fpu_check_underflow(0) {
             let masked = self.state.fpu.control_word & 1 != 0;
-            if masked && self.fpu_write_u32(bus, 0x8000_0000u32).is_err() {
-                return;
+            if masked {
+                self.fpu_write_u32(bus, 0x8000_0000u32)?;
             }
             self.clk(Self::timing(79, 28));
-            return;
+            return Ok(());
         }
         let val = self.fpu_st(0);
         let mut ef = ExceptionFlags::default();
         let i = val.to_i32(self.fpu_rounding_mode(), &mut ef);
         self.fpu_check_result(&ef);
-        if self.fpu_write_u32(bus, i as u32).is_err() {
-            return;
-        }
+        self.fpu_write_u32(bus, i as u32)?;
         self.clk(Self::timing(79, 28));
+        Ok(())
     }
 
-    pub(super) fn fpu_fistp_m16(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_fist_m16(bus);
+    pub(super) fn fpu_fistp_m16(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_fist_m16(bus)?;
         self.fpu_pop();
+        Ok(())
     }
 
-    pub(super) fn fpu_fistp_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_fist_m32(bus);
+    pub(super) fn fpu_fistp_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_fist_m32(bus)?;
         self.fpu_pop();
+        Ok(())
     }
 
     pub(super) fn fpu_fistp_m64(&mut self, bus: &mut impl common::Bus) {

--- a/crates/cpu/src/i386/fpu_ops.rs
+++ b/crates/cpu/src/i386/fpu_ops.rs
@@ -1,6 +1,6 @@
 use softfloat::{ExceptionFlags, Fp80, FpOrdering, Precision, RoundingMode};
 
-use super::I386;
+use super::{I386, Step};
 
 impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     pub(super) fn fpu_fninit(&mut self) {
@@ -13,18 +13,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(11, 7));
     }
 
-    pub(super) fn fpu_fldcw(&mut self, bus: &mut impl common::Bus) {
-        let Some(cw) = self.fpu_read_u16(bus) else {
-            return;
-        };
+    pub(super) fn fpu_fldcw(&mut self, bus: &mut impl common::Bus) -> Step {
+        let cw = self.fpu_read_u16(bus)?;
         self.state.fpu.control_word = cw;
         self.fpu_update_es();
         self.clk(Self::timing(19, 4));
+        Ok(())
     }
 
     pub(super) fn fpu_fnstcw(&mut self, bus: &mut impl common::Bus) {
         let cw = self.state.fpu.control_word;
-        if self.fpu_write_u16(bus, cw).is_none() {
+        if self.fpu_write_u16(bus, cw).is_err() {
             return;
         }
         self.clk(Self::timing(15, 3));
@@ -32,7 +31,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
     pub(super) fn fpu_fnstsw_m16(&mut self, bus: &mut impl common::Bus) {
         let sw = self.state.fpu.status_word;
-        if self.fpu_write_u16(bus, sw).is_none() {
+        if self.fpu_write_u16(bus, sw).is_err() {
             return;
         }
         self.clk(Self::timing(15, 3));
@@ -76,37 +75,34 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(18, 3));
     }
 
-    pub(super) fn fpu_fld_m32(&mut self, bus: &mut impl common::Bus) {
-        let Some(raw) = self.fpu_read_u32(bus) else {
-            return;
-        };
+    pub(super) fn fpu_fld_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        let raw = self.fpu_read_u32(bus)?;
         let val = f32::from_bits(raw);
         let mut ef = ExceptionFlags::default();
         let fp = Fp80::from_f32(val, &mut ef);
         self.fpu_check_result(&ef);
         self.fpu_push(fp);
         self.clk(Self::timing(20, 3));
+        Ok(())
     }
 
-    pub(super) fn fpu_fld_m64(&mut self, bus: &mut impl common::Bus) {
-        let Some(raw) = self.fpu_read_u64(bus) else {
-            return;
-        };
+    pub(super) fn fpu_fld_m64(&mut self, bus: &mut impl common::Bus) -> Step {
+        let raw = self.fpu_read_u64(bus)?;
         let val = f64::from_bits(raw);
         let mut ef = ExceptionFlags::default();
         let fp = Fp80::from_f64(val, &mut ef);
         self.fpu_check_result(&ef);
         self.fpu_push(fp);
         self.clk(Self::timing(25, 3));
+        Ok(())
     }
 
-    pub(super) fn fpu_fld_m80(&mut self, bus: &mut impl common::Bus) {
-        let Some(bytes) = self.fpu_read_tbyte(bus) else {
-            return;
-        };
+    pub(super) fn fpu_fld_m80(&mut self, bus: &mut impl common::Bus) -> Step {
+        let bytes = self.fpu_read_tbyte(bus)?;
         let fp = Fp80::from_le_bytes(bytes);
         self.fpu_push(fp);
         self.clk(Self::timing(44, 6));
+        Ok(())
     }
 
     pub(super) fn fpu_fld_sti(&mut self, i: u8) {
@@ -129,18 +125,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             if masked {
                 let bits = Fp80::INDEFINITE
                     .to_f32(self.fpu_rounding_mode(), &mut ExceptionFlags::default());
-                if self.fpu_write_u32(bus, bits.to_bits()).is_none() {
+                if self.fpu_write_u32(bus, bits.to_bits()).is_err() {
                     return;
                 }
             }
             self.clk(Self::timing(44, 7));
-            return;
         }
         let val = self.fpu_st(0);
         let mut ef = ExceptionFlags::default();
         let f = val.to_f32(self.fpu_rounding_mode(), &mut ef);
         self.fpu_check_result(&ef);
-        if self.fpu_write_u32(bus, f.to_bits()).is_none() {
+        if self.fpu_write_u32(bus, f.to_bits()).is_err() {
             return;
         }
         self.clk(Self::timing(44, 7));
@@ -152,18 +147,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             if masked {
                 let bits = Fp80::INDEFINITE
                     .to_f64(self.fpu_rounding_mode(), &mut ExceptionFlags::default());
-                if self.fpu_write_u64(bus, bits.to_bits()).is_none() {
+                if self.fpu_write_u64(bus, bits.to_bits()).is_err() {
                     return;
                 }
             }
             self.clk(Self::timing(45, 8));
-            return;
         }
         let val = self.fpu_st(0);
         let mut ef = ExceptionFlags::default();
         let f = val.to_f64(self.fpu_rounding_mode(), &mut ef);
         self.fpu_check_result(&ef);
-        if self.fpu_write_u64(bus, f.to_bits()).is_none() {
+        if self.fpu_write_u64(bus, f.to_bits()).is_err() {
             return;
         }
         self.clk(Self::timing(45, 8));
@@ -185,17 +179,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
     pub(super) fn fpu_fstp_m32(&mut self, bus: &mut impl common::Bus) {
         self.fpu_fst_m32(bus);
-        if self.fault_pending {
-            return;
-        }
         self.fpu_pop();
     }
 
     pub(super) fn fpu_fstp_m64(&mut self, bus: &mut impl common::Bus) {
         self.fpu_fst_m64(bus);
-        if self.fault_pending {
-            return;
-        }
         self.fpu_pop();
     }
 
@@ -205,7 +193,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             if masked
                 && self
                     .fpu_write_tbyte(bus, &Fp80::INDEFINITE.to_le_bytes())
-                    .is_none()
+                    .is_err()
             {
                 return;
             }
@@ -214,7 +202,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             return;
         }
         let val = self.fpu_st(0);
-        if self.fpu_write_tbyte(bus, &val.to_le_bytes()).is_none() {
+        if self.fpu_write_tbyte(bus, &val.to_le_bytes()).is_err() {
             return;
         }
         self.fpu_pop();
@@ -226,47 +214,43 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_pop();
     }
 
-    pub(super) fn fpu_fild_m16(&mut self, bus: &mut impl common::Bus) {
-        let Some(raw) = self.fpu_read_u16(bus) else {
-            return;
-        };
+    pub(super) fn fpu_fild_m16(&mut self, bus: &mut impl common::Bus) -> Step {
+        let raw = self.fpu_read_u16(bus)?;
         let fp = Fp80::from_i16(raw as i16);
         self.fpu_push(fp);
         self.clk(Self::timing(61, 13));
+        Ok(())
     }
 
-    pub(super) fn fpu_fild_m32(&mut self, bus: &mut impl common::Bus) {
-        let Some(raw) = self.fpu_read_u32(bus) else {
-            return;
-        };
+    pub(super) fn fpu_fild_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        let raw = self.fpu_read_u32(bus)?;
         let fp = Fp80::from_i32(raw as i32);
         self.fpu_push(fp);
         self.clk(Self::timing(45, 9));
+        Ok(())
     }
 
-    pub(super) fn fpu_fild_m64(&mut self, bus: &mut impl common::Bus) {
-        let Some(raw) = self.fpu_read_u64(bus) else {
-            return;
-        };
+    pub(super) fn fpu_fild_m64(&mut self, bus: &mut impl common::Bus) -> Step {
+        let raw = self.fpu_read_u64(bus)?;
         let fp = Fp80::from_i64(raw as i64);
         self.fpu_push(fp);
         self.clk(Self::timing(56, 10));
+        Ok(())
     }
 
     pub(super) fn fpu_fist_m16(&mut self, bus: &mut impl common::Bus) {
         if self.fpu_check_underflow(0) {
             let masked = self.state.fpu.control_word & 1 != 0;
-            if masked && self.fpu_write_u16(bus, 0x8000u16).is_none() {
+            if masked && self.fpu_write_u16(bus, 0x8000u16).is_err() {
                 return;
             }
             self.clk(Self::timing(82, 29));
-            return;
         }
         let val = self.fpu_st(0);
         let mut ef = ExceptionFlags::default();
         let i = val.to_i16(self.fpu_rounding_mode(), &mut ef);
         self.fpu_check_result(&ef);
-        if self.fpu_write_u16(bus, i as u16).is_none() {
+        if self.fpu_write_u16(bus, i as u16).is_err() {
             return;
         }
         self.clk(Self::timing(82, 29));
@@ -275,7 +259,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
     pub(super) fn fpu_fist_m32(&mut self, bus: &mut impl common::Bus) {
         if self.fpu_check_underflow(0) {
             let masked = self.state.fpu.control_word & 1 != 0;
-            if masked && self.fpu_write_u32(bus, 0x8000_0000u32).is_none() {
+            if masked && self.fpu_write_u32(bus, 0x8000_0000u32).is_err() {
                 return;
             }
             self.clk(Self::timing(79, 28));
@@ -285,7 +269,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let mut ef = ExceptionFlags::default();
         let i = val.to_i32(self.fpu_rounding_mode(), &mut ef);
         self.fpu_check_result(&ef);
-        if self.fpu_write_u32(bus, i as u32).is_none() {
+        if self.fpu_write_u32(bus, i as u32).is_err() {
             return;
         }
         self.clk(Self::timing(79, 28));
@@ -293,24 +277,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
     pub(super) fn fpu_fistp_m16(&mut self, bus: &mut impl common::Bus) {
         self.fpu_fist_m16(bus);
-        if self.fault_pending {
-            return;
-        }
         self.fpu_pop();
     }
 
     pub(super) fn fpu_fistp_m32(&mut self, bus: &mut impl common::Bus) {
         self.fpu_fist_m32(bus);
-        if self.fault_pending {
-            return;
-        }
         self.fpu_pop();
     }
 
     pub(super) fn fpu_fistp_m64(&mut self, bus: &mut impl common::Bus) {
         if self.fpu_check_underflow(0) {
             let masked = self.state.fpu.control_word & 1 != 0;
-            if masked && self.fpu_write_u64(bus, 0x8000_0000_0000_0000u64).is_none() {
+            if masked && self.fpu_write_u64(bus, 0x8000_0000_0000_0000u64).is_err() {
                 return;
             }
             self.fpu_pop();
@@ -321,22 +299,21 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let mut ef = ExceptionFlags::default();
         let i = val.to_i64(self.fpu_rounding_mode(), &mut ef);
         self.fpu_check_result(&ef);
-        if self.fpu_write_u64(bus, i as u64).is_none() {
+        if self.fpu_write_u64(bus, i as u64).is_err() {
             return;
         }
         self.fpu_pop();
         self.clk(Self::timing(80, 28));
     }
 
-    pub(super) fn fpu_fbld(&mut self, bus: &mut impl common::Bus) {
-        let Some(bytes) = self.fpu_read_tbyte(bus) else {
-            return;
-        };
+    pub(super) fn fpu_fbld(&mut self, bus: &mut impl common::Bus) -> Step {
+        let bytes = self.fpu_read_tbyte(bus)?;
         let mut ef = ExceptionFlags::default();
         let fp = Fp80::from_bcd(bytes, &mut ef);
         self.fpu_check_result(&ef);
         self.fpu_push(fp);
         self.clk(Self::timing(266, 70));
+        Ok(())
     }
 
     pub(super) fn fpu_fbstp(&mut self, bus: &mut impl common::Bus) {
@@ -348,7 +325,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                         bus,
                         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0xFF, 0xFF],
                     )
-                    .is_none()
+                    .is_err()
             {
                 return;
             }
@@ -360,7 +337,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let mut ef = ExceptionFlags::default();
         let bcd = val.to_bcd(self.fpu_rounding_mode(), &mut ef);
         self.fpu_check_result(&ef);
-        if self.fpu_write_tbyte(bus, &bcd).is_none() {
+        if self.fpu_write_tbyte(bus, &bcd).is_err() {
             return;
         }
         self.fpu_pop();
@@ -487,18 +464,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         t387: i32,
         t486: i32,
         bus: &mut impl common::Bus,
-    ) {
+    ) -> Step {
         if self.fpu_check_underflow(0) {
             let masked = self.state.fpu.control_word & 1 != 0;
             if masked {
                 self.fpu_write_st(0, Fp80::INDEFINITE);
             }
             self.clk(Self::timing(t387, t486));
-            return;
+            return Ok(());
         }
-        let Some(raw) = self.fpu_read_u32(bus) else {
-            return;
-        };
+        let raw = self.fpu_read_u32(bus)?;
         let val = f32::from_bits(raw);
         let mut ef = ExceptionFlags::default();
         let b = Fp80::from_f32(val, &mut ef);
@@ -509,6 +484,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_check_result(&ef);
         self.fpu_write_st(0, result);
         self.clk(Self::timing(t387, t486));
+        Ok(())
     }
 
     fn fpu_arith_m64(
@@ -517,18 +493,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         t387: i32,
         t486: i32,
         bus: &mut impl common::Bus,
-    ) {
+    ) -> Step {
         if self.fpu_check_underflow(0) {
             let masked = self.state.fpu.control_word & 1 != 0;
             if masked {
                 self.fpu_write_st(0, Fp80::INDEFINITE);
             }
             self.clk(Self::timing(t387, t486));
-            return;
+            return Ok(());
         }
-        let Some(raw) = self.fpu_read_u64(bus) else {
-            return;
-        };
+        let raw = self.fpu_read_u64(bus)?;
         let val = f64::from_bits(raw);
         let mut ef = ExceptionFlags::default();
         let b = Fp80::from_f64(val, &mut ef);
@@ -539,6 +513,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_check_result(&ef);
         self.fpu_write_st(0, result);
         self.clk(Self::timing(t387, t486));
+        Ok(())
     }
 
     fn fpu_arith_mi32(
@@ -547,18 +522,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         t387: i32,
         t486: i32,
         bus: &mut impl common::Bus,
-    ) {
+    ) -> Step {
         if self.fpu_check_underflow(0) {
             let masked = self.state.fpu.control_word & 1 != 0;
             if masked {
                 self.fpu_write_st(0, Fp80::INDEFINITE);
             }
             self.clk(Self::timing(t387, t486));
-            return;
+            return Ok(());
         }
-        let Some(raw) = self.fpu_read_u32(bus) else {
-            return;
-        };
+        let raw = self.fpu_read_u32(bus)?;
         let b = Fp80::from_i32(raw as i32);
         let a = self.fpu_st(0);
         let rc = self.fpu_rounding_mode();
@@ -568,6 +541,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_check_result(&ef);
         self.fpu_write_st(0, result);
         self.clk(Self::timing(t387, t486));
+        Ok(())
     }
 
     fn fpu_arith_mi16(
@@ -576,18 +550,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         t387: i32,
         t486: i32,
         bus: &mut impl common::Bus,
-    ) {
+    ) -> Step {
         if self.fpu_check_underflow(0) {
             let masked = self.state.fpu.control_word & 1 != 0;
             if masked {
                 self.fpu_write_st(0, Fp80::INDEFINITE);
             }
             self.clk(Self::timing(t387, t486));
-            return;
+            return Ok(());
         }
-        let Some(raw) = self.fpu_read_u16(bus) else {
-            return;
-        };
+        let raw = self.fpu_read_u16(bus)?;
         let b = Fp80::from_i16(raw as i16);
         let a = self.fpu_st(0);
         let rc = self.fpu_rounding_mode();
@@ -597,14 +569,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_check_result(&ef);
         self.fpu_write_st(0, result);
         self.clk(Self::timing(t387, t486));
+        Ok(())
     }
 
-    pub(super) fn fpu_fadd_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_m32(Fp80::add, 24, 8, bus);
+    pub(super) fn fpu_fadd_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_m32(Fp80::add, 24, 8, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fadd_m64(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_m64(Fp80::add, 29, 8, bus);
+    pub(super) fn fpu_fadd_m64(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_m64(Fp80::add, 29, 8, bus)?;
+        Ok(())
     }
 
     pub(super) fn fpu_fadd_st0_sti(&mut self, i: u8) {
@@ -620,20 +595,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_pop();
     }
 
-    pub(super) fn fpu_fiadd_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_mi32(Fp80::add, 57, 19, bus);
+    pub(super) fn fpu_fiadd_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_mi32(Fp80::add, 57, 19, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fiadd_m16(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_mi16(Fp80::add, 71, 20, bus);
+    pub(super) fn fpu_fiadd_m16(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_mi16(Fp80::add, 71, 20, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fsub_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_m32(Fp80::sub, 24, 8, bus);
+    pub(super) fn fpu_fsub_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_m32(Fp80::sub, 24, 8, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fsub_m64(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_m64(Fp80::sub, 28, 8, bus);
+    pub(super) fn fpu_fsub_m64(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_m64(Fp80::sub, 28, 8, bus)?;
+        Ok(())
     }
 
     pub(super) fn fpu_fsub_st0_sti(&mut self, i: u8) {
@@ -649,12 +628,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_pop();
     }
 
-    pub(super) fn fpu_fisub_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_mi32(Fp80::sub, 57, 19, bus);
+    pub(super) fn fpu_fisub_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_mi32(Fp80::sub, 57, 19, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fisub_m16(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_mi16(Fp80::sub, 71, 20, bus);
+    pub(super) fn fpu_fisub_m16(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_mi16(Fp80::sub, 71, 20, bus)?;
+        Ok(())
     }
 
     fn fpu_subr(
@@ -667,12 +648,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         Fp80::sub(b, a, rc, pc, ef)
     }
 
-    pub(super) fn fpu_fsubr_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_m32(Self::fpu_subr, 24, 8, bus);
+    pub(super) fn fpu_fsubr_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_m32(Self::fpu_subr, 24, 8, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fsubr_m64(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_m64(Self::fpu_subr, 28, 8, bus);
+    pub(super) fn fpu_fsubr_m64(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_m64(Self::fpu_subr, 28, 8, bus)?;
+        Ok(())
     }
 
     pub(super) fn fpu_fsubr_st0_sti(&mut self, i: u8) {
@@ -690,20 +673,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_pop();
     }
 
-    pub(super) fn fpu_fisubr_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_mi32(Self::fpu_subr, 57, 19, bus);
+    pub(super) fn fpu_fisubr_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_mi32(Self::fpu_subr, 57, 19, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fisubr_m16(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_mi16(Self::fpu_subr, 71, 20, bus);
+    pub(super) fn fpu_fisubr_m16(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_mi16(Self::fpu_subr, 71, 20, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fmul_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_m32(Fp80::mul, 27, 11, bus);
+    pub(super) fn fpu_fmul_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_m32(Fp80::mul, 27, 11, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fmul_m64(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_m64(Fp80::mul, 32, 14, bus);
+    pub(super) fn fpu_fmul_m64(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_m64(Fp80::mul, 32, 14, bus)?;
+        Ok(())
     }
 
     pub(super) fn fpu_fmul_st0_sti(&mut self, i: u8) {
@@ -719,20 +706,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_pop();
     }
 
-    pub(super) fn fpu_fimul_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_mi32(Fp80::mul, 61, 22, bus);
+    pub(super) fn fpu_fimul_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_mi32(Fp80::mul, 61, 22, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fimul_m16(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_mi16(Fp80::mul, 76, 23, bus);
+    pub(super) fn fpu_fimul_m16(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_mi16(Fp80::mul, 76, 23, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fdiv_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_m32(Fp80::div, 89, 73, bus);
+    pub(super) fn fpu_fdiv_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_m32(Fp80::div, 89, 73, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fdiv_m64(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_m64(Fp80::div, 94, 73, bus);
+    pub(super) fn fpu_fdiv_m64(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_m64(Fp80::div, 94, 73, bus)?;
+        Ok(())
     }
 
     pub(super) fn fpu_fdiv_st0_sti(&mut self, i: u8) {
@@ -748,12 +739,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_pop();
     }
 
-    pub(super) fn fpu_fidiv_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_mi32(Fp80::div, 120, 84, bus);
+    pub(super) fn fpu_fidiv_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_mi32(Fp80::div, 120, 84, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fidiv_m16(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_mi16(Fp80::div, 136, 85, bus);
+    pub(super) fn fpu_fidiv_m16(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_mi16(Fp80::div, 136, 85, bus)?;
+        Ok(())
     }
 
     fn fpu_divr(
@@ -766,12 +759,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         Fp80::div(b, a, rc, pc, ef)
     }
 
-    pub(super) fn fpu_fdivr_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_m32(Self::fpu_divr, 89, 73, bus);
+    pub(super) fn fpu_fdivr_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_m32(Self::fpu_divr, 89, 73, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fdivr_m64(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_m64(Self::fpu_divr, 94, 73, bus);
+    pub(super) fn fpu_fdivr_m64(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_m64(Self::fpu_divr, 94, 73, bus)?;
+        Ok(())
     }
 
     pub(super) fn fpu_fdivr_st0_sti(&mut self, i: u8) {
@@ -787,12 +782,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_pop();
     }
 
-    pub(super) fn fpu_fidivr_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_mi32(Self::fpu_divr, 121, 84, bus);
+    pub(super) fn fpu_fidivr_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_mi32(Self::fpu_divr, 121, 84, bus)?;
+        Ok(())
     }
 
-    pub(super) fn fpu_fidivr_m16(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_arith_mi16(Self::fpu_divr, 135, 85, bus);
+    pub(super) fn fpu_fidivr_m16(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_arith_mi16(Self::fpu_divr, 135, 85, bus)?;
+        Ok(())
     }
 
     // Unary arithmetic
@@ -957,15 +954,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_set_cc(c3, c2, false, c0);
     }
 
-    pub(super) fn fpu_fcom_m32(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_fcom_m32(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.fpu_check_underflow(0) {
             self.fpu_compare_and_set_cc(FpOrdering::Unordered);
             self.clk(Self::timing(26, 4));
-            return;
+            return Ok(());
         }
-        let Some(raw) = self.fpu_read_u32(bus) else {
-            return;
-        };
+        let raw = self.fpu_read_u32(bus)?;
         let val = f32::from_bits(raw);
         let mut ef = ExceptionFlags::default();
         let b = Fp80::from_f32(val, &mut ef);
@@ -974,17 +969,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_check_result(&ef);
         self.fpu_compare_and_set_cc(ordering);
         self.clk(Self::timing(26, 4));
+        Ok(())
     }
 
-    pub(super) fn fpu_fcom_m64(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_fcom_m64(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.fpu_check_underflow(0) {
             self.fpu_compare_and_set_cc(FpOrdering::Unordered);
             self.clk(Self::timing(31, 4));
-            return;
+            return Ok(());
         }
-        let Some(raw) = self.fpu_read_u64(bus) else {
-            return;
-        };
+        let raw = self.fpu_read_u64(bus)?;
         let val = f64::from_bits(raw);
         let mut ef = ExceptionFlags::default();
         let b = Fp80::from_f64(val, &mut ef);
@@ -993,6 +987,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_check_result(&ef);
         self.fpu_compare_and_set_cc(ordering);
         self.clk(Self::timing(31, 4));
+        Ok(())
     }
 
     pub(super) fn fpu_fcom_sti(&mut self, i: u8) {
@@ -1010,20 +1005,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(24, 4));
     }
 
-    pub(super) fn fpu_fcomp_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_fcom_m32(bus);
-        if self.fault_pending {
-            return;
-        }
+    pub(super) fn fpu_fcomp_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_fcom_m32(bus)?;
         self.fpu_pop();
+        Ok(())
     }
 
-    pub(super) fn fpu_fcomp_m64(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_fcom_m64(bus);
-        if self.fault_pending {
-            return;
-        }
+    pub(super) fn fpu_fcomp_m64(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_fcom_m64(bus)?;
         self.fpu_pop();
+        Ok(())
     }
 
     pub(super) fn fpu_fcomp_sti(&mut self, i: u8) {
@@ -1089,15 +1080,13 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(26, 5));
     }
 
-    pub(super) fn fpu_ficom_m32(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_ficom_m32(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.fpu_check_underflow(0) {
             self.fpu_compare_and_set_cc(FpOrdering::Unordered);
             self.clk(Self::timing(56, 15));
-            return;
+            return Ok(());
         }
-        let Some(raw) = self.fpu_read_u32(bus) else {
-            return;
-        };
+        let raw = self.fpu_read_u32(bus)?;
         let b = Fp80::from_i32(raw as i32);
         let a = self.fpu_st(0);
         let mut ef = ExceptionFlags::default();
@@ -1105,17 +1094,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_check_result(&ef);
         self.fpu_compare_and_set_cc(ordering);
         self.clk(Self::timing(56, 15));
+        Ok(())
     }
 
-    pub(super) fn fpu_ficom_m16(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_ficom_m16(&mut self, bus: &mut impl common::Bus) -> Step {
         if self.fpu_check_underflow(0) {
             self.fpu_compare_and_set_cc(FpOrdering::Unordered);
             self.clk(Self::timing(71, 16));
-            return;
+            return Ok(());
         }
-        let Some(raw) = self.fpu_read_u16(bus) else {
-            return;
-        };
+        let raw = self.fpu_read_u16(bus)?;
         let b = Fp80::from_i16(raw as i16);
         let a = self.fpu_st(0);
         let mut ef = ExceptionFlags::default();
@@ -1123,22 +1111,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.fpu_check_result(&ef);
         self.fpu_compare_and_set_cc(ordering);
         self.clk(Self::timing(71, 16));
+        Ok(())
     }
 
-    pub(super) fn fpu_ficomp_m32(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_ficom_m32(bus);
-        if self.fault_pending {
-            return;
-        }
+    pub(super) fn fpu_ficomp_m32(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_ficom_m32(bus)?;
         self.fpu_pop();
+        Ok(())
     }
 
-    pub(super) fn fpu_ficomp_m16(&mut self, bus: &mut impl common::Bus) {
-        self.fpu_ficom_m16(bus);
-        if self.fault_pending {
-            return;
-        }
+    pub(super) fn fpu_ficomp_m16(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.fpu_ficom_m16(bus)?;
         self.fpu_pop();
+        Ok(())
     }
 
     pub(super) fn fpu_ftst(&mut self) {
@@ -1364,7 +1349,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             self.fpu_fnstenv_16bit(protected, bus)
         };
-        if saved.is_none() {
+        if saved.is_err() {
             return;
         }
 
@@ -1375,7 +1360,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(103, 67));
     }
 
-    fn fpu_fnstenv_16bit(&mut self, protected: bool, bus: &mut impl common::Bus) -> Option<()> {
+    fn fpu_fnstenv_16bit(&mut self, protected: bool, bus: &mut impl common::Bus) -> Step {
         let base = self.ea;
         self.write_word_linear(bus, base, self.state.fpu.control_word)?;
         self.write_word_linear(bus, base.wrapping_add(2), self.state.fpu.status_word)?;
@@ -1385,7 +1370,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.write_word_linear(bus, base.wrapping_add(6), self.state.fpu.fip_offset as u16)?;
             self.write_word_linear(bus, base.wrapping_add(8), self.state.fpu.fip_selector)?;
             self.write_word_linear(bus, base.wrapping_add(10), self.state.fpu.fdp_offset as u16)?;
-            self.write_word_linear(bus, base.wrapping_add(12), self.state.fpu.fdp_selector)?;
+            self.write_word_linear(bus, base.wrapping_add(12), self.state.fpu.fdp_selector)
         } else {
             self.write_word_linear(bus, base.wrapping_add(6), self.state.fpu.fip_offset as u16)?;
             let ip_hi_opcode = (self.state.fpu.fpu_opcode & 0x7FF)
@@ -1396,23 +1381,22 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 bus,
                 base.wrapping_add(12),
                 ((self.state.fpu.fdp_offset >> 16) as u16 & 0xF) << 12,
-            )?;
+            )
         }
-        Some(())
     }
 
-    fn fpu_write_env_u32(&mut self, bus: &mut impl common::Bus, addr: u32, val: u32) -> Option<()> {
+    fn fpu_write_env_u32(&mut self, bus: &mut impl common::Bus, addr: u32, val: u32) -> Step {
         self.write_word_linear(bus, addr, val as u16)?;
         self.write_word_linear(bus, addr.wrapping_add(2), (val >> 16) as u16)
     }
 
-    fn fpu_read_env_u32(&mut self, bus: &mut impl common::Bus, addr: u32) -> Option<u32> {
+    fn fpu_read_env_u32(&mut self, bus: &mut impl common::Bus, addr: u32) -> Step<u32> {
         let lo = self.read_word_linear(bus, addr)? as u32;
         let hi = self.read_word_linear(bus, addr.wrapping_add(2))? as u32;
-        Some(lo | (hi << 16))
+        Ok(lo | (hi << 16))
     }
 
-    fn fpu_fnstenv_32bit(&mut self, protected: bool, bus: &mut impl common::Bus) -> Option<()> {
+    fn fpu_fnstenv_32bit(&mut self, protected: bool, bus: &mut impl common::Bus) -> Step {
         let base = self.ea;
         self.fpu_write_env_u32(bus, base, 0xFFFF_0000 | self.state.fpu.control_word as u32)?;
         self.fpu_write_env_u32(
@@ -1436,7 +1420,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 bus,
                 base.wrapping_add(24),
                 0xFFFF_0000 | self.state.fpu.fdp_selector as u32,
-            )?;
+            )
         } else {
             self.fpu_write_env_u32(
                 bus,
@@ -1452,9 +1436,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 0xFFFF_0000 | (self.state.fpu.fdp_offset & 0xFFFF),
             )?;
             let dp_hi = ((self.state.fpu.fdp_offset >> 16) & 0xF) << 12;
-            self.fpu_write_env_u32(bus, base.wrapping_add(24), dp_hi)?;
+            self.fpu_write_env_u32(bus, base.wrapping_add(24), dp_hi)
         }
-        Some(())
     }
 
     pub(super) fn fpu_fldenv(&mut self, bus: &mut impl common::Bus) {
@@ -1466,7 +1449,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             self.fpu_fldenv_16bit(protected, bus)
         };
-        if loaded.is_none() {
+        if loaded.is_err() {
             return;
         }
 
@@ -1474,7 +1457,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.clk(Self::timing(71, 44));
     }
 
-    fn fpu_fldenv_16bit(&mut self, protected: bool, bus: &mut impl common::Bus) -> Option<()> {
+    fn fpu_fldenv_16bit(&mut self, protected: bool, bus: &mut impl common::Bus) -> Step {
         // Gather all words first so a faulting read leaves the FPU
         // state untouched.
         let base = self.ea;
@@ -1500,10 +1483,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.state.fpu.fpu_opcode = w8 & 0x7FF;
             self.state.fpu.fdp_offset = w10 as u32 | (((w12 >> 12) as u32 & 0xF) << 16);
         }
-        Some(())
+        Ok(())
     }
 
-    fn fpu_fldenv_32bit(&mut self, protected: bool, bus: &mut impl common::Bus) -> Option<()> {
+    fn fpu_fldenv_32bit(&mut self, protected: bool, bus: &mut impl common::Bus) -> Step {
         let base = self.ea;
         let cw_dw = self.fpu_read_env_u32(bus, base)?;
         let sw_dw = self.fpu_read_env_u32(bus, base.wrapping_add(4))?;
@@ -1528,10 +1511,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             self.state.fpu.fpu_opcode = (dw16 & 0x7FF) as u16;
             self.state.fpu.fdp_offset = (dw20 & 0xFFFF) | (((dw24 >> 12) & 0xF) << 16);
         }
-        Some(())
+        Ok(())
     }
 
-    pub(super) fn fpu_fnsave(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_fnsave(&mut self, bus: &mut impl common::Bus) -> Step {
         let use_32bit = self.code_segment_32bit() ^ self.operand_size_override;
         let protected = self.is_protected_mode();
 
@@ -1540,8 +1523,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             self.fpu_fnstenv_16bit(protected, bus)
         };
-        if env_saved.is_none() {
-            return;
+        if env_saved.is_err() {
+            return Ok(());
         }
 
         let env_size: u32 = if use_32bit { 28 } else { 14 };
@@ -1552,9 +1535,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         // unmodified (FNSAVE re-inits the FPU only on full success).
         let mut phys = [0u32; 80];
         for i in 0..80u32 {
-            let Some(p) = self.translate_linear(reg_base.wrapping_add(i), true, bus) else {
-                return;
-            };
+            let p = self.translate_linear(reg_base.wrapping_add(i), true, bus)?;
             phys[i as usize] = p;
         }
         for reg_idx in 0..8u32 {
@@ -1568,9 +1549,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         // FSAVE reinitializes the FPU - only on full success.
         self.fpu_init();
         self.clk(Self::timing(375, 154));
+        Ok(())
     }
 
-    pub(super) fn fpu_frstor(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn fpu_frstor(&mut self, bus: &mut impl common::Bus) -> Step {
         let use_32bit = self.code_segment_32bit() ^ self.operand_size_override;
         let protected = self.is_protected_mode();
 
@@ -1581,9 +1563,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let reg_base = self.ea.wrapping_add(env_size);
         let mut phys = [0u32; 80];
         for i in 0..80u32 {
-            let Some(p) = self.translate_linear(reg_base.wrapping_add(i), false, bus) else {
-                return;
-            };
+            let p = self.translate_linear(reg_base.wrapping_add(i), false, bus)?;
             phys[i as usize] = p;
         }
         let mut new_regs = [Fp80::ZERO; 8];
@@ -1602,8 +1582,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         } else {
             self.fpu_fldenv_16bit(protected, bus)
         };
-        if env_loaded.is_none() {
-            return;
+        if env_loaded.is_err() {
+            return Ok(());
         }
 
         // All gathers succeeded; commit the FPU register stack.
@@ -1611,5 +1591,6 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
         self.fpu_update_es();
         self.clk(Self::timing(308, 131));
+        Ok(())
     }
 }

--- a/crates/cpu/src/i386/interrupt.rs
+++ b/crates/cpu/src/i386/interrupt.rs
@@ -328,6 +328,40 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             if !Self::descriptor_present(ss_rights) {
                 return self.raise_fault_with_code(12, ss_error_code, bus);
             }
+
+            // Probe-then-commit: translate every byte the dispatch will
+            // push onto the new kernel stack BEFORE committing SS/ESP/VM.
+            let new_ss_base = ss_descriptor.base;
+            let new_b_bit = (ss_descriptor.granularity & 0x40) != 0;
+            let push_size: u32 = if is_386_gate { 4 } else { 2 };
+            let push_count: u32 =
+                if from_vm86 { 4 } else { 0 } + 5 + if error_code.is_some() { 1 } else { 0 };
+
+            // Probe each push slot at its starting linear address (and at
+            // its last byte, for the rare cross-page case).
+            for i in 1..=push_count {
+                let raw_off = new_esp.wrapping_sub(i * push_size);
+                let off_lo = if new_b_bit {
+                    raw_off
+                } else {
+                    raw_off as u16 as u32
+                };
+                let linear_lo = new_ss_base.wrapping_add(off_lo);
+                self.translate_linear(linear_lo, true, bus)?;
+                if push_size > 1 {
+                    let raw_hi = raw_off.wrapping_add(push_size - 1);
+                    let off_hi = if new_b_bit {
+                        raw_hi
+                    } else {
+                        raw_hi as u16 as u32
+                    };
+                    let linear_hi = new_ss_base.wrapping_add(off_hi);
+                    if (linear_hi & !0xFFF) != (linear_lo & !0xFFF) {
+                        self.translate_linear(linear_hi, true, bus)?;
+                    }
+                }
+            }
+
             self.set_accessed_bit(new_ss, bus)?;
             self.set_loaded_segment_cache(SegReg32::SS, new_ss, ss_descriptor);
             self.eflags_upper &= !0x0003_0000; // Clear RF and VM before setting ESP.

--- a/crates/cpu/src/i386/interrupt.rs
+++ b/crates/cpu/src/i386/interrupt.rs
@@ -1,4 +1,4 @@
-use super::I386;
+use super::{Fault, I386, Step};
 use crate::{PENDING_IRQ, PENDING_NMI, SegReg32};
 
 const INTGATE_286: u8 = 6;
@@ -46,7 +46,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         if self.pending_irq & PENDING_NMI != 0 && self.inhibit_all == 0 {
             self.pending_irq &= !PENDING_NMI;
             bus.acknowledge_nmi();
-            self.raise_interrupt(2, bus);
+            let _ = self.raise_interrupt(2, bus);
         } else if self.flags.if_flag
             && self.pending_irq & PENDING_IRQ != 0
             && self.no_interrupt == 0
@@ -54,7 +54,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         {
             self.pending_irq &= !PENDING_IRQ;
             let vector = bus.acknowledge_irq();
-            self.raise_interrupt(vector, bus);
+            let _ = self.raise_interrupt(vector, bus);
         }
     }
 
@@ -68,7 +68,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         is_external: bool,
         is_fault: bool,
         bus: &mut impl common::Bus,
-    ) {
+    ) -> Step {
         self.rep_active = false;
         if !self.is_protected_mode() {
             // 80486 PRM 22.5 item 21 / Table 22-2: a vector beyond the IDTR
@@ -80,31 +80,37 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 let df_addr = 8u32 * 4;
                 if df_addr + 3 > idt_limit {
                     self.shutdown = true;
-                    return;
+                    return Err(Fault);
                 }
-                self.interrupt_with_return_eip(8, return_eip, Some(0), false, false, true, bus);
-                return;
+                return self.interrupt_with_return_eip(
+                    8,
+                    return_eip,
+                    Some(0),
+                    false,
+                    false,
+                    true,
+                    bus,
+                );
             }
 
             let flags_val = self.flags.compress();
-            self.push(bus, flags_val);
+            self.push(bus, flags_val)?;
             self.flags.tf = false;
             self.flags.if_flag = false;
 
             let cs = self.sregs[SegReg32::CS as usize];
-            self.push(bus, cs);
-            self.push(bus, return_eip as u16);
+            self.push(bus, cs)?;
+            self.push(bus, return_eip as u16)?;
 
             let dest_ip = bus.read_word(addr);
             let dest_cs = bus.read_word(addr + 2);
-            if !self.load_segment(SegReg32::CS, dest_cs, bus) {
-                return;
-            }
+            self.load_segment(SegReg32::CS, dest_cs, bus)?;
             self.ip = dest_ip;
             self.ip_upper = 0;
+            Ok(())
         } else {
             self.supervisor_override = true;
-            self.interrupt_protected(
+            let result = self.interrupt_protected(
                 vector,
                 return_eip,
                 error_code,
@@ -114,6 +120,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 bus,
             );
             self.supervisor_override = false;
+            result
         }
     }
 
@@ -127,27 +134,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         is_external: bool,
         is_fault: bool,
         bus: &mut impl common::Bus,
-    ) {
+    ) -> Step {
         let ext = is_external as u16;
         let gate_offset = (vector as u32) * 8;
         if gate_offset + 7 > self.idt_limit as u32 {
-            self.raise_fault_with_code(13, gate_offset as u16 + 2 + ext, bus);
-            return;
+            return self.raise_fault_with_code(13, gate_offset as u16 + 2 + ext, bus);
         }
 
         let gate_addr = self.idt_base.wrapping_add(gate_offset);
-        let Some(w0) = self.read_word_linear(bus, gate_addr) else {
-            return;
-        };
-        let Some(w1) = self.read_word_linear(bus, gate_addr.wrapping_add(2)) else {
-            return;
-        };
-        let Some(w2) = self.read_word_linear(bus, gate_addr.wrapping_add(4)) else {
-            return;
-        };
-        let Some(w3) = self.read_word_linear(bus, gate_addr.wrapping_add(6)) else {
-            return;
-        };
+        let w0 = self.read_word_linear(bus, gate_addr)?;
+        let w1 = self.read_word_linear(bus, gate_addr.wrapping_add(2))?;
+        let w2 = self.read_word_linear(bus, gate_addr.wrapping_add(4))?;
+        let w3 = self.read_word_linear(bus, gate_addr.wrapping_add(6))?;
 
         let gate_selector = w1;
         let rights_byte = (w2 >> 8) as u8;
@@ -158,13 +156,11 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let cpl = self.cpl();
 
         if is_software_int && gate_dpl < cpl {
-            self.raise_fault_with_code(13, gate_offset as u16 + 2 + ext, bus);
-            return;
+            return self.raise_fault_with_code(13, gate_offset as u16 + 2 + ext, bus);
         }
 
         if !gate_present {
-            self.raise_fault_with_code(11, gate_offset as u16 + 2 + ext, bus);
-            return;
+            return self.raise_fault_with_code(11, gate_offset as u16 + 2 + ext, bus);
         }
 
         let (gate_ip, is_386_gate) = match gate_type {
@@ -172,23 +168,22 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             INTGATE_286 | TRAPGATE_286 => (w0 as u32, false),
             TASKGATE => {
                 let task_selector = gate_selector;
-                self.switch_task(task_selector, super::TaskType::Call, bus);
+                self.switch_task(task_selector, super::TaskType::Call, bus)?;
                 let flags_val = self.flags.compress();
                 let new_cpl = self.cpl();
                 self.flags.load_flags(flags_val, new_cpl, true);
                 if let Some(code) = error_code {
                     let is_386_tss = (self.tr_rights & 0x0F) >= 0x09;
                     if is_386_tss {
-                        self.push_dword(bus, code as u32);
+                        self.push_dword(bus, code as u32)?;
                     } else {
-                        self.push(bus, code);
+                        self.push(bus, code)?;
                     }
                 }
-                return;
+                return Ok(());
             }
             _ => {
-                self.raise_fault_with_code(13, gate_offset as u16 + 2 + ext, bus);
-                return;
+                return self.raise_fault_with_code(13, gate_offset as u16 + 2 + ext, bus);
             }
         };
 
@@ -202,7 +197,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             ext,
             is_fault,
             bus,
-        );
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -217,18 +212,22 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         ext: u16,
         is_fault: bool,
         bus: &mut impl common::Bus,
-    ) {
-        let Some(descriptor) = self.decode_descriptor(gate_selector, bus) else {
-            if !self.fault_pending {
-                self.raise_fault_with_code(13, Self::segment_error_code(gate_selector) + ext, bus);
-            }
-            return;
+    ) -> Step {
+        let Some(descriptor) = self.decode_descriptor(gate_selector, bus)? else {
+            return self.raise_fault_with_code(
+                13,
+                Self::segment_error_code(gate_selector) + ext,
+                bus,
+            );
         };
 
         let rights = descriptor.rights;
         if !Self::descriptor_is_code(rights) || !Self::descriptor_is_segment(rights) {
-            self.raise_fault_with_code(13, Self::segment_error_code(gate_selector) + ext, bus);
-            return;
+            return self.raise_fault_with_code(
+                13,
+                Self::segment_error_code(gate_selector) + ext,
+                bus,
+            );
         }
 
         let target_dpl = Self::descriptor_dpl(rights);
@@ -236,23 +235,31 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let cpl = self.cpl();
 
         if target_dpl > cpl {
-            self.raise_fault_with_code(13, Self::segment_error_code(gate_selector) + ext, bus);
-            return;
+            return self.raise_fault_with_code(
+                13,
+                Self::segment_error_code(gate_selector) + ext,
+                bus,
+            );
         }
 
         if from_vm86 && (Self::descriptor_is_conforming_code(rights) || target_dpl != 0) {
-            self.raise_fault_with_code(13, Self::segment_error_code(gate_selector) + ext, bus);
-            return;
+            return self.raise_fault_with_code(
+                13,
+                Self::segment_error_code(gate_selector) + ext,
+                bus,
+            );
         }
 
         if !Self::descriptor_present(rights) {
-            self.raise_fault_with_code(11, Self::segment_error_code(gate_selector) + ext, bus);
-            return;
+            return self.raise_fault_with_code(
+                11,
+                Self::segment_error_code(gate_selector) + ext,
+                bus,
+            );
         }
 
         if gate_ip > descriptor.limit {
-            self.raise_fault_with_code(13, ext, bus);
-            return;
+            return self.raise_fault_with_code(13, ext, bus);
         }
 
         if Self::descriptor_is_conforming_code(rights) {
@@ -267,34 +274,19 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 let tss_esp_offset = 4 + new_dpl as u32 * 8;
                 let tss_ss_offset = 8 + new_dpl as u32 * 8;
                 if tss_ss_offset + 1 > self.tr_limit {
-                    self.raise_fault_with_code(10, Self::segment_error_code(self.tr), bus);
-                    return;
+                    return self.raise_fault_with_code(10, Self::segment_error_code(self.tr), bus);
                 }
-                let Some(esp) =
-                    self.read_dword_linear(bus, self.tr_base.wrapping_add(tss_esp_offset))
-                else {
-                    return;
-                };
-                let Some(ss) = self.read_word_linear(bus, self.tr_base.wrapping_add(tss_ss_offset))
-                else {
-                    return;
-                };
+                let esp = self.read_dword_linear(bus, self.tr_base.wrapping_add(tss_esp_offset))?;
+                let ss = self.read_word_linear(bus, self.tr_base.wrapping_add(tss_ss_offset))?;
                 (esp, ss)
             } else {
                 let tss_sp_offset = 2 + new_dpl as u32 * 4;
                 let tss_ss_offset = 4 + new_dpl as u32 * 4;
                 if tss_ss_offset + 1 > self.tr_limit {
-                    self.raise_fault_with_code(10, Self::segment_error_code(self.tr), bus);
-                    return;
+                    return self.raise_fault_with_code(10, Self::segment_error_code(self.tr), bus);
                 }
-                let Some(sp) = self.read_word_linear(bus, self.tr_base.wrapping_add(tss_sp_offset))
-                else {
-                    return;
-                };
-                let Some(ss) = self.read_word_linear(bus, self.tr_base.wrapping_add(tss_ss_offset))
-                else {
-                    return;
-                };
+                let sp = self.read_word_linear(bus, self.tr_base.wrapping_add(tss_sp_offset))?;
+                let ss = self.read_word_linear(bus, self.tr_base.wrapping_add(tss_ss_offset))?;
                 (sp as u32, ss)
             };
 
@@ -319,33 +311,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
             let ss_error_code = Self::segment_error_code(new_ss) + ext;
             if new_ss & 0xFFFC == 0 {
-                self.raise_fault_with_code(10, ss_error_code, bus);
-                return;
+                return self.raise_fault_with_code(10, ss_error_code, bus);
             }
-            let Some(ss_descriptor) = self.decode_descriptor(new_ss, bus) else {
-                if !self.fault_pending {
-                    self.raise_fault_with_code(10, ss_error_code, bus);
-                }
-                return;
+            let Some(ss_descriptor) = self.decode_descriptor(new_ss, bus)? else {
+                return self.raise_fault_with_code(10, ss_error_code, bus);
             };
             let ss_rights = ss_descriptor.rights;
             let ss_dpl = Self::descriptor_dpl(ss_rights);
             let ss_rpl = new_ss & 0x0003;
             if !Self::descriptor_is_segment(ss_rights) || !Self::descriptor_is_writable(ss_rights) {
-                self.raise_fault_with_code(10, ss_error_code, bus);
-                return;
+                return self.raise_fault_with_code(10, ss_error_code, bus);
             }
             if ss_dpl != new_dpl || ss_rpl != new_dpl {
-                self.raise_fault_with_code(10, ss_error_code, bus);
-                return;
+                return self.raise_fault_with_code(10, ss_error_code, bus);
             }
             if !Self::descriptor_present(ss_rights) {
-                self.raise_fault_with_code(12, ss_error_code, bus);
-                return;
+                return self.raise_fault_with_code(12, ss_error_code, bus);
             }
-            if self.set_accessed_bit(new_ss, bus).is_none() {
-                return;
-            }
+            self.set_accessed_bit(new_ss, bus)?;
             self.set_loaded_segment_cache(SegReg32::SS, new_ss, ss_descriptor);
             self.eflags_upper &= !0x0003_0000; // Clear RF and VM before setting ESP.
             if self.use_esp() {
@@ -356,99 +339,37 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
 
             if is_386_gate {
                 if from_vm86 {
-                    self.push_dword(bus, old_gs as u32);
-                    if self.fault_pending {
-                        return;
-                    }
-                    self.push_dword(bus, old_fs as u32);
-                    if self.fault_pending {
-                        return;
-                    }
-                    self.push_dword(bus, old_ds as u32);
-                    if self.fault_pending {
-                        return;
-                    }
-                    self.push_dword(bus, old_es as u32);
-                    if self.fault_pending {
-                        return;
-                    }
+                    self.push_dword(bus, old_gs as u32)?;
+                    self.push_dword(bus, old_fs as u32)?;
+                    self.push_dword(bus, old_ds as u32)?;
+                    self.push_dword(bus, old_es as u32)?;
                 }
-                self.push_dword(bus, old_ss as u32);
-                if self.fault_pending {
-                    return;
-                }
-                self.push_dword(bus, old_sp);
-                if self.fault_pending {
-                    return;
-                }
-                self.push_dword(bus, old_eflags);
-                if self.fault_pending {
-                    return;
-                }
-                self.push_dword(bus, old_cs as u32);
-                if self.fault_pending {
-                    return;
-                }
-                self.push_dword(bus, return_eip);
-                if self.fault_pending {
-                    return;
-                }
+                self.push_dword(bus, old_ss as u32)?;
+                self.push_dword(bus, old_sp)?;
+                self.push_dword(bus, old_eflags)?;
+                self.push_dword(bus, old_cs as u32)?;
+                self.push_dword(bus, return_eip)?;
                 if let Some(code) = error_code {
-                    self.push_dword(bus, code as u32);
-                    if self.fault_pending {
-                        return;
-                    }
+                    self.push_dword(bus, code as u32)?;
                 }
             } else {
                 if from_vm86 {
-                    self.push(bus, old_gs);
-                    if self.fault_pending {
-                        return;
-                    }
-                    self.push(bus, old_fs);
-                    if self.fault_pending {
-                        return;
-                    }
-                    self.push(bus, old_ds);
-                    if self.fault_pending {
-                        return;
-                    }
-                    self.push(bus, old_es);
-                    if self.fault_pending {
-                        return;
-                    }
+                    self.push(bus, old_gs)?;
+                    self.push(bus, old_fs)?;
+                    self.push(bus, old_ds)?;
+                    self.push(bus, old_es)?;
                 }
-                self.push(bus, old_ss);
-                if self.fault_pending {
-                    return;
-                }
-                self.push(bus, old_sp as u16);
-                if self.fault_pending {
-                    return;
-                }
-                self.push(bus, old_eflags as u16);
-                if self.fault_pending {
-                    return;
-                }
-                self.push(bus, old_cs);
-                if self.fault_pending {
-                    return;
-                }
-                self.push(bus, return_eip as u16);
-                if self.fault_pending {
-                    return;
-                }
+                self.push(bus, old_ss)?;
+                self.push(bus, old_sp as u16)?;
+                self.push(bus, old_eflags as u16)?;
+                self.push(bus, old_cs)?;
+                self.push(bus, return_eip as u16)?;
                 if let Some(code) = error_code {
-                    self.push(bus, code);
-                    if self.fault_pending {
-                        return;
-                    }
+                    self.push(bus, code)?;
                 }
             }
 
-            if self.set_accessed_bit(gate_selector, bus).is_none() {
-                return;
-            }
+            self.set_accessed_bit(gate_selector, bus)?;
             let adjusted_selector = (gate_selector & !3) | new_dpl;
             self.set_loaded_segment_cache(SegReg32::CS, adjusted_selector, descriptor);
             self.ip = gate_ip as u16;
@@ -466,7 +387,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.set_null_segment(SegReg32::FS, 0);
                 self.set_null_segment(SegReg32::GS, 0);
             }
-            return;
+            return Ok(());
         }
 
         // Same-privilege interrupt.
@@ -476,50 +397,24 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 eflags |= 0x0001_0000;
             }
             let cs = self.sregs[SegReg32::CS as usize];
-            self.push_dword(bus, eflags);
-            if self.fault_pending {
-                return;
-            }
-            self.push_dword(bus, cs as u32);
-            if self.fault_pending {
-                return;
-            }
-            self.push_dword(bus, return_eip);
-            if self.fault_pending {
-                return;
-            }
+            self.push_dword(bus, eflags)?;
+            self.push_dword(bus, cs as u32)?;
+            self.push_dword(bus, return_eip)?;
             if let Some(code) = error_code {
-                self.push_dword(bus, code as u32);
-                if self.fault_pending {
-                    return;
-                }
+                self.push_dword(bus, code as u32)?;
             }
         } else {
             let flags_val = self.flags.compress();
             let cs = self.sregs[SegReg32::CS as usize];
-            self.push(bus, flags_val);
-            if self.fault_pending {
-                return;
-            }
-            self.push(bus, cs);
-            if self.fault_pending {
-                return;
-            }
-            self.push(bus, return_eip as u16);
-            if self.fault_pending {
-                return;
-            }
+            self.push(bus, flags_val)?;
+            self.push(bus, cs)?;
+            self.push(bus, return_eip as u16)?;
             if let Some(code) = error_code {
-                self.push(bus, code);
-                if self.fault_pending {
-                    return;
-                }
+                self.push(bus, code)?;
             }
         }
 
-        if self.set_accessed_bit(gate_selector, bus).is_none() {
-            return;
-        }
+        self.set_accessed_bit(gate_selector, bus)?;
         let adjusted_selector = (gate_selector & !3) | cpl;
         self.set_loaded_segment_cache(SegReg32::CS, adjusted_selector, descriptor);
         self.ip = gate_ip as u16;
@@ -531,15 +426,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         if gate_type == INTGATE_286 || gate_type == INTGATE_386 {
             self.flags.if_flag = false;
         }
+        Ok(())
     }
 
-    pub(super) fn raise_interrupt(&mut self, vector: u8, bus: &mut impl common::Bus) {
+    pub(super) fn raise_interrupt(&mut self, vector: u8, bus: &mut impl common::Bus) -> Step {
         let return_eip = if self.rep_active {
             self.rep_restart_ip_upper | self.rep_restart_ip as u32
         } else {
             self.ip_upper | self.ip as u32
         };
-        self.interrupt_with_return_eip(vector, return_eip, None, false, true, false, bus);
+        self.interrupt_with_return_eip(vector, return_eip, None, false, true, false, bus)
     }
 
     pub(super) fn raise_software_interrupt(
@@ -547,7 +443,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         vector: u8,
         is_int_n: bool,
         bus: &mut impl common::Bus,
-    ) {
+    ) -> Step {
         let return_eip = if self.rep_active {
             self.rep_restart_ip_upper | self.rep_restart_ip as u32
         } else {
@@ -556,70 +452,86 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         // In VM86, only INT n (opcode 0xCD) is IOPL-sensitive.
         // INT 3 and INTO always go through the IDT without an IOPL check.
         if self.is_virtual_mode() && is_int_n && self.flags.iopl < 3 {
-            self.raise_fault_with_code(13, 0, bus);
-            return;
+            return self.raise_fault_with_code(13, 0, bus);
         }
-        self.interrupt_with_return_eip(vector, return_eip, None, true, false, false, bus);
+        self.interrupt_with_return_eip(vector, return_eip, None, true, false, false, bus)
     }
 
-    pub(super) fn raise_trap(&mut self, vector: u8, bus: &mut impl common::Bus) {
+    pub(super) fn raise_trap(&mut self, vector: u8, bus: &mut impl common::Bus) -> Step {
         let return_eip = if self.rep_active {
             self.rep_restart_ip_upper | self.rep_restart_ip as u32
         } else {
             self.ip_upper | self.ip as u32
         };
-        self.interrupt_with_return_eip(vector, return_eip, None, false, false, false, bus);
+        self.interrupt_with_return_eip(vector, return_eip, None, false, false, false, bus)
     }
 
-    pub(super) fn raise_fault(&mut self, vector: u8, bus: &mut impl common::Bus) {
+    pub(super) fn raise_fault<T>(&mut self, vector: u8, bus: &mut impl common::Bus) -> Step<T> {
         if self.shutdown {
-            return;
+            return Err(Fault);
         }
         let saved_fault_pending = self.fault_pending;
         self.fault_pending = false;
         let return_eip = self.prev_ip_upper | self.prev_ip as u32;
         if self.is_protected_mode() {
             match self.check_double_fault(vector) {
-                DoubleFaultResult::Shutdown => return,
+                DoubleFaultResult::Shutdown => return Err(Fault),
                 DoubleFaultResult::DoubleFault => {
-                    self.interrupt_with_return_eip(8, return_eip, Some(0), false, false, true, bus);
+                    self.interrupt_with_return_eip(
+                        8,
+                        return_eip,
+                        Some(0),
+                        false,
+                        false,
+                        true,
+                        bus,
+                    )?;
                     self.trap_level = 0;
                     self.fault_pending = true;
-                    return;
+                    return Err(Fault);
                 }
                 DoubleFaultResult::Normal => {}
             }
         }
-        self.interrupt_with_return_eip(vector, return_eip, None, false, false, true, bus);
+        let _ = self.interrupt_with_return_eip(vector, return_eip, None, false, false, true, bus);
         self.trap_level = 0;
         self.fault_pending = saved_fault_pending || self.fault_pending;
+        Err(Fault)
     }
 
-    pub(super) fn raise_fault_with_code(
+    pub(super) fn raise_fault_with_code<T>(
         &mut self,
         vector: u8,
         error_code: u16,
         bus: &mut impl common::Bus,
-    ) {
+    ) -> Step<T> {
         if self.shutdown {
-            return;
+            return Err(Fault);
         }
         let saved_fault_pending = self.fault_pending;
         self.fault_pending = false;
         let return_eip = self.prev_ip_upper | self.prev_ip as u32;
         if self.is_protected_mode() {
             match self.check_double_fault(vector) {
-                DoubleFaultResult::Shutdown => return,
+                DoubleFaultResult::Shutdown => return Err(Fault),
                 DoubleFaultResult::DoubleFault => {
-                    self.interrupt_with_return_eip(8, return_eip, Some(0), false, false, true, bus);
+                    self.interrupt_with_return_eip(
+                        8,
+                        return_eip,
+                        Some(0),
+                        false,
+                        false,
+                        true,
+                        bus,
+                    )?;
                     self.trap_level = 0;
                     self.fault_pending = true;
-                    return;
+                    return Err(Fault);
                 }
                 DoubleFaultResult::Normal => {}
             }
         }
-        self.interrupt_with_return_eip(
+        let _ = self.interrupt_with_return_eip(
             vector,
             return_eip,
             Some(error_code),
@@ -630,6 +542,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         );
         self.trap_level = 0;
         self.fault_pending = saved_fault_pending || self.fault_pending;
+        Err(Fault)
     }
 
     fn check_double_fault(&mut self, vector: u8) -> DoubleFaultResult {

--- a/crates/cpu/src/i386/modrm.rs
+++ b/crates/cpu/src/i386/modrm.rs
@@ -1,4 +1,4 @@
-use super::I386;
+use super::{I386, Step};
 use crate::{ByteReg, DwordReg, SegReg32, WordReg, build_x86_reg_word_table, build_x86_rm_table};
 
 static MODRM_REG: [u8; 256] = build_x86_reg_word_table();
@@ -253,16 +253,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
     }
 
-    pub(super) fn get_rm_byte(&mut self, modrm: u8, bus: &mut impl common::Bus) -> Option<u8> {
+    pub(super) fn get_rm_byte(&mut self, modrm: u8, bus: &mut impl common::Bus) -> Step<u8> {
         if modrm >= 0xC0 {
-            Some(self.regs.byte(self.rm_byte(modrm)))
+            Ok(self.regs.byte(self.rm_byte(modrm)))
         } else {
             self.calc_ea(modrm, bus);
-            if !self.check_segment_access(self.ea_seg, self.eo32, 1, false, bus) {
-                return None;
-            }
+            self.check_segment_access(self.ea_seg, self.eo32, 1, false, bus)?;
             let addr = self.translate_linear(self.ea, false, bus)?;
-            Some(bus.read_byte(addr))
+            Ok(bus.read_byte(addr))
         }
     }
 
@@ -270,22 +268,20 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         &mut self,
         modrm: u8,
         bus: &mut impl common::Bus,
-    ) -> Option<u8> {
+    ) -> Step<u8> {
         if modrm >= 0xC0 {
-            Some(self.regs.byte(self.rm_byte(modrm)))
+            Ok(self.regs.byte(self.rm_byte(modrm)))
         } else {
             self.calc_ea(modrm, bus);
-            if !self.check_segment_access(self.ea_seg, self.eo32, 1, true, bus) {
-                return None;
-            }
+            self.check_segment_access(self.ea_seg, self.eo32, 1, true, bus)?;
             let addr = self.translate_linear(self.ea, true, bus)?;
-            Some(bus.read_byte(addr))
+            Ok(bus.read_byte(addr))
         }
     }
 
-    pub(super) fn get_rm_word(&mut self, modrm: u8, bus: &mut impl common::Bus) -> Option<u16> {
+    pub(super) fn get_rm_word(&mut self, modrm: u8, bus: &mut impl common::Bus) -> Step<u16> {
         if modrm >= 0xC0 {
-            Some(self.regs.word(self.rm_word(modrm)))
+            Ok(self.regs.word(self.rm_word(modrm)))
         } else {
             self.calc_ea(modrm, bus);
             self.seg_read_word(bus)
@@ -296,18 +292,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         &mut self,
         modrm: u8,
         bus: &mut impl common::Bus,
-    ) -> Option<u16> {
+    ) -> Step<u16> {
         if modrm >= 0xC0 {
-            Some(self.regs.word(self.rm_word(modrm)))
+            Ok(self.regs.word(self.rm_word(modrm)))
         } else {
             self.calc_ea(modrm, bus);
             self.seg_read_word_for_update(bus)
         }
     }
 
-    pub(super) fn get_rm_dword(&mut self, modrm: u8, bus: &mut impl common::Bus) -> Option<u32> {
+    pub(super) fn get_rm_dword(&mut self, modrm: u8, bus: &mut impl common::Bus) -> Step<u32> {
         if modrm >= 0xC0 {
-            Some(self.regs.dword(self.rm_dword(modrm)))
+            Ok(self.regs.dword(self.rm_dword(modrm)))
         } else {
             self.calc_ea(modrm, bus);
             self.seg_read_dword(bus)
@@ -318,75 +314,102 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         &mut self,
         modrm: u8,
         bus: &mut impl common::Bus,
-    ) -> Option<u32> {
+    ) -> Step<u32> {
         if modrm >= 0xC0 {
-            Some(self.regs.dword(self.rm_dword(modrm)))
+            Ok(self.regs.dword(self.rm_dword(modrm)))
         } else {
             self.calc_ea(modrm, bus);
             self.seg_read_dword_for_update(bus)
         }
     }
 
-    pub(super) fn putback_rm_byte(&mut self, modrm: u8, value: u8, bus: &mut impl common::Bus) {
+    pub(super) fn putback_rm_byte(
+        &mut self,
+        modrm: u8,
+        value: u8,
+        bus: &mut impl common::Bus,
+    ) -> Step {
         if modrm >= 0xC0 {
             let reg = self.rm_byte(modrm);
             self.regs.set_byte(reg, value);
         } else {
-            let Some(addr) = self.translate_linear(self.ea, true, bus) else {
-                return;
-            };
+            let addr = self.translate_linear(self.ea, true, bus)?;
             bus.write_byte(addr, value);
         }
+        Ok(())
     }
 
-    pub(super) fn putback_rm_word(&mut self, modrm: u8, value: u16, bus: &mut impl common::Bus) {
+    pub(super) fn putback_rm_word(
+        &mut self,
+        modrm: u8,
+        value: u16,
+        bus: &mut impl common::Bus,
+    ) -> Step {
         if modrm >= 0xC0 {
             let reg = self.rm_word(modrm);
             self.regs.set_word(reg, value);
+            Ok(())
         } else {
-            self.seg_write_word(bus, value);
+            self.seg_write_word(bus, value)
         }
     }
 
-    pub(super) fn putback_rm_dword(&mut self, modrm: u8, value: u32, bus: &mut impl common::Bus) {
+    pub(super) fn putback_rm_dword(
+        &mut self,
+        modrm: u8,
+        value: u32,
+        bus: &mut impl common::Bus,
+    ) -> Step {
         if modrm >= 0xC0 {
             let reg = self.rm_dword(modrm);
             self.regs.set_dword(reg, value);
+            Ok(())
         } else {
-            self.seg_write_dword(bus, value);
+            self.seg_write_dword(bus, value)
         }
     }
 
-    pub(super) fn put_rm_byte(&mut self, modrm: u8, value: u8, bus: &mut impl common::Bus) {
+    pub(super) fn put_rm_byte(&mut self, modrm: u8, value: u8, bus: &mut impl common::Bus) -> Step {
         if modrm >= 0xC0 {
             let reg = self.rm_byte(modrm);
             self.regs.set_byte(reg, value);
         } else {
             self.calc_ea(modrm, bus);
-            let Some(addr) = self.translate_linear(self.ea, true, bus) else {
-                return;
-            };
+            let addr = self.translate_linear(self.ea, true, bus)?;
             bus.write_byte(addr, value);
         }
+        Ok(())
     }
 
-    pub(super) fn put_rm_word(&mut self, modrm: u8, value: u16, bus: &mut impl common::Bus) {
+    pub(super) fn put_rm_word(
+        &mut self,
+        modrm: u8,
+        value: u16,
+        bus: &mut impl common::Bus,
+    ) -> Step {
         if modrm >= 0xC0 {
             let reg = self.rm_word(modrm);
             self.regs.set_word(reg, value);
+            Ok(())
         } else {
             self.calc_ea(modrm, bus);
-            self.seg_write_word(bus, value);
+            self.seg_write_word(bus, value)
         }
     }
 
-    pub(super) fn put_rm_dword(&mut self, modrm: u8, value: u32, bus: &mut impl common::Bus) {
+    pub(super) fn put_rm_dword(
+        &mut self,
+        modrm: u8,
+        value: u32,
+        bus: &mut impl common::Bus,
+    ) -> Step {
         if modrm >= 0xC0 {
             let reg = self.rm_dword(modrm);
             self.regs.set_dword(reg, value);
+            Ok(())
         } else {
             self.calc_ea(modrm, bus);
-            self.seg_write_dword(bus, value);
+            self.seg_write_dword(bus, value)
         }
     }
 }

--- a/crates/cpu/src/i386/paging.rs
+++ b/crates/cpu/src/i386/paging.rs
@@ -1,4 +1,4 @@
-use super::{CPU_MODEL_486, I386};
+use super::{CPU_MODEL_486, Fault, I386, Step};
 
 const TLB_SIZE: usize = 64;
 const TLB_MASK: u32 = (TLB_SIZE as u32) - 1;
@@ -29,12 +29,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         linear: u32,
         write: bool,
         bus: &mut impl common::Bus,
-    ) -> Option<u32> {
+    ) -> Step<u32> {
         if self.fault_pending {
-            return None;
+            return Err(Fault);
         }
         if !self.is_paging_enabled() {
-            return Some(linear);
+            return Ok(linear);
         }
 
         let page = linear >> 12;
@@ -43,18 +43,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         if self.tlb_valid[slot] && self.tlb_tag[slot] == page {
             let is_user = self.is_user_page_access();
             if is_user && !self.tlb_user[slot] {
-                self.raise_page_fault(linear, write, true, bus);
-                return None;
+                return self.raise_page_fault(linear, write, true, bus);
             }
             let wp_enforced = CPU_MODEL == CPU_MODEL_486 && self.cr0 & 0x0001_0000 != 0;
             if write && (is_user || wp_enforced) && !self.tlb_writable[slot] {
-                self.raise_page_fault(linear, write, true, bus);
-                return None;
+                return self.raise_page_fault(linear, write, true, bus);
             }
             if write && !self.tlb_dirty[slot] {
                 return self.page_table_walk(linear, write, bus);
             }
-            return Some(self.tlb_phys[slot] | (linear & 0xFFF));
+            return Ok(self.tlb_phys[slot] | (linear & 0xFFF));
         }
 
         self.page_table_walk(linear, write, bus)
@@ -65,7 +63,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         linear: u32,
         write: bool,
         bus: &mut impl common::Bus,
-    ) -> Option<u32> {
+    ) -> Step<u32> {
         let dir_index = (linear >> 22) & 0x3FF;
         let table_index = (linear >> 12) & 0x3FF;
         let offset = linear & 0xFFF;
@@ -74,16 +72,14 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let pde = self.read_dword_phys_raw(bus, pde_addr);
 
         if pde & PTE_PRESENT == 0 {
-            self.raise_page_fault(linear, write, false, bus);
-            return None;
+            return self.raise_page_fault(linear, write, false, bus);
         }
 
         let pte_addr = (pde & 0xFFFF_F000) | (table_index << 2);
         let pte = self.read_dword_phys_raw(bus, pte_addr);
 
         if pte & PTE_PRESENT == 0 {
-            self.raise_page_fault(linear, write, false, bus);
-            return None;
+            return self.raise_page_fault(linear, write, false, bus);
         }
 
         // Permission check: user mode needs U/S=1 on both PDE and PTE.
@@ -95,20 +91,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let is_user = self.is_user_page_access();
         if is_user {
             if pde & PTE_USER == 0 || pte & PTE_USER == 0 {
-                self.raise_page_fault(linear, write, true, bus);
-                return None;
+                return self.raise_page_fault(linear, write, true, bus);
             }
             if write && (pde & PTE_WRITABLE == 0 || pte & PTE_WRITABLE == 0) {
-                self.raise_page_fault(linear, write, true, bus);
-                return None;
+                return self.raise_page_fault(linear, write, true, bus);
             }
         } else if write
             && CPU_MODEL == CPU_MODEL_486
             && self.cr0 & 0x0001_0000 != 0
             && (pde & PTE_WRITABLE == 0 || pte & PTE_WRITABLE == 0)
         {
-            self.raise_page_fault(linear, write, true, bus);
-            return None;
+            return self.raise_page_fault(linear, write, true, bus);
         }
 
         // Set accessed bit on PDE if not already set.
@@ -138,16 +131,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         self.tlb_writable[slot] = pde & PTE_WRITABLE != 0 && pte & PTE_WRITABLE != 0;
         self.tlb_user[slot] = pde & PTE_USER != 0 && pte & PTE_USER != 0;
 
-        Some(physical)
+        Ok(physical)
     }
 
-    fn raise_page_fault(
+    fn raise_page_fault<T>(
         &mut self,
         linear: u32,
         write: bool,
         present: bool,
         bus: &mut impl common::Bus,
-    ) {
+    ) -> Step<T> {
         self.cr2 = linear;
         let mut error_code: u16 = 0;
         if present {
@@ -160,7 +153,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             error_code |= 4; // U/S bit
         }
         self.fault_pending = true;
-        self.raise_fault_with_code(14, error_code, bus);
+        self.raise_fault_with_code(14, error_code, bus)
     }
 
     #[inline(always)]

--- a/crates/cpu/src/i386/rep.rs
+++ b/crates/cpu/src/i386/rep.rs
@@ -1,4 +1,4 @@
-use super::I386;
+use super::{I386, Step};
 use crate::{DwordReg, SegReg32, WordReg};
 
 #[derive(Clone, Copy, PartialEq)]
@@ -26,7 +26,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         }
     }
 
-    fn start_rep(&mut self, rep_type: RepType, bus: &mut impl common::Bus) {
+    fn start_rep(&mut self, rep_type: RepType, bus: &mut impl common::Bus) -> Step {
         self.clk(Self::timing(0, 1));
         self.rep_restart_ip = self.prev_ip;
         self.rep_restart_ip_upper = self.prev_ip_upper;
@@ -91,15 +91,16 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             _ => 2,
         };
         self.clk(startup);
-        self.do_rep(rep_type, next, bus);
+        self.do_rep(rep_type, next, bus)?;
+        Ok(())
     }
 
-    fn do_rep(&mut self, rep_type: RepType, next: u8, bus: &mut impl common::Bus) {
+    fn do_rep(&mut self, rep_type: RepType, next: u8, bus: &mut impl common::Bus) -> Step {
         let mut count = self.rep_count();
 
         if count == 0 {
             self.rep_completed = true;
-            return;
+            return Ok(());
         }
 
         let is_cmps_scas = matches!(next, 0xA6 | 0xA7 | 0xAE | 0xAF);
@@ -116,7 +117,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let initial_ip_upper = self.ip_upper;
 
         loop {
-            match next {
+            let iter_result = match next {
                 0x6C => self.insb(bus),
                 0x6D => self.insw(bus),
                 0x6E => self.outsb(bus),
@@ -132,17 +133,18 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 0xAE => self.scasb(bus),
                 0xAF => self.scasw(bus),
                 _ => {
-                    self.dispatch(next, bus);
-                    return;
+                    self.dispatch(next, bus)?;
+                    return Ok(());
                 }
-            }
-            if self.fault_pending
+            };
+            if iter_result.is_err()
+                || self.fault_pending
                 || self.sregs[SegReg32::CS as usize] != initial_cs
                 || self.ip != initial_ip
                 || self.ip_upper != initial_ip_upper
             {
                 self.set_rep_count(count);
-                return;
+                return iter_result;
             }
             let per_iteration_adjust = match next {
                 0xA4 | 0xA5 => Self::timing(-3, -4),
@@ -201,16 +203,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
                 self.set_rep_count(count);
                 self.ip = self.rep_restart_ip;
                 self.ip_upper = self.rep_restart_ip_upper;
-                return;
+                return Ok(());
             }
         }
 
         self.set_rep_count(count);
         self.seg_prefix = false;
         self.rep_completed = true;
+        Ok(())
     }
 
-    pub(super) fn continue_rep(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn continue_rep(&mut self, bus: &mut impl common::Bus) -> Step {
         self.ip = self.rep_ip;
         self.ip_upper = self.rep_ip_upper;
         self.prev_ip = self.rep_restart_ip;
@@ -226,14 +229,17 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             RepType::RepE
         };
         self.rep_active = false;
-        self.do_rep(rep_type, next, bus);
+        self.do_rep(rep_type, next, bus)?;
+        Ok(())
     }
 
-    pub(super) fn repne(&mut self, bus: &mut impl common::Bus) {
-        self.start_rep(RepType::RepNe, bus);
+    pub(super) fn repne(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.start_rep(RepType::RepNe, bus)?;
+        Ok(())
     }
 
-    pub(super) fn repe(&mut self, bus: &mut impl common::Bus) {
-        self.start_rep(RepType::RepE, bus);
+    pub(super) fn repe(&mut self, bus: &mut impl common::Bus) -> Step {
+        self.start_rep(RepType::RepE, bus)?;
+        Ok(())
     }
 }

--- a/crates/cpu/src/i386/string_ops.rs
+++ b/crates/cpu/src/i386/string_ops.rs
@@ -1,4 +1,4 @@
-use super::I386;
+use super::{Fault, I386, Step};
 use crate::{ByteReg, DwordReg, SegReg32, WordReg};
 
 type ProbedDwordWrite = (u32, Option<(u32, u32, u32)>);
@@ -83,7 +83,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
         base: u32,
         offset: u32,
-    ) -> Option<u16> {
+    ) -> Step<u16> {
         let l0 = self.string_addr_delta(base, offset, 0);
         let same_page = if self.address_size_override {
             l0 & 0xFFF <= 0xFFE
@@ -92,12 +92,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         if same_page {
             let a0 = self.translate_linear(l0, false, bus)?;
-            return Some(bus.read_word(a0));
+            return Ok(bus.read_word(a0));
         }
         let l1 = self.string_addr_delta(base, offset, 1);
         let a0 = self.translate_linear(l0, false, bus)?;
         let a1 = self.translate_linear(l1, false, bus)?;
-        Some(bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8))
+        Ok(bus.read_byte(a0) as u16 | ((bus.read_byte(a1) as u16) << 8))
     }
 
     #[inline(always)]
@@ -108,7 +108,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         offset: u32,
         value: u16,
     ) -> bool {
-        let Some((a0, cross)) = self.string_probe_write_word(bus, base, offset) else {
+        let Ok((a0, cross)) = self.string_probe_write_word(bus, base, offset) else {
             return false;
         };
         match cross {
@@ -132,7 +132,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
         base: u32,
         offset: u32,
-    ) -> Option<(u32, Option<u32>)> {
+    ) -> Step<(u32, Option<u32>)> {
         let l0 = self.string_addr_delta(base, offset, 0);
         let same_page = if self.address_size_override {
             l0 & 0xFFF <= 0xFFE
@@ -141,12 +141,12 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         if same_page {
             let a0 = self.translate_linear(l0, true, bus)?;
-            return Some((a0, None));
+            return Ok((a0, None));
         }
         let l1 = self.string_addr_delta(base, offset, 1);
         let a0 = self.translate_linear(l0, true, bus)?;
         let a1 = self.translate_linear(l1, true, bus)?;
-        Some((a0, Some(a1)))
+        Ok((a0, Some(a1)))
     }
 
     #[inline(always)]
@@ -155,7 +155,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
         base: u32,
         offset: u32,
-    ) -> Option<u32> {
+    ) -> Step<u32> {
         let l0 = self.string_addr_delta(base, offset, 0);
         let same_page = if self.address_size_override {
             l0 & 0xFFF <= 0xFFC
@@ -164,7 +164,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         if same_page {
             let a0 = self.translate_linear(l0, false, bus)?;
-            return Some(bus.read_dword(a0));
+            return Ok(bus.read_dword(a0));
         }
         let l1 = self.string_addr_delta(base, offset, 1);
         let l2 = self.string_addr_delta(base, offset, 2);
@@ -173,12 +173,10 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let a1 = self.translate_linear(l1, false, bus)?;
         let a2 = self.translate_linear(l2, false, bus)?;
         let a3 = self.translate_linear(l3, false, bus)?;
-        Some(
-            bus.read_byte(a0) as u32
-                | ((bus.read_byte(a1) as u32) << 8)
-                | ((bus.read_byte(a2) as u32) << 16)
-                | ((bus.read_byte(a3) as u32) << 24),
-        )
+        Ok(bus.read_byte(a0) as u32
+            | ((bus.read_byte(a1) as u32) << 8)
+            | ((bus.read_byte(a2) as u32) << 16)
+            | ((bus.read_byte(a3) as u32) << 24))
     }
 
     #[inline(always)]
@@ -189,7 +187,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         offset: u32,
         value: u32,
     ) -> bool {
-        let Some((a0, cross)) = self.string_probe_write_dword(bus, base, offset) else {
+        let Ok((a0, cross)) = self.string_probe_write_dword(bus, base, offset) else {
             return false;
         };
         match cross {
@@ -212,7 +210,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         bus: &mut impl common::Bus,
         base: u32,
         offset: u32,
-    ) -> Option<ProbedDwordWrite> {
+    ) -> Step<ProbedDwordWrite> {
         let l0 = self.string_addr_delta(base, offset, 0);
         let same_page = if self.address_size_override {
             l0 & 0xFFF <= 0xFFC
@@ -221,7 +219,7 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         if same_page {
             let a0 = self.translate_linear(l0, true, bus)?;
-            return Some((a0, None));
+            return Ok((a0, None));
         }
         let l1 = self.string_addr_delta(base, offset, 1);
         let l2 = self.string_addr_delta(base, offset, 2);
@@ -230,62 +228,47 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         let a1 = self.translate_linear(l1, true, bus)?;
         let a2 = self.translate_linear(l2, true, bus)?;
         let a3 = self.translate_linear(l3, true, bus)?;
-        Some((a0, Some((a1, a2, a3))))
+        Ok((a0, Some((a1, a2, a3))))
     }
 
-    pub(super) fn movsb(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn movsb(&mut self, bus: &mut impl common::Bus) -> Step {
         let si = self.string_index_si();
         let di = self.string_index_di();
         let src_seg = self.default_seg(SegReg32::DS);
-        if !self.check_segment_access(src_seg, si, 1, false, bus) {
-            return;
-        }
-        if !self.check_segment_access(SegReg32::ES, di, 1, true, bus) {
-            return;
-        }
+        self.check_segment_access(src_seg, si, 1, false, bus)?;
+        self.check_segment_access(SegReg32::ES, di, 1, true, bus)?;
         let src_linear = self.string_addr(self.seg_base(src_seg), si);
         let dst_linear = self.string_addr(self.seg_base(SegReg32::ES), di);
-        let Some(src_phys) = self.translate_linear(src_linear, false, bus) else {
-            return;
-        };
+        let src_phys = self.translate_linear(src_linear, false, bus)?;
         let val = bus.read_byte(src_phys);
-        let Some(dst_phys) = self.translate_linear(dst_linear, true, bus) else {
-            return;
-        };
+        let dst_phys = self.translate_linear(dst_linear, true, bus)?;
         bus.write_byte(dst_phys, val);
         self.string_advance_si(1);
         self.string_advance_di(1);
         self.clk(Self::timing(7, 7));
+        Ok(())
     }
 
-    pub(super) fn movsw(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn movsw(&mut self, bus: &mut impl common::Bus) -> Step {
         let si = self.string_index_si();
         let di = self.string_index_di();
         let src_seg = self.default_seg(SegReg32::DS);
         let access_size = if self.operand_size_override { 4 } else { 2 };
-        if !self.check_segment_access(src_seg, si, access_size, false, bus) {
-            return;
-        }
-        if !self.check_segment_access(SegReg32::ES, di, access_size, true, bus) {
-            return;
-        }
+        self.check_segment_access(src_seg, si, access_size, false, bus)?;
+        self.check_segment_access(SegReg32::ES, di, access_size, true, bus)?;
         let src_base = self.seg_base(src_seg);
         let dst_base = self.seg_base(SegReg32::ES);
         if self.operand_size_override {
-            let Some(val) = self.string_read_dword(bus, src_base, si) else {
-                return;
-            };
+            let val = self.string_read_dword(bus, src_base, si)?;
             if !self.string_write_dword(bus, dst_base, di, val) {
-                return;
+                return Ok(());
             }
             self.string_advance_si(4);
             self.string_advance_di(4);
         } else {
-            let Some(val) = self.string_read_word(bus, src_base, si) else {
-                return;
-            };
+            let val = self.string_read_word(bus, src_base, si)?;
             if !self.string_write_word(bus, dst_base, di, val) {
-                return;
+                return Ok(());
             }
             self.string_advance_si(2);
             self.string_advance_di(2);
@@ -297,64 +280,46 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
         self.clk(Self::timing(7, 7) + penalty);
+        Ok(())
     }
 
-    pub(super) fn cmpsb(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn cmpsb(&mut self, bus: &mut impl common::Bus) -> Step {
         let si = self.string_index_si();
         let di = self.string_index_di();
         let src_seg = self.default_seg(SegReg32::DS);
-        if !self.check_segment_access(src_seg, si, 1, false, bus) {
-            return;
-        }
-        if !self.check_segment_access(SegReg32::ES, di, 1, false, bus) {
-            return;
-        }
+        self.check_segment_access(src_seg, si, 1, false, bus)?;
+        self.check_segment_access(SegReg32::ES, di, 1, false, bus)?;
         let src_linear = self.string_addr(self.seg_base(src_seg), si);
         let dst_linear = self.string_addr(self.seg_base(SegReg32::ES), di);
-        let Some(src_phys) = self.translate_linear(src_linear, false, bus) else {
-            return;
-        };
-        let Some(dst_phys) = self.translate_linear(dst_linear, false, bus) else {
-            return;
-        };
+        let src_phys = self.translate_linear(src_linear, false, bus)?;
+        let dst_phys = self.translate_linear(dst_linear, false, bus)?;
         let src = bus.read_byte(src_phys);
         let dst = bus.read_byte(dst_phys);
         self.alu_sub_byte(src, dst);
         self.string_advance_si(1);
         self.string_advance_di(1);
         self.clk(Self::timing(10, 8));
+        Ok(())
     }
 
-    pub(super) fn cmpsw(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn cmpsw(&mut self, bus: &mut impl common::Bus) -> Step {
         let si = self.string_index_si();
         let di = self.string_index_di();
         let src_seg = self.default_seg(SegReg32::DS);
         let access_size = if self.operand_size_override { 4 } else { 2 };
-        if !self.check_segment_access(src_seg, si, access_size, false, bus) {
-            return;
-        }
-        if !self.check_segment_access(SegReg32::ES, di, access_size, false, bus) {
-            return;
-        }
+        self.check_segment_access(src_seg, si, access_size, false, bus)?;
+        self.check_segment_access(SegReg32::ES, di, access_size, false, bus)?;
         let src_base = self.seg_base(src_seg);
         let dst_base = self.seg_base(SegReg32::ES);
         if self.operand_size_override {
-            let Some(src) = self.string_read_dword(bus, src_base, si) else {
-                return;
-            };
-            let Some(dst) = self.string_read_dword(bus, dst_base, di) else {
-                return;
-            };
+            let src = self.string_read_dword(bus, src_base, si)?;
+            let dst = self.string_read_dword(bus, dst_base, di)?;
             self.alu_sub_dword(src, dst);
             self.string_advance_si(4);
             self.string_advance_di(4);
         } else {
-            let Some(src) = self.string_read_word(bus, src_base, si) else {
-                return;
-            };
-            let Some(dst) = self.string_read_word(bus, dst_base, di) else {
-                return;
-            };
+            let src = self.string_read_word(bus, src_base, si)?;
+            let dst = self.string_read_word(bus, dst_base, di)?;
             self.alu_sub_word(src, dst);
             self.string_advance_si(2);
             self.string_advance_di(2);
@@ -366,38 +331,34 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
         self.clk(Self::timing(10, 8) + penalty);
+        Ok(())
     }
 
-    pub(super) fn stosb(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn stosb(&mut self, bus: &mut impl common::Bus) -> Step {
         let di = self.string_index_di();
-        if !self.check_segment_access(SegReg32::ES, di, 1, true, bus) {
-            return;
-        }
+        self.check_segment_access(SegReg32::ES, di, 1, true, bus)?;
         let linear = self.string_addr(self.seg_base(SegReg32::ES), di);
         let al = self.regs.byte(ByteReg::AL);
-        let Some(addr) = self.translate_linear(linear, true, bus) else {
-            return;
-        };
+        let addr = self.translate_linear(linear, true, bus)?;
         bus.write_byte(addr, al);
         self.string_advance_di(1);
         self.clk(Self::timing(4, 5));
+        Ok(())
     }
 
-    pub(super) fn stosw(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn stosw(&mut self, bus: &mut impl common::Bus) -> Step {
         let di = self.string_index_di();
         let access_size = if self.operand_size_override { 4 } else { 2 };
-        if !self.check_segment_access(SegReg32::ES, di, access_size, true, bus) {
-            return;
-        }
+        self.check_segment_access(SegReg32::ES, di, access_size, true, bus)?;
         let base = self.seg_base(SegReg32::ES);
         if self.operand_size_override {
             if !self.string_write_dword(bus, base, di, self.regs.dword(DwordReg::EAX)) {
-                return;
+                return Ok(());
             }
             self.string_advance_di(4);
         } else {
             if !self.string_write_word(bus, base, di, self.regs.word(WordReg::AX)) {
-                return;
+                return Ok(());
             }
             self.string_advance_di(2);
         }
@@ -408,42 +369,34 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
         self.clk(Self::timing(4, 5) + penalty);
+        Ok(())
     }
 
-    pub(super) fn lodsb(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn lodsb(&mut self, bus: &mut impl common::Bus) -> Step {
         let si = self.string_index_si();
         let src_seg = self.default_seg(SegReg32::DS);
-        if !self.check_segment_access(src_seg, si, 1, false, bus) {
-            return;
-        }
+        self.check_segment_access(src_seg, si, 1, false, bus)?;
         let linear = self.string_addr(self.seg_base(src_seg), si);
-        let Some(addr) = self.translate_linear(linear, false, bus) else {
-            return;
-        };
+        let addr = self.translate_linear(linear, false, bus)?;
         let val = bus.read_byte(addr);
         self.regs.set_byte(ByteReg::AL, val);
         self.string_advance_si(1);
         self.clk(Self::timing(5, 5));
+        Ok(())
     }
 
-    pub(super) fn lodsw(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn lodsw(&mut self, bus: &mut impl common::Bus) -> Step {
         let si = self.string_index_si();
         let src_seg = self.default_seg(SegReg32::DS);
         let access_size = if self.operand_size_override { 4 } else { 2 };
-        if !self.check_segment_access(src_seg, si, access_size, false, bus) {
-            return;
-        }
+        self.check_segment_access(src_seg, si, access_size, false, bus)?;
         let base = self.seg_base(src_seg);
         if self.operand_size_override {
-            let Some(val) = self.string_read_dword(bus, base, si) else {
-                return;
-            };
+            let val = self.string_read_dword(bus, base, si)?;
             self.regs.set_dword(DwordReg::EAX, val);
             self.string_advance_si(4);
         } else {
-            let Some(val) = self.string_read_word(bus, base, si) else {
-                return;
-            };
+            let val = self.string_read_word(bus, base, si)?;
             self.regs.set_word(WordReg::AX, val);
             self.string_advance_si(2);
         }
@@ -454,42 +407,34 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
         self.clk(Self::timing(5, 5) + penalty);
+        Ok(())
     }
 
-    pub(super) fn scasb(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn scasb(&mut self, bus: &mut impl common::Bus) -> Step {
         let di = self.string_index_di();
-        if !self.check_segment_access(SegReg32::ES, di, 1, false, bus) {
-            return;
-        }
+        self.check_segment_access(SegReg32::ES, di, 1, false, bus)?;
         let linear = self.string_addr(self.seg_base(SegReg32::ES), di);
-        let Some(addr) = self.translate_linear(linear, false, bus) else {
-            return;
-        };
+        let addr = self.translate_linear(linear, false, bus)?;
         let dst = bus.read_byte(addr);
         let al = self.regs.byte(ByteReg::AL);
         self.alu_sub_byte(al, dst);
         self.string_advance_di(1);
         self.clk(Self::timing(7, 6));
+        Ok(())
     }
 
-    pub(super) fn scasw(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn scasw(&mut self, bus: &mut impl common::Bus) -> Step {
         let di = self.string_index_di();
         let access_size = if self.operand_size_override { 4 } else { 2 };
-        if !self.check_segment_access(SegReg32::ES, di, access_size, false, bus) {
-            return;
-        }
+        self.check_segment_access(SegReg32::ES, di, access_size, false, bus)?;
         let base = self.seg_base(SegReg32::ES);
         if self.operand_size_override {
-            let Some(dst) = self.string_read_dword(bus, base, di) else {
-                return;
-            };
+            let dst = self.string_read_dword(bus, base, di)?;
             let eax = self.regs.dword(DwordReg::EAX);
             self.alu_sub_dword(eax, dst);
             self.string_advance_di(4);
         } else {
-            let Some(dst) = self.string_read_word(bus, base, di) else {
-                return;
-            };
+            let dst = self.string_read_word(bus, base, di)?;
             let aw = self.regs.word(WordReg::AX);
             self.alu_sub_word(aw, dst);
             self.string_advance_di(2);
@@ -501,41 +446,37 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
         self.clk(Self::timing(7, 6) + penalty);
+        Ok(())
     }
 
-    pub(super) fn insb(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn insb(&mut self, bus: &mut impl common::Bus) -> Step {
         let port = self.regs.word(WordReg::DX);
-        if !self.check_io_privilege(port, 1, bus) {
-            return;
+        if self.check_io_privilege(port, 1, bus).is_err() {
+            return Err(Fault);
         }
         let di = self.string_index_di();
-        if !self.check_segment_access(SegReg32::ES, di, 1, true, bus) {
-            return;
-        }
+        self.check_segment_access(SegReg32::ES, di, 1, true, bus)?;
         let linear = self.string_addr(self.seg_base(SegReg32::ES), di);
-        let Some(addr) = self.translate_linear(linear, true, bus) else {
-            return;
-        };
+        let addr = self.translate_linear(linear, true, bus)?;
         let val = bus.io_read_byte(port);
         bus.write_byte(addr, val);
         self.string_advance_di(1);
         self.clk(Self::timing(15, 17));
+        Ok(())
     }
 
-    pub(super) fn insw(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn insw(&mut self, bus: &mut impl common::Bus) -> Step {
         let port = self.regs.word(WordReg::DX);
         let size = if self.operand_size_override { 4 } else { 2 };
-        if !self.check_io_privilege(port, size, bus) {
-            return;
+        if self.check_io_privilege(port, size, bus).is_err() {
+            return Err(Fault);
         }
         let di = self.string_index_di();
-        if !self.check_segment_access(SegReg32::ES, di, size as u32, true, bus) {
-            return;
-        }
+        self.check_segment_access(SegReg32::ES, di, size as u32, true, bus)?;
         let base = self.seg_base(SegReg32::ES);
         if self.operand_size_override {
-            let Some((a0, cross)) = self.string_probe_write_dword(bus, base, di) else {
-                return;
+            let Ok((a0, cross)) = self.string_probe_write_dword(bus, base, di) else {
+                return Ok(());
             };
             let low = bus.io_read_word(port) as u32;
             let high = bus.io_read_word(port.wrapping_add(2)) as u32;
@@ -551,8 +492,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             }
             self.string_advance_di(4);
         } else {
-            let Some((a0, cross)) = self.string_probe_write_word(bus, base, di) else {
-                return;
+            let Ok((a0, cross)) = self.string_probe_write_word(bus, base, di) else {
+                return Ok(());
             };
             let val = bus.io_read_word(port);
             match cross {
@@ -571,51 +512,43 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
         self.clk(Self::timing(15, 17) + penalty);
+        Ok(())
     }
 
-    pub(super) fn outsb(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn outsb(&mut self, bus: &mut impl common::Bus) -> Step {
         let port = self.regs.word(WordReg::DX);
-        if !self.check_io_privilege(port, 1, bus) {
-            return;
+        if self.check_io_privilege(port, 1, bus).is_err() {
+            return Err(Fault);
         }
         let si = self.string_index_si();
         let src_seg = self.default_seg(SegReg32::DS);
-        if !self.check_segment_access(src_seg, si, 1, false, bus) {
-            return;
-        }
+        self.check_segment_access(src_seg, si, 1, false, bus)?;
         let linear = self.string_addr(self.seg_base(src_seg), si);
-        let Some(addr) = self.translate_linear(linear, false, bus) else {
-            return;
-        };
+        let addr = self.translate_linear(linear, false, bus)?;
         let val = bus.read_byte(addr);
         bus.io_write_byte(port, val);
         self.string_advance_si(1);
         self.clk(Self::timing(14, 17));
+        Ok(())
     }
 
-    pub(super) fn outsw(&mut self, bus: &mut impl common::Bus) {
+    pub(super) fn outsw(&mut self, bus: &mut impl common::Bus) -> Step {
         let port = self.regs.word(WordReg::DX);
         let size = if self.operand_size_override { 4 } else { 2 };
-        if !self.check_io_privilege(port, size, bus) {
-            return;
+        if self.check_io_privilege(port, size, bus).is_err() {
+            return Err(Fault);
         }
         let si = self.string_index_si();
         let src_seg = self.default_seg(SegReg32::DS);
-        if !self.check_segment_access(src_seg, si, size as u32, false, bus) {
-            return;
-        }
+        self.check_segment_access(src_seg, si, size as u32, false, bus)?;
         let base = self.seg_base(src_seg);
         if self.operand_size_override {
-            let Some(val) = self.string_read_dword(bus, base, si) else {
-                return;
-            };
+            let val = self.string_read_dword(bus, base, si)?;
             bus.io_write_word(port, val as u16);
             bus.io_write_word(port.wrapping_add(2), (val >> 16) as u16);
             self.string_advance_si(4);
         } else {
-            let Some(val) = self.string_read_word(bus, base, si) else {
-                return;
-            };
+            let val = self.string_read_word(bus, base, si)?;
             bus.io_write_word(port, val);
             self.string_advance_si(2);
         }
@@ -626,5 +559,6 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
         };
         let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
         self.clk(Self::timing(14, 17) + penalty);
+        Ok(())
     }
 }

--- a/crates/cpu/src/lib.rs
+++ b/crates/cpu/src/lib.rs
@@ -60,8 +60,9 @@
 //!         as soon as they are available, but we are very confident, that our current V30 is
 //!         already 99% cycle accurate when beeing compared to an original V30.
 
-#![warn(missing_docs)]
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(clippy::unnecessary_wraps)]
 
 mod i286;
 mod i386;

--- a/crates/cpu/tests/paging_i386.rs
+++ b/crates/cpu/tests/paging_i386.rs
@@ -1,5 +1,6 @@
 use common::Cpu as _;
 use cpu::{CPU_MODEL_486, I386};
+use softfloat::Fp80;
 
 const RAM_SIZE: usize = 2 * 1024 * 1024;
 const ADDRESS_MASK: u32 = 0x001F_FFFF;
@@ -2818,4 +2819,223 @@ fn paging_iret_inter_priv_pf_on_data_segment_decode_does_not_commit() {
         PG_PAGE_TABLE_0 + SPILL_PTE_INDEX * 4,
         saved_spill_pte,
     );
+}
+
+/// LEAVE atomicity: a #PF on the BP pop must leave ESP/EBP at their
+/// pre-instruction values. The 386 LEAVE conceptually does
+/// `SP := BP; pop BP`. A non-atomic implementation commits the SP update
+/// before the pop and leaves SP at BP after the fault, breaking restart.
+#[test]
+fn paging_fault_leave_16bit_preserves_sp_bp_on_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state_template = setup_paged_protected_mode(&mut bus);
+    let mut state = state_template;
+    state.set_esp(0x0FF0);
+    state.set_ebp(0x4000);
+    cpu.load_state(&state);
+
+    // Mark page 4 (linear 0x4000..0x4FFF) as not present. SS:BP points there.
+    let bp_pte_index: u32 = 0x4;
+    write_dword_at(&mut bus, PG_PAGE_TABLE_0 + bp_pte_index * 4, 0);
+
+    // LEAVE (0xC9)
+    place_at(&mut bus, PG_CODE_BASE, &[0xC9]);
+
+    cpu.step(&mut bus); // LEAVE -> #PF
+    cpu.step(&mut bus); // HLT in handler
+
+    assert!(cpu.halted(), "handler must HLT");
+    assert_eq!(cpu.ip(), PG_PF_HANDLER_IP as u32 + 1);
+    assert_eq!(
+        cpu.cr2, 0x4000,
+        "CR2 must point at the linear address of the faulting BP pop"
+    );
+
+    // Same-privilege #PF pushes 4 dwords on the source stack: err, EIP, CS, EFLAGS.
+    // So handler_sp == ESP_at_fault - 16. If LEAVE is atomic, ESP_at_fault is
+    // the original ESP (0x0FF0). If LEAVE prematurely committed SP := BP,
+    // ESP_at_fault would be BP (0x4000).
+    let handler_sp = cpu.esp();
+    assert_eq!(
+        handler_sp,
+        0x0FF0_u32.wrapping_sub(16),
+        "ESP at fault must be the pre-instruction ESP, not BP"
+    );
+
+    assert_eq!(
+        cpu.ebp(),
+        0x4000,
+        "EBP must not have been popped on faulting LEAVE"
+    );
+}
+
+/// LEAVE r/m32 (with operand-size override 0x66) - same atomicity property
+/// as the 16-bit form, but pops a dword instead of a word.
+#[test]
+fn paging_fault_leave_32bit_preserves_sp_bp_on_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state_template = setup_paged_protected_mode(&mut bus);
+    let mut state = state_template;
+    state.set_esp(0x0FF0);
+    state.set_ebp(0x4000);
+    cpu.load_state(&state);
+
+    let bp_pte_index: u32 = 0x4;
+    write_dword_at(&mut bus, PG_PAGE_TABLE_0 + bp_pte_index * 4, 0);
+
+    // 0x66 0xC9 - LEAVE with operand-size override (pops 4 bytes into EBP)
+    place_at(&mut bus, PG_CODE_BASE, &[0x66, 0xC9]);
+
+    cpu.step(&mut bus); // LEAVE -> #PF
+    cpu.step(&mut bus); // HLT in handler
+
+    assert!(cpu.halted());
+    assert_eq!(cpu.ip(), PG_PF_HANDLER_IP as u32 + 1);
+    assert_eq!(cpu.cr2, 0x4000);
+
+    let handler_sp = cpu.esp();
+    assert_eq!(
+        handler_sp,
+        0x0FF0_u32.wrapping_sub(16),
+        "ESP at fault must be the pre-instruction ESP, not BP"
+    );
+
+    assert_eq!(cpu.ebp(), 0x4000, "EBP must not have been popped");
+}
+
+/// Sets up a paged ring-0 state with TOP=0 and ST(0)=Fp80::ONE (a value that
+/// converts losslessly to f32/f64, so fpu_check_result leaves the precision
+/// flag clear). Marks PTE for linear page 0x14 as not present and sets BX
+/// to 0x4000, so DS:[BX] = 0x14000 will #PF on any memory FPU access. The
+/// FPU memory stores below all target this address.
+fn setup_fpu_fault_state(bus: &mut TestBus) -> cpu::I386State {
+    let mut state = setup_paged_protected_mode(bus);
+    state.set_ebx(0x4000);
+    state.fpu.registers[0] = Fp80::ONE;
+    state.fpu.status_word = 0; // TOP=0, no exception bits
+    state.fpu.tag_word = 0xFFFC; // reg 0 valid (00), regs 1..7 empty (11)
+    state.fpu.control_word = 0x037F; // default; precision = extended
+    state
+}
+
+/// FSTP DWORD PTR [BX] atomicity: a #PF on the memory write must leave
+/// the FPU stack untouched. The buggy implementation calls fpu_pop()
+/// unconditionally after fpu_fst_m32 (whose internal write returns Step
+/// but whose void signature swallows the failure), so on fault TOP would
+/// advance and ST(0)'s tag would flip to empty.
+#[test]
+fn paging_fault_fstp_m32_preserves_st0_on_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_fpu_fault_state(&mut bus);
+    cpu.load_state(&state);
+
+    // PTE 0x14 = not present. DS:BX = 0x10000 + 0x4000 = 0x14000.
+    write_dword_at(&mut bus, PG_PAGE_TABLE_0 + 0x14 * 4, 0);
+
+    // FSTP DWORD PTR [BX] - 0xD9 /3 mod=00 rm=111 -> 0xD9 0x1F
+    place_at(&mut bus, PG_CODE_BASE, &[0xD9, 0x1F]);
+
+    cpu.step(&mut bus); // FSTP -> #PF
+    cpu.step(&mut bus); // HLT in handler
+
+    assert!(cpu.halted());
+    assert_eq!(cpu.ip(), PG_PF_HANDLER_IP as u32 + 1);
+    assert_eq!(cpu.cr2, 0x14000);
+
+    let top = (cpu.state.fpu.status_word >> 11) & 7;
+    assert_eq!(top, 0, "TOP must not have advanced on faulting FSTP");
+
+    let tag_st0 = cpu.state.fpu.tag_word & 0x3;
+    assert_eq!(
+        tag_st0, 0b00,
+        "ST(0) tag must remain valid on faulting FSTP"
+    );
+
+    assert_eq!(
+        cpu.state.fpu.registers[0],
+        Fp80::ONE,
+        "ST(0) register slot must be unchanged on faulting FSTP"
+    );
+}
+
+/// FSTP QWORD PTR [BX] - same property for the 64-bit form (DD /3).
+#[test]
+fn paging_fault_fstp_m64_preserves_st0_on_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_fpu_fault_state(&mut bus);
+    cpu.load_state(&state);
+
+    write_dword_at(&mut bus, PG_PAGE_TABLE_0 + 0x14 * 4, 0);
+
+    // FSTP QWORD PTR [BX] - 0xDD /3 mod=00 rm=111 -> 0xDD 0x1F
+    place_at(&mut bus, PG_CODE_BASE, &[0xDD, 0x1F]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert!(cpu.halted());
+    assert_eq!(cpu.cr2, 0x14000);
+
+    let top = (cpu.state.fpu.status_word >> 11) & 7;
+    assert_eq!(top, 0, "TOP must not advance on faulting FSTP m64");
+    assert_eq!(cpu.state.fpu.tag_word & 0x3, 0b00);
+    assert_eq!(cpu.state.fpu.registers[0], Fp80::ONE);
+}
+
+/// FISTP WORD PTR [BX] - DF /3 mod=00 rm=111 -> 0xDF 0x1F.
+#[test]
+fn paging_fault_fistp_m16_preserves_st0_on_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_fpu_fault_state(&mut bus);
+    cpu.load_state(&state);
+
+    write_dword_at(&mut bus, PG_PAGE_TABLE_0 + 0x14 * 4, 0);
+
+    place_at(&mut bus, PG_CODE_BASE, &[0xDF, 0x1F]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert!(cpu.halted());
+    assert_eq!(cpu.cr2, 0x14000);
+
+    let top = (cpu.state.fpu.status_word >> 11) & 7;
+    assert_eq!(top, 0, "TOP must not advance on faulting FISTP m16");
+    assert_eq!(cpu.state.fpu.tag_word & 0x3, 0b00);
+    assert_eq!(cpu.state.fpu.registers[0], Fp80::ONE);
+}
+
+/// FISTP DWORD PTR [BX] - DB /3 mod=00 rm=111 -> 0xDB 0x1F.
+#[test]
+fn paging_fault_fistp_m32_preserves_st0_on_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_fpu_fault_state(&mut bus);
+    cpu.load_state(&state);
+
+    write_dword_at(&mut bus, PG_PAGE_TABLE_0 + 0x14 * 4, 0);
+
+    place_at(&mut bus, PG_CODE_BASE, &[0xDB, 0x1F]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert!(cpu.halted());
+    assert_eq!(cpu.cr2, 0x14000);
+
+    let top = (cpu.state.fpu.status_word >> 11) & 7;
+    assert_eq!(top, 0, "TOP must not advance on faulting FISTP m32");
+    assert_eq!(cpu.state.fpu.tag_word & 0x3, 0b00);
+    assert_eq!(cpu.state.fpu.registers[0], Fp80::ONE);
 }

--- a/crates/cpu/tests/paging_i386.rs
+++ b/crates/cpu/tests/paging_i386.rs
@@ -3318,3 +3318,126 @@ fn paging_fault_pushad_v86_preserves_sp_on_fault() {
 
     assert_v86_pf_frame_preserves_sp_with_cr2(&cpu, &bus, 0x2004, 0, 0x1FFC);
 }
+
+/// V86 -> ring0 INT dispatch must be restartable: if a push onto the
+/// TSS-supplied kernel stack faults, the #PF handler must observe the
+/// original V86 state (VM=1, V86 SS:ESP, V86 segment registers, EIP
+/// pointing at the INT instruction) so that IRET back re-executes the
+/// INT cleanly. Layout:
+/// - TSS ESP0 = 0x4020 (kernel stack just inside page 4, present).
+/// - Page 3 (linear 0x3000..0x3FFF) NOT PRESENT.
+/// - V86 INT pushes 9 dwords descending from 0x401C to 0x3FFC. The 9th
+///   push at 0x3FFC is in page 3 (FAULT).
+/// - The subsequent #PF dispatch is itself inter-priv (CPL was still 3
+///   since the original INT had not yet committed CS). #PF pushes 10
+///   dwords (from_vm86=true if VM was preserved) totaling 40 bytes,
+///   descending from 0x401C to 0x3FF8 - all in page 4.
+#[test]
+fn paging_fault_v86_int_dispatch_preserves_state_on_kernel_stack_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let mut state = setup_paged_protected_mode(&mut bus);
+    write_dword_at(&mut bus, PG_TSS_BASE + 4, 0x4020);
+
+    make_v86(&mut state, V86_CS_SELECTOR, V86_SS_SELECTOR);
+    let v86_esp_orig: u32 = 0x0F00;
+    state.set_esp(v86_esp_orig);
+    state.ip = 0;
+    state.ip_upper = 0;
+
+    let pde = read_dword_at(&bus, PG_PAGE_DIR);
+    write_dword_at(&mut bus, PG_PAGE_DIR, pde | PTE_US);
+    for i in 0..512u32 {
+        let pte = read_dword_at(&bus, PG_PAGE_TABLE_0 + i * 4);
+        if pte & PTE_P != 0 {
+            write_dword_at(&mut bus, PG_PAGE_TABLE_0 + i * 4, pte | PTE_US);
+        }
+    }
+    write_dword_at(&mut bus, PG_PAGE_TABLE_0 + 3 * 4, 0);
+
+    // INT 0x80 -> 386 gate so the V86 dispatch pushes 9 dwords (36 bytes,
+    // crossing into page 3 and faulting).
+    write_idt_gate(
+        &mut bus,
+        PG_IDT_BASE,
+        0x80,
+        PG_PF_HANDLER_IP as u32,
+        PG_CS_SEL,
+        14,
+        3,
+    );
+    // #PF gate -> 286 gate so its V86 dispatch pushes 10 words (20 bytes),
+    // which fits entirely in page 4. This lets the #PF actually deliver
+    // rather than triple-faulting on the same absent page, so the test
+    // can observe the preserved V86 state in the saved frame.
+    write_idt_gate(
+        &mut bus,
+        PG_IDT_BASE,
+        14,
+        PG_PF_HANDLER_IP as u32,
+        PG_CS_SEL,
+        6,
+        0,
+    );
+
+    cpu.load_state(&state);
+    place_at(&mut bus, V86_CS_BASE, &[0xCD, 0x80]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert!(cpu.halted(), "#PF handler must HLT");
+    assert_eq!(
+        cpu.cr2, 0x3FFC,
+        "CR2 must point at the faulting kernel stack push"
+    );
+
+    // #PF gate is a 286 gate -> V86 inter-priv pushes 10 words (20 bytes).
+    let handler_sp = cpu.esp();
+    assert_eq!(
+        handler_sp,
+        0x4020u32.wrapping_sub(20),
+        "V86 #PF (286 gate) must consume 20 bytes on the TSS stack"
+    );
+
+    // 286-gate V86 inter-priv frame (low to high): errcode, IP, CS,
+    // FLAGS, SP, SS, ES, DS, FS, GS -- each 2 bytes.
+    let frame_base = PG_STACK_BASE + handler_sp;
+    let saved_ip = read_word_at(&bus, frame_base + 2);
+    let saved_cs = read_word_at(&bus, frame_base + 4);
+    let saved_flags = read_word_at(&bus, frame_base + 6);
+    let saved_sp = read_word_at(&bus, frame_base + 8);
+    let saved_ss = read_word_at(&bus, frame_base + 10);
+
+    assert_eq!(saved_ip, 0, "saved IP must point at INT 0x80 for restart");
+    assert_eq!(
+        saved_cs, V86_CS_SELECTOR,
+        "saved CS must be V86 CS, not kernel CS"
+    );
+    // VM is necessarily 0 inside the ring-0 handler; instead, verify
+    // that the saved frame structure proves VM was 1 at fault time -
+    // a from_vm86 inter-priv push from the secondary #PF dispatch
+    // includes the V86 segment registers (GS, FS, DS, ES). If the
+    // primary INT dispatch had pre-cleared VM, the #PF dispatch would
+    // have taken the non-vm86 path with a shorter frame, and we'd have
+    // failed the handler_sp = ESP0 - 20 assertion above.
+    let _ = saved_flags;
+    let saved_es = read_word_at(&bus, frame_base + 12);
+    let saved_ds = read_word_at(&bus, frame_base + 14);
+    let saved_fs = read_word_at(&bus, frame_base + 16);
+    let saved_gs = read_word_at(&bus, frame_base + 18);
+    // V86 ES/DS/FS/GS were left at 0 by make_v86, so all four should be 0.
+    assert_eq!(saved_es, 0, "saved V86 ES must be preserved");
+    assert_eq!(saved_ds, 0, "saved V86 DS must be preserved");
+    assert_eq!(saved_fs, 0, "saved V86 FS must be preserved");
+    assert_eq!(saved_gs, 0, "saved V86 GS must be preserved");
+    assert_eq!(
+        saved_sp as u32, v86_esp_orig,
+        "saved SP must be the V86 SP, not the kernel TSS ESP"
+    );
+    assert_eq!(
+        saved_ss, V86_SS_SELECTOR,
+        "saved SS must be V86 SS, not the kernel SS"
+    );
+}

--- a/crates/cpu/tests/paging_i386.rs
+++ b/crates/cpu/tests/paging_i386.rs
@@ -3441,3 +3441,160 @@ fn paging_fault_v86_int_dispatch_preserves_state_on_kernel_stack_fault() {
         "saved SS must be V86 SS, not the kernel SS"
     );
 }
+
+/// CALL FAR ptr16:16 in V86 - sequential push(CS); push(IP). SP=0x2002:
+/// push CS at 0x2000 (page 2, OK), push IP at 0x1FFE (page 1, FAULT).
+/// Buggy code commits SP after the first push, so the saved-ESP frame
+/// slot would read 0x2000 instead of 0x2002.
+#[test]
+fn paging_fault_call_far_v86_preserves_sp_on_ip_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_v86_descending_push_fault(&mut bus, 0x2002);
+    cpu.load_state(&state);
+
+    // CALL FAR 0x1234:0x5678 - 0x9A imm16 imm16
+    place_at(&mut bus, V86_CS_BASE, &[0x9A, 0x78, 0x56, 0x34, 0x12]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_v86_pf_frame_preserves_sp_with_cr2(&cpu, &bus, 0x2002, 0, 0x1FFE);
+}
+
+/// CALL FAR ptr16:32 in V86 (0x66 prefix) - dword pushes. SP=0x2004:
+/// push CS dword at 0x2000-0x2003 (page 2, OK), push EIP dword at
+/// 0x1FFC-0x1FFF (page 1, FAULT).
+#[test]
+fn paging_fault_call_far_o32_v86_preserves_esp_on_eip_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_v86_descending_push_fault(&mut bus, 0x2004);
+    cpu.load_state(&state);
+
+    // 0x66 0x9A imm32 imm16 - CALL FAR ptr16:32
+    place_at(
+        &mut bus,
+        V86_CS_BASE,
+        &[0x66, 0x9A, 0x78, 0x56, 0x34, 0x12, 0x00, 0x10],
+    );
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_v86_pf_frame_preserves_sp_with_cr2(&cpu, &bus, 0x2004, 0, 0x1FFC);
+}
+
+/// CALL m16:16 far indirect (group FF /3) in V86 - sequential push(CS);
+/// push(IP). Same fault property as CALL FAR ptr16:16. The far pointer
+/// itself is placed in a mapped data page.
+#[test]
+fn paging_fault_call_m_far_v86_preserves_sp_on_ip_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_v86_descending_push_fault(&mut bus, 0x2002);
+    cpu.load_state(&state);
+
+    // Place a m16:16 far pointer at DS:[0x6000] (page 6, mapped).
+    // Layout: IP word at +0, CS word at +2.
+    write_word_at(&mut bus, 0x6000, 0x5678);
+    write_word_at(&mut bus, 0x6002, 0x1234);
+
+    // CALL FAR WORD PTR [0x6000] - 0xFF /3 with modrm 0x1E disp16.
+    place_at(&mut bus, V86_CS_BASE, &[0xFF, 0x1E, 0x00, 0x60]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_v86_pf_frame_preserves_sp_with_cr2(&cpu, &bus, 0x2002, 0, 0x1FFE);
+}
+
+/// ENTER 0, 2 in V86 with the source frame pointer landing in an absent
+/// page. The instruction pushes BP, then walks SS:[BP-2] for the chain.
+/// Buggy code commits the first push (SP -= 2, write BP at SP-2) before
+/// the chain read fires. Atomic code reads the chain into a buffer
+/// before any commit, so a #PF leaves SP and the stack word at the BP
+/// slot untouched. SP=0x4002 (page 4, mapped), BP=0x1004 (page 1, absent).
+/// Chain read at SS:[0x1002] faults; we observe CR2=0x1002, saved-ESP=
+/// 0x4002, the BP push slot at linear 0x4000 still zeroed, and the V86
+/// BP register unchanged.
+#[test]
+fn paging_fault_enter_level_2_chain_read_preserves_state() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let mut state = setup_v86_descending_push_fault(&mut bus, 0x4002);
+    state.set_ebp(0x1004);
+    cpu.load_state(&state);
+
+    // ENTER 0x0000, 0x02 - 0xC8 imm16 imm8.
+    place_at(&mut bus, V86_CS_BASE, &[0xC8, 0x00, 0x00, 0x02]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_v86_pf_frame_preserves_sp_with_cr2(&cpu, &bus, 0x4002, 0, 0x1002);
+
+    // Push slot for BP at SS:[0x4000] must remain at its initial zero
+    // value - the chain read fault must abort before the BP push commits.
+    let bp_slot = read_word_at(&bus, 0x4000);
+    assert_eq!(
+        bp_slot, 0,
+        "BP push slot must not be written when ENTER faults on chain read"
+    );
+    assert_eq!(
+        cpu.ebp(),
+        0x1004,
+        "EBP must remain at its V86 value when ENTER faults"
+    );
+}
+
+/// POP word ptr [absent_page] in V86 - pop reads from stack (mapped),
+/// then put writes to memory (absent). Buggy code commits SP from the
+/// pop before attempting the write, so the saved-ESP frame slot would
+/// read 0x2002. Atomic code rolls SP back when the put faults.
+#[test]
+fn paging_fault_pop_rm_mem_v86_preserves_sp() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_v86_descending_push_fault(&mut bus, 0x2000);
+    cpu.load_state(&state);
+
+    // Seed the top-of-stack with a known word so pop reads valid data.
+    write_word_at(&mut bus, 0x2000, 0xBEEF);
+
+    // POP WORD PTR [0x1000] - 0x8F /0 with modrm 0x06 disp16. Memory
+    // target lands in absent page 1.
+    place_at(&mut bus, V86_CS_BASE, &[0x8F, 0x06, 0x00, 0x10]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_v86_pf_frame_preserves_sp_with_cr2(&cpu, &bus, 0x2000, 0, 0x1000);
+}
+
+/// POP DWORD PTR [absent_page] in V86 (0x66 prefix) - same property
+/// with dword pop. SP=0x2000 so the stack read fits in page 2 and the
+/// memory write hits page 1.
+#[test]
+fn paging_fault_pop_rm_o32_mem_v86_preserves_esp() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_v86_descending_push_fault(&mut bus, 0x2000);
+    cpu.load_state(&state);
+
+    write_dword_at(&mut bus, 0x2000, 0xDEAD_BEEF);
+
+    // 0x66 0x8F 0x06 disp16 - POP DWORD PTR [disp16] (16-bit address mode).
+    place_at(&mut bus, V86_CS_BASE, &[0x66, 0x8F, 0x06, 0x00, 0x10]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_v86_pf_frame_preserves_sp_with_cr2(&cpu, &bus, 0x2000, 0, 0x1000);
+}

--- a/crates/cpu/tests/paging_i386.rs
+++ b/crates/cpu/tests/paging_i386.rs
@@ -3117,9 +3117,25 @@ fn assert_v86_pf_frame_preserves_sp(
     expected_user_esp: u32,
     expected_user_eip: u32,
 ) {
+    assert_v86_pf_frame_preserves_sp_with_cr2(
+        cpu,
+        bus,
+        expected_user_esp,
+        expected_user_eip,
+        0x1000,
+    );
+}
+
+fn assert_v86_pf_frame_preserves_sp_with_cr2(
+    cpu: &I386,
+    bus: &TestBus,
+    expected_user_esp: u32,
+    expected_user_eip: u32,
+    expected_cr2: u32,
+) {
     assert!(cpu.halted(), "ring-0 #PF handler must HLT");
     assert_eq!(cpu.ip(), PG_PF_HANDLER_IP as u32 + 1);
-    assert_eq!(cpu.cr2, 0x1000, "CR2 must point at the not-present CS slot");
+    assert_eq!(cpu.cr2, expected_cr2, "CR2 must point at the faulting slot");
 
     // Ring-0 ESP after the 10-dword V86 fault frame push.
     let handler_sp = cpu.esp();
@@ -3135,11 +3151,11 @@ fn assert_v86_pf_frame_preserves_sp(
 
     assert_eq!(
         saved_eip, expected_user_eip,
-        "saved EIP must point at the faulting RET FAR for restart"
+        "saved EIP must point at the faulting instruction for restart"
     );
     assert_eq!(
         saved_esp, expected_user_esp,
-        "saved V86 ESP must be the pre-instruction SP, not the partially-popped SP"
+        "saved V86 ESP must be the pre-instruction SP, not the partially-modified SP"
     );
 }
 
@@ -3202,4 +3218,103 @@ fn paging_fault_ret_far_o32_v86_preserves_esp_on_cs_fault() {
     cpu.step(&mut bus);
 
     assert_v86_pf_frame_preserves_sp(&cpu, &bus, 0x0FFC, 0);
+}
+
+/// IRET in V86 - 16-bit form pops IP, CS, FLAGS. SP=0x0FFE puts the IP
+/// slot in page 0 and the CS slot at the start of page 1 (not present).
+/// Buggy code commits SP from the first pop before the second runs.
+#[test]
+fn paging_fault_iret_v86_preserves_sp_on_cs_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_v86_ret_far_fault(&mut bus, 0x0FFE);
+    cpu.load_state(&state);
+
+    place_at(&mut bus, V86_CS_BASE, &[0xCF]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_v86_pf_frame_preserves_sp(&cpu, &bus, 0x0FFE, 0);
+}
+
+/// IRETD in V86 - 32-bit form pops 3 dwords.
+#[test]
+fn paging_fault_iretd_v86_preserves_sp_on_cs_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_v86_ret_far_fault(&mut bus, 0x0FFC);
+    cpu.load_state(&state);
+
+    place_at(&mut bus, V86_CS_BASE, &[0x66, 0xCF]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_v86_pf_frame_preserves_sp(&cpu, &bus, 0x0FFC, 0);
+}
+
+/// Variant of the V86 fault harness with page 2 (linear 0x2000) present
+/// and page 1 (linear 0x1000) not present. Stack starts in page 2 and
+/// pushes descend into page 1 so push #2+ faults.
+fn setup_v86_descending_push_fault(bus: &mut TestBus, sp: u16) -> cpu::I386State {
+    let mut state = setup_paged_protected_mode(bus);
+    make_v86(&mut state, V86_CS_SELECTOR, V86_SS_SELECTOR);
+    state.set_esp(sp as u32);
+    state.ip = 0;
+    state.ip_upper = 0;
+
+    let pde = read_dword_at(bus, PG_PAGE_DIR);
+    write_dword_at(bus, PG_PAGE_DIR, pde | PTE_US);
+    for i in 0..512u32 {
+        let pte = read_dword_at(bus, PG_PAGE_TABLE_0 + i * 4);
+        if pte & PTE_P != 0 {
+            write_dword_at(bus, PG_PAGE_TABLE_0 + i * 4, pte | PTE_US);
+        }
+    }
+    // Page 1 (linear 0x1000) is NOT PRESENT.
+    write_dword_at(bus, PG_PAGE_TABLE_0 + 4, 0);
+    state
+}
+
+/// PUSHA in V86 - 8 sequential pushes. SP=0x2002: push #1 (AX) at 0x2000
+/// (page 2, OK), push #2 (CX) at 0x1FFE (page 1, FAULT).
+#[test]
+fn paging_fault_pusha_v86_preserves_sp_on_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let mut state = setup_v86_descending_push_fault(&mut bus, 0x2002);
+    state.set_eax(0xAAAA);
+    state.set_ecx(0xCCCC);
+    cpu.load_state(&state);
+
+    place_at(&mut bus, V86_CS_BASE, &[0x60]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_v86_pf_frame_preserves_sp_with_cr2(&cpu, &bus, 0x2002, 0, 0x1FFE);
+}
+
+/// PUSHAD in V86 - 8 sequential dword pushes. SP=0x2004: push #1 (EAX)
+/// at 0x2000 (page 2, OK), push #2 (ECX) at 0x1FFC (page 1, FAULT).
+#[test]
+fn paging_fault_pushad_v86_preserves_sp_on_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let mut state = setup_v86_descending_push_fault(&mut bus, 0x2004);
+    state.set_eax(0xAAAAAAAA);
+    state.set_ecx(0xCCCCCCCC);
+    cpu.load_state(&state);
+
+    place_at(&mut bus, V86_CS_BASE, &[0x66, 0x60]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_v86_pf_frame_preserves_sp_with_cr2(&cpu, &bus, 0x2004, 0, 0x1FFC);
 }

--- a/crates/cpu/tests/paging_i386.rs
+++ b/crates/cpu/tests/paging_i386.rs
@@ -319,6 +319,38 @@ fn make_ring3(state: &mut cpu::I386State) {
     state.seg_rights[cpu::SegReg32::ES as usize] = 0xF3;
 }
 
+/// Transforms a ring-0 protected-mode + paging state into V86 mode.
+/// CS / SS / DS / ES are reshaped to real-mode-style caches (base =
+/// selector << 4, limit 0xFFFF, data-style rights). The VM flag (EFLAGS
+/// bit 17) is set. The caller is responsible for placing the V86
+/// instruction at `(cs_selector << 4) + ip` linear, and ensuring those
+/// pages are present and identity-mapped.
+fn make_v86(state: &mut cpu::I386State, cs_selector: u16, ss_selector: u16) {
+    state.set_cs(cs_selector);
+    state.seg_bases[cpu::SegReg32::CS as usize] = (cs_selector as u32) << 4;
+    state.seg_limits[cpu::SegReg32::CS as usize] = 0xFFFF;
+    state.seg_rights[cpu::SegReg32::CS as usize] = 0xF3;
+
+    state.set_ss(ss_selector);
+    state.seg_bases[cpu::SegReg32::SS as usize] = (ss_selector as u32) << 4;
+    state.seg_limits[cpu::SegReg32::SS as usize] = 0xFFFF;
+    state.seg_rights[cpu::SegReg32::SS as usize] = 0xF3;
+    state.seg_granularity[cpu::SegReg32::SS as usize] = 0;
+
+    state.set_ds(0);
+    state.seg_bases[cpu::SegReg32::DS as usize] = 0;
+    state.seg_limits[cpu::SegReg32::DS as usize] = 0xFFFF;
+    state.seg_rights[cpu::SegReg32::DS as usize] = 0xF3;
+
+    state.set_es(0);
+    state.seg_bases[cpu::SegReg32::ES as usize] = 0;
+    state.seg_limits[cpu::SegReg32::ES as usize] = 0xFFFF;
+    state.seg_rights[cpu::SegReg32::ES as usize] = 0xF3;
+
+    state.eflags_upper |= 0x0002_0000; // VM=1
+    state.flags.iopl = 3;
+}
+
 /// Identity-mapped paging: MOV AL,[DS:offset] reads through page tables correctly.
 #[test]
 fn paging_identity_map_read_byte() {
@@ -3038,4 +3070,136 @@ fn paging_fault_fistp_m32_preserves_st0_on_fault() {
     assert_eq!(top, 0, "TOP must not advance on faulting FISTP m32");
     assert_eq!(cpu.state.fpu.tag_word & 0x3, 0b00);
     assert_eq!(cpu.state.fpu.registers[0], Fp80::ONE);
+}
+
+/// Layout for V86 RET FAR atomicity tests:
+/// - V86 CS = 0x0500 -> linear 0x5000 (page 0x5, present, contains RET FAR)
+/// - V86 SS = 0x0000 -> linear 0..0xFFFF
+/// - Page 0 (linear 0..0xFFF) is present; the V86 stack IP slot lives here.
+/// - Page 1 (linear 0x1000..0x1FFF) is marked NOT PRESENT; the V86 stack
+///   CS slot lives here. The second pop on RET FAR is what should #PF.
+/// - On the V86 -> ring 0 #PF transition, the CPU loads SS:ESP from TSS
+///   (ESP0=0xFFF0, SS0=PG_SS_SEL, base 0) and pushes a 10-dword frame
+///   (GS, FS, DS, ES, SS, ESP, EFLAGS, CS, EIP, errcode = 40 bytes).
+const V86_CS_SELECTOR: u16 = 0x0500;
+const V86_SS_SELECTOR: u16 = 0x0000;
+const V86_CS_BASE: u32 = (V86_CS_SELECTOR as u32) << 4; // 0x5000
+const V86_PF_FRAME_BYTES: u32 = 40;
+
+fn setup_v86_ret_far_fault(bus: &mut TestBus, sp: u16) -> cpu::I386State {
+    let mut state = setup_paged_protected_mode(bus);
+    make_v86(&mut state, V86_CS_SELECTOR, V86_SS_SELECTOR);
+    state.set_esp(sp as u32);
+    state.ip = 0;
+    state.ip_upper = 0;
+
+    // V86 runs at CPL=3, so PDE and the pages directly touched by V86
+    // need US=1. We mark the whole identity map US-accessible; the
+    // kernel-side IDT/GDT/TSS/handler pages are accessed in supervisor
+    // mode (CPL drops to 0 on #PF entry) and don't depend on US.
+    let pde = read_dword_at(bus, PG_PAGE_DIR);
+    write_dword_at(bus, PG_PAGE_DIR, pde | PTE_US);
+    for i in 0..512u32 {
+        let pte = read_dword_at(bus, PG_PAGE_TABLE_0 + i * 4);
+        if pte & PTE_P != 0 {
+            write_dword_at(bus, PG_PAGE_TABLE_0 + i * 4, pte | PTE_US);
+        }
+    }
+
+    // Mark linear page 0x1000 (PTE index 1) as not present.
+    write_dword_at(bus, PG_PAGE_TABLE_0 + 4, 0);
+    state
+}
+
+fn assert_v86_pf_frame_preserves_sp(
+    cpu: &I386,
+    bus: &TestBus,
+    expected_user_esp: u32,
+    expected_user_eip: u32,
+) {
+    assert!(cpu.halted(), "ring-0 #PF handler must HLT");
+    assert_eq!(cpu.ip(), PG_PF_HANDLER_IP as u32 + 1);
+    assert_eq!(cpu.cr2, 0x1000, "CR2 must point at the not-present CS slot");
+
+    // Ring-0 ESP after the 10-dword V86 fault frame push.
+    let handler_sp = cpu.esp();
+    assert_eq!(
+        handler_sp,
+        0xFFF0u32.wrapping_sub(V86_PF_FRAME_BYTES),
+        "V86 #PF must consume 40 bytes on the TSS-supplied stack"
+    );
+
+    // V86 frame layout (low to high): errcode, EIP, CS, EFLAGS, ESP, SS, ...
+    let saved_eip = read_dword_at(bus, PG_STACK_BASE + handler_sp + 4);
+    let saved_esp = read_dword_at(bus, PG_STACK_BASE + handler_sp + 16);
+
+    assert_eq!(
+        saved_eip, expected_user_eip,
+        "saved EIP must point at the faulting RET FAR for restart"
+    );
+    assert_eq!(
+        saved_esp, expected_user_esp,
+        "saved V86 ESP must be the pre-instruction SP, not the partially-popped SP"
+    );
+}
+
+/// RET FAR in V86 - second pop (CS slot) faults; SP must remain at its
+/// pre-instruction value. Buggy code commits SP += 2 from the first pop
+/// before the second pop runs, so the saved-ESP frame slot would read 0x1000.
+#[test]
+fn paging_fault_ret_far_v86_preserves_sp_on_cs_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_v86_ret_far_fault(&mut bus, 0x0FFE);
+    cpu.load_state(&state);
+
+    // RET FAR at V86 CS:IP = 0x0500:0x0000 = linear 0x5000.
+    place_at(&mut bus, V86_CS_BASE, &[0xCB]);
+
+    cpu.step(&mut bus); // RET FAR -> #PF on the CS pop
+    cpu.step(&mut bus); // HLT in handler
+
+    assert_v86_pf_frame_preserves_sp(&cpu, &bus, 0x0FFE, 0);
+}
+
+/// RET FAR imm16 in V86 - same property; SP must not have absorbed the
+/// imm operand either.
+#[test]
+fn paging_fault_ret_far_imm_v86_preserves_sp_on_cs_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_v86_ret_far_fault(&mut bus, 0x0FFE);
+    cpu.load_state(&state);
+
+    // RET FAR 0x0004 -- 0xCA imm16
+    place_at(&mut bus, V86_CS_BASE, &[0xCA, 0x04, 0x00]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_v86_pf_frame_preserves_sp(&cpu, &bus, 0x0FFE, 0);
+}
+
+/// RET FAR with operand-size override 0x66 in V86 - 32-bit IP / CS pops.
+/// SP = 0x0FFC means the dword IP slot is at 0x0FFC..0x0FFF (page 0,
+/// present) and the dword CS slot is at 0x1000..0x1003 (page 1, not
+/// present). The first read succeeds; the second must fault without
+/// committing SP.
+#[test]
+fn paging_fault_ret_far_o32_v86_preserves_esp_on_cs_fault() {
+    let mut cpu: I386 = I386::new();
+    let mut bus = TestBus::new();
+
+    let state = setup_v86_ret_far_fault(&mut bus, 0x0FFC);
+    cpu.load_state(&state);
+
+    // 0x66 0xCB -- operand-size override + RET FAR
+    place_at(&mut bus, V86_CS_BASE, &[0x66, 0xCB]);
+
+    cpu.step(&mut bus);
+    cpu.step(&mut bus);
+
+    assert_v86_pf_frame_preserves_sp(&cpu, &bus, 0x0FFC, 0);
 }


### PR DESCRIPTION
This should now close the gap on the 386. But more in depth testing with Win95 and it's command-line needs to be done. OS/2 might also be a good target to test too, since it was designed with the protected mode in mind.