### PR TITLE
fix: polarity of graphics extension bit

### DIFF
--- a/crates/device/src/i8255_system_ppi.rs
+++ b/crates/device/src/i8255_system_ppi.rs
@@ -18,7 +18,8 @@ const PORT_B_CLOCK_8MHZ: u8 = 0x20;
 const _PORT_B_LCD: u8 = 0x10;
 
 /// Port B bit 3: HGC - mirrors DIP SW 1-8 (graphics extension).
-/// 1 = basic mode (OFF), 0 = expanded mode (ON).
+/// 1 = DIP SW 1-8 OFF = basic mode (no analog 16-color extension).
+/// 0 = DIP SW 1-8 ON  = expanded mode (analog 16-color extension installed).
 /// Ref: undoc98 `io_prn.txt` (I/O 0042h bit 3)
 const PORT_B_GRAPHICS_EXT: u8 = 0x08;
 
@@ -302,13 +303,13 @@ impl I8255SystemPpi {
         }
     }
 
-    /// Sets the graphics extension bit in port B (bit 3).
+    /// Sets the graphics extension bit (HGC, bit 3) in port B.
     /// Ref: undoc98 `io_prn.txt` (I/O 0042h bit 3)
     pub fn set_graphics_extension_bit(&mut self, enabled: bool) {
         if enabled {
-            self.state.port_b |= PORT_B_GRAPHICS_EXT;
-        } else {
             self.state.port_b &= !PORT_B_GRAPHICS_EXT;
+        } else {
+            self.state.port_b |= PORT_B_GRAPHICS_EXT;
         }
     }
 }

--- a/crates/machine/tests/bios/post_bios_state.rs
+++ b/crates/machine/tests/bios/post_bios_state.rs
@@ -297,7 +297,7 @@ fn post_bios_state_vm() {
     check!(f, state.fdc_640k.drive_equipped, 3, "FDC 640K equipped");
 
     // === System PPI ===
-    check!(f, state.system_ppi.port_b, 0x8A, "System PPI port B");
+    check!(f, state.system_ppi.port_b, 0x82, "System PPI port B");
     check!(f, state.system_ppi.port_c, 0x18, "System PPI port C");
     check!(f, state.system_ppi.dip_switch_2, 0xF3, "DIP switch 2");
     check!(
@@ -624,7 +624,7 @@ fn post_bios_state_f() {
     check!(f, state.fdc_640k.drive_equipped, 3, "FDC 640K equipped");
 
     // === System PPI ===
-    check!(f, state.system_ppi.port_b, 0xA8, "System PPI port B");
+    check!(f, state.system_ppi.port_b, 0xA0, "System PPI port B");
     check!(f, state.system_ppi.port_c, 0x18, "System PPI port C");
 
     // === CGROM ===
@@ -853,7 +853,7 @@ fn post_bios_state_vx() {
     check!(f, state.fdc_640k.control, 0x48, "FDC 640K control");
 
     // === System PPI ===
-    check!(f, state.system_ppi.port_b, 0x88, "System PPI port B");
+    check!(f, state.system_ppi.port_b, 0x80, "System PPI port B");
     check!(f, state.system_ppi.port_c, 0xB8, "System PPI port C");
     check!(f, state.system_ppi.dip_switch_2, 0xF3, "DIP switch 2");
 
@@ -1132,7 +1132,7 @@ fn post_bios_state_ra() {
     check_true!(f, state.serial.expect_mode, "Serial expecting mode");
 
     // === System PPI ===
-    check!(f, state.system_ppi.port_b, 0xA8, "System PPI port B");
+    check!(f, state.system_ppi.port_b, 0xA0, "System PPI port B");
     check!(f, state.system_ppi.port_c, 0xB8, "System PPI port C");
 
     // === FDC 1MB ===
@@ -1409,7 +1409,7 @@ fn post_bios_state_pc9821as_ide() {
     check_true!(f, state.serial.expect_mode, "Serial expecting mode");
 
     // === System PPI ===
-    check!(f, state.system_ppi.port_b, 0xA8, "System PPI port B");
+    check!(f, state.system_ppi.port_b, 0xA0, "System PPI port B");
     check!(f, state.system_ppi.port_c, 0xB8, "System PPI port C");
 
     // === FDC 1MB ===


### PR DESCRIPTION
This lets us boot D.P.S. using a real BIOS with a BASIC ROM.