### PR TITLE
fix: multiple issues when installing and running Windows 3.1

### DIFF
--- a/crates/device/src/pegc.rs
+++ b/crates/device/src/pegc.rs
@@ -185,6 +185,44 @@ impl Pegc {
         self.state.mode_register = 0;
     }
 
+    fn reset_transfer_state_from_length(&mut self) {
+        self.state.remain = u32::from(self.state.block_length) + 1;
+        self.state.last_data_length = 0;
+    }
+
+    fn source_buffer_length(&self) -> usize {
+        self.state
+            .last_data_length
+            .clamp(0, self.state.last_vram_data.len() as i32) as usize
+    }
+
+    fn append_source_buffer(&mut self, index: usize, value: u8) {
+        let write_index = self.source_buffer_length() + index;
+        if write_index < self.state.last_vram_data.len() {
+            self.state.last_vram_data[write_index] = value;
+        }
+    }
+
+    fn finish_source_buffer_append(&mut self, pixels: u32) {
+        let length = self
+            .source_buffer_length()
+            .saturating_add(pixels as usize)
+            .min(self.state.last_vram_data.len());
+        self.state.last_data_length = length as i32;
+    }
+
+    fn consume_source_buffer(&mut self, pixels: usize) {
+        let length = self.source_buffer_length();
+        let consumed = pixels.min(length);
+        if consumed == 0 {
+            return;
+        }
+
+        self.state.last_vram_data.copy_within(consumed..length, 0);
+        self.state.last_vram_data[length - consumed..length].fill(0);
+        self.state.last_data_length = (length - consumed) as i32;
+    }
+
     /// Writes the 256-color palette index register (port 0xA8 in PEGC mode).
     pub fn write_palette_index(&mut self, value: u8) {
         self.state.palette_index = value;
@@ -335,6 +373,10 @@ impl Pegc {
             REG_PALETTE1 => self.state.palette_color_1 = value,
             REG_PALETTE2 => self.state.palette_color_2 = value,
             _ => {}
+        }
+
+        if offset < REG_PATTERN {
+            self.reset_transfer_state_from_length();
         }
     }
 
@@ -606,7 +648,6 @@ impl Pegc {
         };
 
         let mut result: u32 = 0;
-        self.state.last_data_length = 0;
 
         if !source_from_cpu {
             for i in 0u32..pixels {
@@ -622,7 +663,7 @@ impl Pegc {
                     result |= 1u32 << i;
                 }
 
-                self.state.last_vram_data[i as usize] = data;
+                self.append_source_buffer(i as usize, data);
 
                 if pattern_update {
                     for plane in 0..8u32 {
@@ -631,10 +672,7 @@ impl Pegc {
                     }
                 }
             }
-        }
-
-        if self.state.last_data_length < 32 {
-            self.state.last_data_length = (self.state.last_data_length + pixels as i32).min(32);
+            self.finish_source_buffer_append(pixels);
         }
 
         result
@@ -689,6 +727,8 @@ impl Pegc {
         }
         base_address &= PEGC_VRAM_SIZE as u32 - 1;
 
+        let source_buffer_length = self.source_buffer_length();
+
         for i in 0..data_length {
             let pixel_address = if shift_direction_decrement {
                 base_address.wrapping_sub(i as u32) & (PEGC_VRAM_SIZE as u32 - 1)
@@ -704,8 +744,14 @@ impl Pegc {
                     } else {
                         0x00
                     }
-                } else {
+                } else if (i as usize) < source_buffer_length {
                     self.state.last_vram_data[i as usize]
+                } else {
+                    self.state.remain -= 1;
+                    if self.state.remain == 0 {
+                        break;
+                    }
+                    continue;
                 };
 
                 let destination = vram[pixel_address as usize];
@@ -733,10 +779,10 @@ impl Pegc {
             }
         }
 
-        if self.state.last_data_length > pixels_signed {
-            self.state.last_data_length -= pixels_signed;
-        } else {
+        if source_from_cpu {
             self.state.last_data_length = 0;
+        } else {
+            self.consume_source_buffer(pixels as usize);
         }
     }
 
@@ -1189,15 +1235,15 @@ mod tests {
     }
 
     #[test]
-    fn mmio_register_write_does_not_reset_block_transfer() {
+    fn mmio_control_write_resets_block_transfer() {
         let mut pegc = Pegc::new();
         pegc.state.block_length = 99;
         pegc.state.remain = 42;
         pegc.state.last_data_length = 16;
 
         pegc.mmio_write_byte(MMIO2_BASE + REG_PLANE_ACCESS, 0xFF);
-        assert_eq!(pegc.state.remain, 42);
-        assert_eq!(pegc.state.last_data_length, 16);
+        assert_eq!(pegc.state.remain, 100);
+        assert_eq!(pegc.state.last_data_length, 0);
     }
 
     #[test]
@@ -1259,6 +1305,60 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn plane_mode_shifted_vram_source_write_consumes_full_words() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x10F0;
+        pegc.state.write_mask = 0xFFFF;
+        pegc.state.block_length = 31;
+        pegc.state.remain = 32;
+        pegc.state.shift_read = 0;
+        pegc.state.shift_write = 5;
+
+        let mut vram = vec![0u8; PEGC_VRAM_SIZE];
+        let source_offset = 0x1000u32;
+        let source_pixel_base = source_offset * 8;
+        for i in 0..48u32 {
+            vram[(source_pixel_base + i) as usize] = (i + 1) as u8;
+        }
+
+        pegc.plane_read_word(source_offset, &vram);
+        pegc.plane_read_word(source_offset + 2, &vram);
+        pegc.plane_read_word(source_offset + 4, &vram);
+
+        let destination_offset = 0x2000u32;
+        let destination_pixel_base = destination_offset * 8;
+        pegc.plane_write_word(destination_offset, 0, &mut vram);
+        pegc.plane_write_word(destination_offset + 2, 0, &mut vram);
+        pegc.plane_write_word(destination_offset + 4, 0, &mut vram);
+
+        for i in 0..11u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + 5 + i) as usize],
+                (i + 1) as u8,
+                "first shifted write copied source pixel {i} incorrectly"
+            );
+        }
+        for i in 0..16u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + 16 + i) as usize],
+                (17 + i) as u8,
+                "second shifted write did not advance by a full source word"
+            );
+        }
+        for i in 0..5u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + 32 + i) as usize],
+                (33 + i) as u8,
+                "final shifted write did not continue from the next source word"
+            );
+        }
+        assert_eq!(vram[(destination_pixel_base + 37) as usize], 0x00);
+        assert_eq!(pegc.state.remain, 0);
     }
 
     #[test]

--- a/crates/device/src/pegc.rs
+++ b/crates/device/src/pegc.rs
@@ -93,6 +93,8 @@ pub struct PegcState {
     pub last_data_length: i32,
     /// Remaining block transfer count for plane mode.
     pub remain: u32,
+    /// Skips the padding write after a shifted CPU-source block completes.
+    pub skip_next_shifted_cpu_write: bool,
     /// 256-color palette: 256 entries of [green, red, blue], 8-bit components.
     pub palette_256: Box<[[u8; 3]; 256]>,
     /// Currently selected palette index (port 0xA8 in PEGC mode).
@@ -135,6 +137,7 @@ impl Pegc {
                 last_vram_data: [0u8; 64],
                 last_data_length: 0,
                 remain: 0,
+                skip_next_shifted_cpu_write: false,
                 palette_256: Box::new([[0u8; 3]; 256]),
                 palette_index: 0,
             },
@@ -188,6 +191,7 @@ impl Pegc {
     fn reset_transfer_state_from_length(&mut self) {
         self.state.remain = u32::from(self.state.block_length) + 1;
         self.state.last_data_length = 0;
+        self.state.skip_next_shifted_cpu_write = false;
     }
 
     fn source_buffer_length(&self) -> usize {
@@ -709,6 +713,12 @@ impl Pegc {
         if self.state.remain == 0 {
             self.state.remain = block_length + 1;
             self.state.last_data_length = 0;
+            if self.state.skip_next_shifted_cpu_write {
+                self.state.skip_next_shifted_cpu_write = false;
+                return;
+            }
+        } else {
+            self.state.skip_next_shifted_cpu_write = false;
         }
 
         let pixels_signed = pixels as i32;
@@ -777,6 +787,10 @@ impl Pegc {
             if self.state.remain == 0 {
                 break;
             }
+        }
+
+        if self.state.remain == 0 && !extended_shift_mode && dest_shift != 0 {
+            self.state.skip_next_shifted_cpu_write = true;
         }
 
         if source_from_cpu {
@@ -1359,6 +1373,50 @@ mod tests {
         }
         assert_eq!(vram[(destination_pixel_base + 37) as usize], 0x00);
         assert_eq!(pegc.state.remain, 0);
+    }
+
+    #[test]
+    fn plane_mode_shifted_cpu_source_aligned_block_skips_padding_word() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x0100;
+        pegc.state.write_mask = 0xFFFF;
+        pegc.state.block_length = 31;
+        pegc.state.remain = 32;
+        pegc.state.shift_write = 5;
+
+        let mut vram = vec![0x77u8; PEGC_VRAM_SIZE];
+        let destination_offset = 0x2000u32;
+        let destination_pixel_base = destination_offset * 8;
+
+        pegc.plane_write_word(destination_offset, 0xFFFF, &mut vram);
+        pegc.plane_write_word(destination_offset + 2, 0xFFFF, &mut vram);
+        pegc.plane_write_word(destination_offset + 4, 0x0000, &mut vram);
+
+        for i in 0..5u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + i) as usize],
+                0x77,
+                "pixel {i} before the destination shift should be untouched"
+            );
+        }
+        for i in 5..37u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + i) as usize],
+                0xFF,
+                "shifted block pixel {i} should come from the first two source words"
+            );
+        }
+        for i in 37..53u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + i) as usize],
+                0x77,
+                "the padding word should not start a new shifted block at pixel {i}"
+            );
+        }
+        assert_eq!(pegc.state.remain, 32);
+        assert!(!pegc.state.skip_next_shifted_cpu_write);
     }
 
     #[test]

--- a/crates/device/src/upd7220_gdc.rs
+++ b/crates/device/src/upd7220_gdc.rs
@@ -32,6 +32,17 @@ const STATUS_HBLANK: u8 = 0x40;
 /// Status register bit 7: light pen detect (always 1 on PC-98 slave GDC).
 const STATUS_LIGHT_PEN: u8 = 0x80;
 
+/// SYNC P1 display mode bits 1 and 5: mixed display.
+pub const DISPLAY_MODE_MIXED: u8 = 0x00;
+
+/// SYNC P1 display mode bits 1 and 5: graphics display.
+pub const DISPLAY_MODE_GRAPHICS: u8 = 0x02;
+
+/// SYNC P1 display mode bits 1 and 5: character display.
+pub const DISPLAY_MODE_CHARACTER: u8 = 0x20;
+
+const DISPLAY_MODE_MASK: u8 = DISPLAY_MODE_GRAPHICS | DISPLAY_MODE_CHARACTER;
+
 /// Dot clock for 400-line mode (24.83 kHz horizontal): 21.0526 MHz.
 pub const DOT_CLOCK_400LINE: u32 = 21_052_600;
 
@@ -293,7 +304,7 @@ impl Gdc {
                 drawing_dm: 0,
                 drawing_gd: false,
                 bitmap_mod: 0,
-                display_mode: 0,
+                display_mode: DISPLAY_MODE_MIXED,
                 interlace_mode: 0,
                 draw_on_retrace: true,
                 aw: 80,
@@ -365,7 +376,7 @@ impl Gdc {
                 drawing_dm: 0,
                 drawing_gd: false,
                 bitmap_mod: 0,
-                display_mode: 0,
+                display_mode: DISPLAY_MODE_MIXED,
                 interlace_mode: 0,
                 draw_on_retrace: false,
                 aw: 0,
@@ -521,7 +532,11 @@ impl Gdc {
         }
 
         let total_chars = u64::from(self.hs + self.hbp + self.aw + self.hfp);
-        let horiz_mult: u64 = if self.display_mode == 0x02 { 16 } else { 8 };
+        let horiz_mult: u64 = if self.display_mode == DISPLAY_MODE_GRAPHICS {
+            16
+        } else {
+            8
+        };
         let cpu = u64::from(self.cpu_clock_hz);
         let dot = u64::from(self.dot_clock_hz);
         let line_period = cpu * total_chars * horiz_mult / dot;
@@ -625,7 +640,7 @@ impl Gdc {
 
     /// Returns effective pitch, halved if mixed mode with GD set.
     fn get_effective_pitch(&self) -> u16 {
-        if self.display_mode == 0 && self.drawing_gd {
+        if self.display_mode == DISPLAY_MODE_MIXED && self.drawing_gd {
             self.pitch >> 1
         } else {
             self.pitch
@@ -634,7 +649,7 @@ impl Gdc {
 
     /// Returns the pattern data for a given drawing cycle.
     fn get_pattern(&self, cycle: u16) -> u16 {
-        if self.display_mode == 0 && !self.drawing_gd {
+        if self.display_mode == DISPLAY_MODE_MIXED && !self.drawing_gd {
             // Text/mixed mode without GD: return full 16-bit pattern.
             self.pattern
         } else {
@@ -829,7 +844,11 @@ impl Gdc {
         // vsync_period = frame_time_s * cpu_clock
         let cpu = u64::from(self.cpu_clock_hz);
         let dot = u64::from(self.dot_clock_hz);
-        let horiz_mult: u64 = if self.display_mode == 0x02 { 16 } else { 8 };
+        let horiz_mult: u64 = if self.display_mode == DISPLAY_MODE_GRAPHICS {
+            16
+        } else {
+            8
+        };
         self.vsync_period = cpu * total_chars * total_lines * horiz_mult / dot;
 
         if total_lines == 0 || self.vsync_period == 0 {

--- a/crates/device/src/upd7220_gdc/commands.rs
+++ b/crates/device/src/upd7220_gdc/commands.rs
@@ -142,7 +142,7 @@ impl Gdc {
 
         // P1: mode byte.
         let mode = p[0];
-        self.display_mode = (mode & 0x02) | (mode & 0x20);
+        self.display_mode = mode & super::DISPLAY_MODE_MASK;
         self.interlace_mode = (mode & 0x01) | (mode & 0x08);
         self.draw_on_retrace = mode & 0x10 != 0;
 

--- a/crates/machine/src/bus.rs
+++ b/crates/machine/src/bus.rs
@@ -45,7 +45,7 @@ use device::{
     soundboard_86::{Soundboard86, Soundboard86Action},
     upd765a_fdc::FloppyController,
     upd4990a_rtc::Upd4990aRtc,
-    upd7220_gdc::Gdc,
+    upd7220_gdc::{DISPLAY_MODE_GRAPHICS, Gdc},
     upd52611_crtc::Upd52611Crtc,
 };
 use software_renderer::{
@@ -1386,6 +1386,8 @@ impl<T: Tracing> Pc9801Bus<T> {
             cursor_bottom,
             gdc_graphics_pitch,
             gdc_graphics_scroll,
+            gdc_graphics_display_mode_is_graphics: self.gdc_slave.state.display_mode
+                == DISPLAY_MODE_GRAPHICS,
             gdc_graphics_al,
             crt_31khz_enabled: self.display_control.is_crt_31khz_enabled(),
             palette_rgba,

--- a/crates/machine/src/bus/bios.rs
+++ b/crates/machine/src/bus/bios.rs
@@ -318,6 +318,7 @@ impl<T: Tracing> Pc9801Bus<T> {
 #[cfg(test)]
 mod tests {
     use common::{Bus, Cpu, CpuMode, CpuType, MachineModel, NoTracing, SegmentRegister};
+    use device::floppy::FloppyImage;
 
     use super::{
         PAGE_ACCESSED, PAGE_DIRTY, hle_page_translate_read, hle_page_translate_write,
@@ -550,6 +551,12 @@ mod tests {
         u16::from(bus.read_byte(address)) | (u16::from(bus.read_byte(address + 1)) << 8)
     }
 
+    fn test_hdm_floppy(first_sector_byte: u8) -> FloppyImage {
+        let mut data = vec![0u8; 1_261_568];
+        data[0] = first_sector_byte;
+        FloppyImage::from_hdm_bytes(&data).unwrap()
+    }
+
     #[test]
     fn hle_translate_read_sets_accessed_bits() {
         let mut memory = test_memory();
@@ -647,6 +654,29 @@ mod tests {
         assert_eq!(cpu.sp(), 0x0004);
         assert_eq!(read_bus_word(&mut bus, 0x0002_0000), 0xAAAA);
         assert_eq!(read_bus_word(&mut bus, 0x0002_0002), 0xBBBB);
+    }
+
+    #[test]
+    fn int1bh_fdd_read_uses_paged_protected_mode_buffer() {
+        let mut bus = test_bus();
+        setup_hle_page_tables(&mut bus);
+        bus.insert_floppy(0, test_hdm_floppy(0xA5), None);
+
+        let mut cpu = TestCpu::default();
+        cpu.set_ax(0x0690);
+        cpu.set_bx(0);
+        cpu.set_cx(0x0300);
+        cpu.set_dx(0x0001);
+        cpu.set_bp(0);
+        cpu.set_es(0x2222);
+        cpu.set_segment_base_for_test(SegmentRegister::ES, 0x0002_0000);
+
+        bus.hle_int1bh(&mut cpu);
+
+        assert_eq!(cpu.ah(), 0x00);
+        assert_eq!(bus.read_byte(0x0003_0000), 0xA5);
+        assert_eq!(bus.read_byte(0x0002_0000), 0x00);
+        assert_eq!(bus.read_byte(0x0002_2220), 0x00);
     }
 
     #[test]

--- a/crates/machine/src/bus/bios/disk.rs
+++ b/crates/machine/src/bus/bios/disk.rs
@@ -117,9 +117,9 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let r = cpu.dl();
                 let n_val = cpu.ch();
                 let sector_size = 128usize << n_val;
-                let buf_seg = cpu.es();
                 let buf_off = cpu.bp();
-                let buf_addr = (u32::from(buf_seg) << 4).wrapping_add(u32::from(buf_off));
+                let buf_addr =
+                    self.hle_linear_address(cpu, SegmentRegister::ES, u32::from(buf_off));
                 let transfer_bytes = cpu.bx() as usize;
                 let size = if transfer_bytes > 0 {
                     transfer_bytes
@@ -156,7 +156,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let mut h = h;
                 let mut hd = (h ^ (cpu.al() >> 2)) & 1;
                 // Segment wrap check.
-                if (buf_addr & 0xFFFF) > ((buf_addr + size as u32 - 1) & 0xFFFF) {
+                if Self::fdd_buffer_segment_wraps(buf_off, size) {
                     self.tracer.trace_int1bh_fdd_write(
                         drive,
                         c,
@@ -242,9 +242,9 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let r = cpu.dl();
                 let n_val = cpu.ch();
                 let sector_size = 128usize << n_val;
-                let buf_seg = cpu.es();
                 let buf_off = cpu.bp();
-                let buf_addr = (u32::from(buf_seg) << 4).wrapping_add(u32::from(buf_off));
+                let buf_addr =
+                    self.hle_linear_address(cpu, SegmentRegister::ES, u32::from(buf_off));
                 let transfer_bytes = cpu.bx() as usize;
                 let size = if transfer_bytes > 0 {
                     transfer_bytes
@@ -252,7 +252,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                     sector_size
                 };
                 // Segment wrap check.
-                if (buf_addr & 0xFFFF) > ((buf_addr + size as u32 - 1) & 0xFFFF) {
+                if Self::fdd_buffer_segment_wraps(buf_off, size) {
                     return if is_diagnostic { 0x00 } else { 0x20 };
                 }
                 if ah & 0x10 != 0 {
@@ -265,13 +265,14 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let mut offset = 0u32;
                 let mut current_r = r;
                 for _ in 0..sector_count {
-                    if let Some(data) =
-                        self.floppy
-                            .read_sector_data(drive, track_index, c, h, current_r, n_val)
+                    if let Some(data) = self
+                        .floppy
+                        .read_sector_data(drive, track_index, c, h, current_r, n_val)
+                        .map(<[u8]>::to_vec)
                     {
                         if !is_diagnostic {
                             for (j, &byte) in data.iter().enumerate() {
-                                self.memory.write_byte(buf_addr + offset + j as u32, byte);
+                                self.write_mem_byte(buf_addr + offset + j as u32, byte);
                             }
                         }
                         offset += data.len() as u32;
@@ -281,13 +282,14 @@ impl<T: Tracing> Pc9801Bus<T> {
                         h = 1;
                         track_index = (self.fdd_seek_cylinder[drive] as usize) * 2 + 1;
                         current_r = 1;
-                        if let Some(data) =
-                            self.floppy
-                                .read_sector_data(drive, track_index, c, h, current_r, n_val)
+                        if let Some(data) = self
+                            .floppy
+                            .read_sector_data(drive, track_index, c, h, current_r, n_val)
+                            .map(<[u8]>::to_vec)
                         {
                             if !is_diagnostic {
                                 for (j, &byte) in data.iter().enumerate() {
-                                    self.memory.write_byte(buf_addr + offset + j as u32, byte);
+                                    self.write_mem_byte(buf_addr + offset + j as u32, byte);
                                 }
                             }
                             offset += data.len() as u32;
@@ -379,9 +381,9 @@ impl<T: Tracing> Pc9801Bus<T> {
                 let hd = (h ^ (cpu.al() >> 2)) & 1;
                 let n_val = cpu.ch();
                 let fill_byte = cpu.dl();
-                let buf_seg = cpu.es();
                 let buf_off = cpu.bp();
-                let buf_addr = (u32::from(buf_seg) << 4).wrapping_add(u32::from(buf_off));
+                let buf_addr =
+                    self.hle_linear_address(cpu, SegmentRegister::ES, u32::from(buf_off));
                 let buf_size = cpu.bx() as usize;
                 let sector_count = buf_size / 4;
                 let track_index = (self.fdd_seek_cylinder[drive] as usize) * 2 + hd as usize;
@@ -405,6 +407,15 @@ impl<T: Tracing> Pc9801Bus<T> {
             }
             _ => 0x40,
         }
+    }
+
+    fn fdd_buffer_segment_wraps(buffer_offset: u16, size: usize) -> bool {
+        if size == 0 {
+            return false;
+        }
+        let start = u32::from(buffer_offset);
+        let end = start.wrapping_add(size as u32 - 1);
+        (start & 0xFFFF) > (end & 0xFFFF)
     }
 
     fn int1bh_hdd(&mut self, cpu: &mut impl Cpu, function: u8) {

--- a/crates/machine/src/bus/init.rs
+++ b/crates/machine/src/bus/init.rs
@@ -20,7 +20,7 @@ use device::{
     sdip::Sdip,
     upd765a_fdc::FloppyController,
     upd4990a_rtc::Upd4990aRtc,
-    upd7220_gdc::{Gdc, GdcScrollPartition},
+    upd7220_gdc::{DISPLAY_MODE_GRAPHICS, Gdc, GdcScrollPartition},
     upd52611_crtc::Upd52611Crtc,
 };
 use software_renderer::SoftwareRenderer;
@@ -747,7 +747,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         }
         match self.machine_model {
             MachineModel::PC9801F | MachineModel::PC9801VM => {
-                self.gdc_slave.state.display_mode = 2;
+                self.gdc_slave.state.display_mode = DISPLAY_MODE_GRAPHICS;
             }
             MachineModel::PC9801VX
             | MachineModel::PC9801RA

--- a/crates/machine/tests/bios/int18h.rs
+++ b/crates/machine/tests/bios/int18h.rs
@@ -1,4 +1,5 @@
 use common::{Bus, Cpu};
+use device::upd7220_gdc::DISPLAY_MODE_GRAPHICS;
 
 use super::{
     KB_COUNT, KB_HEAD, KB_TAIL, TEST_CODE, boot_inject_run_f, boot_inject_run_pc9821as,
@@ -4398,7 +4399,7 @@ fn draw_mode_set_sync_mode_byte_f() {
         state.gdc_slave.param_buffer[0], 0x02,
         "AH=4Ah CH=0x02 should write 0x02 as SYNC P1 mode byte"
     );
-    assert_eq!(state.gdc_slave.display_mode, 0x02);
+    assert_eq!(state.gdc_slave.display_mode, DISPLAY_MODE_GRAPHICS);
 }
 
 #[test]
@@ -4412,7 +4413,7 @@ fn draw_mode_set_sync_mode_byte_vm() {
         state.gdc_slave.param_buffer[0], 0x02,
         "AH=4Ah CH=0x02 should write 0x02 as SYNC P1 mode byte"
     );
-    assert_eq!(state.gdc_slave.display_mode, 0x02);
+    assert_eq!(state.gdc_slave.display_mode, DISPLAY_MODE_GRAPHICS);
 }
 
 #[test]
@@ -4421,7 +4422,7 @@ fn draw_mode_set_sync_mode_byte_vx() {
     let machine = boot_inject_run_vx(&[], &code, INT18H_BUDGET);
     let state = machine.save_state();
     assert_eq!(state.gdc_slave.param_buffer[0], 0x02);
-    assert_eq!(state.gdc_slave.display_mode, 0x02);
+    assert_eq!(state.gdc_slave.display_mode, DISPLAY_MODE_GRAPHICS);
 }
 
 #[test]
@@ -4430,7 +4431,7 @@ fn draw_mode_set_sync_mode_byte_ra() {
     let machine = boot_inject_run_ra(&[], &code, INT18H_BUDGET);
     let state = machine.save_state();
     assert_eq!(state.gdc_slave.param_buffer[0], 0x02);
-    assert_eq!(state.gdc_slave.display_mode, 0x02);
+    assert_eq!(state.gdc_slave.display_mode, DISPLAY_MODE_GRAPHICS);
 }
 
 #[test]

--- a/crates/machine/tests/bios/post_bios_state.rs
+++ b/crates/machine/tests/bios/post_bios_state.rs
@@ -1,3 +1,5 @@
+use device::upd7220_gdc::{DISPLAY_MODE_GRAPHICS, DISPLAY_MODE_MIXED};
+
 use super::read_ram_u16;
 
 macro_rules! check {
@@ -104,7 +106,7 @@ fn post_bios_state_vm() {
     check!(
         f,
         state.gdc_master.display_mode,
-        0,
+        DISPLAY_MODE_MIXED,
         "Master GDC display mode"
     );
     check!(
@@ -199,7 +201,12 @@ fn post_bios_state_vm() {
     check_true!(f, state.gdc_slave.is_slave, "Slave GDC is slave");
     check!(f, state.gdc_slave.pitch, 40, "Slave GDC pitch");
     check!(f, state.gdc_slave.mask, 0, "Slave GDC mask");
-    check!(f, state.gdc_slave.display_mode, 2, "Slave GDC display mode");
+    check!(
+        f,
+        state.gdc_slave.display_mode,
+        DISPLAY_MODE_GRAPHICS,
+        "Slave GDC display mode"
+    );
     check_true!(
         f,
         state.gdc_slave.draw_on_retrace,

--- a/crates/software_renderer/src/compose.rs
+++ b/crates/software_renderer/src/compose.rs
@@ -558,8 +558,12 @@ fn compose_pegc(
         0
     };
     let mut text_scroll_iter = ScrollLineIter::new(inputs.gdc_scroll_start_line);
-    let mut pegc_scanline_iter =
-        PegcScanlineBaseIter::new(inputs.gdc_graphics_scroll, graphics_pitch, page_base);
+    let mut pegc_scanline_iter = PegcScanlineBaseIter::new(
+        inputs.gdc_graphics_scroll,
+        graphics_pitch,
+        page_base,
+        inputs.gdc_graphics_display_mode_is_graphics,
+    );
 
     for y in 0..max_y {
         // Text overlay rules are shared with digital modes; only the graphics
@@ -765,29 +769,35 @@ impl GraphicsByteBaseIter {
     }
 }
 
-/// PEGC scanline address iterator. PEGC is byte-per-pixel, so the old shader
-/// formula `(start * 2 + scanline * pitch * 2) * 8 + x` is split into a
-/// per-scanline base here and an `+ x` in `load_pegc_indices`.
+/// PEGC scanline address iterator. PEGC is byte-per-pixel, so the GDC word
+/// address is expanded to pixels here and `load_pegc_indices` adds X.
 struct PegcScanlineBaseIter {
     scroll_iter: ScrollLineIter,
     pitch: u32,
     page_base: u32,
+    graphics_display_mode: bool,
 }
 
 impl PegcScanlineBaseIter {
-    fn new(scrolls: [u32; 4], pitch: u32, page_base: u32) -> Self {
+    fn new(scrolls: [u32; 4], pitch: u32, page_base: u32, graphics_display_mode: bool) -> Self {
         Self {
             scroll_iter: ScrollLineIter::new(scrolls),
             pitch,
             page_base,
+            graphics_display_mode,
         }
     }
 
     fn next(&mut self) -> u32 {
         let (start_address, scanline) = self.scroll_iter.next();
+        let line_pitch = if self.graphics_display_mode {
+            self.pitch
+        } else {
+            self.pitch.wrapping_mul(2)
+        };
         let inner = start_address
             .wrapping_mul(2)
-            .wrapping_add(scanline.wrapping_mul(self.pitch).wrapping_mul(2))
+            .wrapping_add(scanline.wrapping_mul(line_pitch))
             .wrapping_mul(8);
         self.page_base.wrapping_add(inner)
     }

--- a/crates/software_renderer/src/lib.rs
+++ b/crates/software_renderer/src/lib.rs
@@ -83,6 +83,8 @@ pub struct RenderInputs<'a> {
     pub gdc_graphics_pitch: u32,
     /// Four packed graphics scroll descriptors.
     pub gdc_graphics_scroll: [u32; 4],
+    /// Whether the graphics GDC SYNC P1 display mode is graphics.
+    pub gdc_graphics_display_mode_is_graphics: bool,
     /// Graphics GDC active display lines (AL from SYNC command).
     pub gdc_graphics_al: u32,
     /// CRT horizontal-scan-frequency flag (port 09A8h).

--- a/crates/software_renderer/tests/software_renderer.rs
+++ b/crates/software_renderer/tests/software_renderer.rs
@@ -33,6 +33,7 @@ fn base_inputs<'a>(
 
         gdc_graphics_pitch: 0,
         gdc_graphics_scroll: [0; 4],
+        gdc_graphics_display_mode_is_graphics: false,
         gdc_graphics_al: 0,
         crt_31khz_enabled: false,
 

--- a/src/image_selector.rs
+++ b/src/image_selector.rs
@@ -401,6 +401,7 @@ fn rebuild_render(
         cursor_bottom: 0,
         gdc_graphics_pitch: 0,
         gdc_graphics_scroll: [0; 4],
+        gdc_graphics_display_mode_is_graphics: false,
         gdc_graphics_al: 0,
         crt_31khz_enabled: false,
 

--- a/tests/copy.rs
+++ b/tests/copy.rs
@@ -640,6 +640,10 @@ fn invalid_image_source_path_does_not_truncate_for_image_to_image() {
     assert_eq!(std::fs::read(&dest_image).unwrap(), before);
 }
 
+// Windows strips trailing dots from file names at the OS level, so `FILE` and
+// `FILE.` cannot coexist in the host directory; the collision scenario can
+// only be constructed on case-sensitive Unix-like filesystems.
+#[cfg(unix)]
 #[test]
 fn host_name_collisions_are_rejected_before_writing() {
     let dir = unique_tempdir("collisions");


### PR DESCRIPTION
Currently the installation of Windows 3.1 is broken under DOS 6.2. But DOS 5.0A works without a problem. Standard NEC OEM Windows 3.1 works best, since it ships with the PEGC drivers needed for the 256-color mode.

Mouse pointer is still broken, which I will once I hunted down that bug.