### PR TITLE
fix: PEGC renders Windows 3.1 mostly correct now

### DIFF
--- a/crates/device/src/pegc.rs
+++ b/crates/device/src/pegc.rs
@@ -685,8 +685,7 @@ impl Pegc {
         let plane_mask = self.state.plane_access_mask;
         let palette1 = self.state.palette_color_1;
 
-        let decrement_shifted_vram_source =
-            !source_from_cpu && shift_direction_decrement && source_shift != 0;
+        let decrement_vram_source = !source_from_cpu && shift_direction_decrement;
         if self.state.remain == 0
             && self.state.skip_next_shifted_padding_write
             && !source_from_cpu
@@ -701,7 +700,7 @@ impl Pegc {
         let block_start = (self.state.remain == block_length + 1
             && !self.state.leading_shifted_padding_write_skipped)
             || (self.state.remain == 0 && !self.state.skip_next_shifted_padding_write);
-        let base_address = if decrement_shifted_vram_source {
+        let base_address = if decrement_vram_source {
             offset.wrapping_mul(8).wrapping_add(pixels - source_shift)
         } else {
             let base_address = offset.wrapping_mul(8).wrapping_add(source_shift);
@@ -780,12 +779,10 @@ impl Pegc {
         let block_length = u32::from(self.state.block_length);
         let source_shift = u32::from(self.state.shift_read);
         let dest_shift = u32::from(self.state.shift_write);
-        let decrement_shifted_vram_source =
-            !source_from_cpu && shift_direction_decrement && source_shift != 0;
+        let decrement_vram_source = !source_from_cpu && shift_direction_decrement;
         let increment_shifted_vram_source =
             !source_from_cpu && !shift_direction_decrement && source_shift != 0;
-        let same_shift_decrement_vram_source =
-            decrement_shifted_vram_source && source_shift == dest_shift;
+        let same_shift_decrement_vram_source = decrement_vram_source && source_shift == dest_shift;
 
         if self.state.remain == 0 {
             self.state.remain = block_length + 1;
@@ -849,14 +846,25 @@ impl Pegc {
         let extended_shift_mode = !source_from_cpu || ((block_length + 1) & (pixels - 1)) != 0;
 
         let block_start = self.state.remain == block_length + 1;
-        let source_byte_in_row = self.state.last_plane_read_offset & 0x7F;
-        let destination_byte_in_row = offset & 0x7F;
-        let same_scanline = (self.state.last_plane_read_offset & !0x7F) == (offset & !0x7F);
+        let asymmetric_edge_aligned_decrement_vram_source =
+            decrement_vram_source && source_shift < dest_shift;
+        let edge_aligned_decrement_shifted_vram_source =
+            same_shift_decrement_vram_source || asymmetric_edge_aligned_decrement_vram_source;
+        let increment_shifted_leading_padding =
+            source_shift > dest_shift && block_length + 1 > pixels - dest_shift;
+        if block_start
+            && source_from_cpu
+            && !shift_direction_decrement
+            && source_shift > dest_shift
+            && !self.state.leading_shifted_padding_write_skipped
+        {
+            self.append_cpu_source_buffer(value, pixels, source_shift);
+            self.state.leading_shifted_padding_write_skipped = true;
+            return;
+        }
         if block_start
             && increment_shifted_vram_source
-            && source_shift > dest_shift
-            && same_scanline
-            && source_byte_in_row > destination_byte_in_row
+            && increment_shifted_leading_padding
             && !self.state.leading_shifted_padding_write_skipped
         {
             self.state.leading_shifted_padding_write_skipped = true;
@@ -869,15 +877,15 @@ impl Pegc {
 
         if extended_shift_mode {
             if shift_direction_decrement {
-                if decrement_shifted_vram_source && dest_shift != 0 {
+                if decrement_vram_source {
                     if block_start {
-                        if same_shift_decrement_vram_source {
+                        if edge_aligned_decrement_shifted_vram_source {
                             base_address = base_address.wrapping_add(pixels - dest_shift);
                         } else {
                             base_address = base_address.wrapping_sub(dest_shift);
                         }
                         data_length -= dest_shift as i32;
-                    } else if same_shift_decrement_vram_source {
+                    } else if edge_aligned_decrement_shifted_vram_source {
                         base_address = base_address.wrapping_add(pixels);
                     }
                 } else {
@@ -901,7 +909,11 @@ impl Pegc {
         base_address &= PEGC_VRAM_SIZE as u32 - 1;
 
         if source_from_cpu {
-            let source_start = if block_start { source_shift } else { 0 };
+            let source_start = if block_start && !self.state.leading_shifted_padding_write_skipped {
+                source_shift
+            } else {
+                0
+            };
             self.append_cpu_source_buffer(value, pixels, source_start);
         }
 
@@ -957,47 +969,6 @@ impl Pegc {
         }
 
         if self.state.remain == 0
-            && !source_from_cpu
-            && !shift_direction_decrement
-            && source_shift != 0
-            && dest_shift != 0
-            && processed_pixels < data_length.max(0) as usize
-        {
-            for i in processed_pixels..data_length.max(0) as usize {
-                if i >= source_buffer_length {
-                    break;
-                }
-                let pixel_mask_bit = write_mask_position(i as u32);
-                if pixel_mask & pixel_mask_bit == 0 {
-                    continue;
-                }
-
-                let pixel_address =
-                    base_address.wrapping_add(i as u32) & (PEGC_VRAM_SIZE as u32 - 1);
-                let shifted_pixel_index = shifted_bit_offset + i as u32;
-                let source = self.state.last_vram_data[i];
-                let destination = vram[pixel_address as usize];
-
-                if rop_enabled {
-                    let (pattern1, pattern2) =
-                        self.get_pattern_colors(rop_method, shifted_pixel_index);
-                    let result = apply_rop(
-                        rop_code,
-                        source,
-                        destination,
-                        pattern1,
-                        pattern2,
-                        plane_mask,
-                    );
-                    vram[pixel_address as usize] = (destination & plane_mask) | result;
-                } else {
-                    vram[pixel_address as usize] =
-                        apply_source_copy(source, destination, plane_mask);
-                }
-            }
-        }
-
-        if self.state.remain == 0
             && !same_shift_decrement_vram_source
             && ((!extended_shift_mode && dest_shift != 0)
                 || (!source_from_cpu && source_shift != 0))
@@ -1016,15 +987,6 @@ impl Pegc {
             };
             self.state.shifted_padding_pixels = 0;
             if !source_from_cpu
-                && shift_direction_decrement
-                && source_shift != 0
-                && dest_shift != 0
-                && processed_pixels < pixels as usize
-            {
-                self.state.shifted_padding_base_address =
-                    base_address.wrapping_sub(processed_pixels as u32);
-                self.state.shifted_padding_pixels = pixels / 2;
-            } else if !source_from_cpu
                 && !shift_direction_decrement
                 && source_shift != 0
                 && dest_shift != 0
@@ -1042,13 +1004,16 @@ impl Pegc {
                 self.state.leading_shifted_padding_write_skipped = false;
             }
         } else {
-            let consume_pixels = if decrement_shifted_vram_source {
+            let consume_pixels = if decrement_vram_source {
                 processed_pixels
             } else {
                 pixels as usize
             };
             self.consume_source_buffer(consume_pixels);
-            if self.state.remain == 0 && same_shift_decrement_vram_source {
+            if self.state.remain == 0
+                && decrement_vram_source
+                && !self.state.skip_next_shifted_padding_write
+            {
                 self.state.last_vram_data.fill(0);
                 self.state.last_data_length = 0;
             }
@@ -1641,7 +1606,7 @@ mod tests {
     }
 
     #[test]
-    fn plane_mode_decrement_read_starts_before_word_boundary() {
+    fn plane_mode_decrement_vram_read_starts_after_word_boundary() {
         let mut pegc = Pegc::new();
         pegc.state.mode_register = 1;
         pegc.state.plane_access_mask = 0x00;
@@ -1650,11 +1615,11 @@ mod tests {
         pegc.state.remain = 4;
 
         let mut vram = vec![0u8; PEGC_VRAM_SIZE];
-        vram[15] = 0xA0;
-        vram[14] = 0xA1;
-        vram[13] = 0xA2;
-        vram[12] = 0xA3;
-        vram[16] = 0xEE;
+        vram[31] = 0xA0;
+        vram[30] = 0xA1;
+        vram[29] = 0xA2;
+        vram[28] = 0xA3;
+        vram[27] = 0xEE;
 
         pegc.plane_read_word(2, &vram);
 
@@ -1724,6 +1689,19 @@ mod tests {
         }
     }
 
+    fn increment_vram_source_copy(block_length: u16, shift_read: u8, shift_write: u8) -> Pegc {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x10F0;
+        pegc.state.write_mask = 0xFFFF;
+        pegc.state.block_length = block_length;
+        pegc.state.remain = u32::from(block_length) + 1;
+        pegc.state.shift_read = shift_read;
+        pegc.state.shift_write = shift_write;
+        pegc
+    }
+
     #[test]
     fn plane_mode_asymmetric_decrement_vram_source_keeps_tail_across_words() {
         let mut pegc = decrement_vram_source_copy(25, 4, 5);
@@ -1733,7 +1711,7 @@ mod tests {
         let destination_offset = 0x2000u32;
         let source_high_pixel = decrement_source_high_pixel(source_offset, pegc.state.shift_read);
         let destination_high_pixel =
-            decrement_destination_high_pixel(destination_offset, pegc.state.shift_write, false);
+            decrement_destination_high_pixel(destination_offset, pegc.state.shift_write, true);
 
         for index in 0..26u32 {
             vram[(source_high_pixel - index) as usize] = (index + 1) as u8;
@@ -1779,6 +1757,316 @@ mod tests {
                 original[source_start + i],
                 "right-edge copy pixel {i}"
             );
+        }
+    }
+
+    #[test]
+    fn plane_mode_asymmetric_decrement_vram_source_down_left_trace_uses_logical_edge() {
+        let mut pegc = decrement_vram_source_copy(425, 7, 12);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let plane_pitch_bytes = plane_pitch_pixels as u32 / 8;
+        let source_first_offset = 0xB0DC2u32 - 0xA8000;
+        let destination_first_offset = 0xB203Eu32 - 0xA8000;
+        let source_x = 111isize;
+        let source_y = 131isize;
+        let destination_x = 74isize;
+        let destination_y = 168isize;
+        let destination_delta_pixels = ((destination_y - source_y) * plane_pitch_pixels as isize
+            + (destination_x - source_x)) as usize;
+        let width = 426usize;
+        let height = 153usize;
+
+        for row_index in 0..height {
+            let source_offset = source_first_offset - row_index as u32 * plane_pitch_bytes;
+            let source_high_pixel =
+                decrement_source_high_pixel(source_offset, pegc.state.shift_read) as usize;
+            for pixel_index in 0..width {
+                vram[source_high_pixel - pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(37)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(5);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in 0..height {
+            let mut source_offset = source_first_offset - row_index as u32 * plane_pitch_bytes;
+            let mut destination_offset =
+                destination_first_offset - row_index as u32 * plane_pitch_bytes;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset = source_offset.wrapping_sub(2);
+                destination_offset = destination_offset.wrapping_sub(2);
+            }
+        }
+
+        for row_index in 0..height {
+            let source_offset = source_first_offset - row_index as u32 * plane_pitch_bytes;
+            let source_high_pixel =
+                decrement_source_high_pixel(source_offset, pegc.state.shift_read) as usize;
+            let destination_high_pixel = source_high_pixel + destination_delta_pixels;
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_high_pixel - pixel_index],
+                    original[source_high_pixel - pixel_index],
+                    "down-left trace row {row_index} pixel {pixel_index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plane_mode_asymmetric_decrement_vram_source_down_right_trace_uses_logical_edge() {
+        let mut pegc = decrement_vram_source_copy(425, 2, 13);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let plane_pitch_bytes = plane_pitch_pixels as u32 / 8;
+        let source_first_offset = 0xAF5C2u32 - 0xA8000;
+        let destination_first_offset = 0xB0848u32 - 0xA8000;
+        let source_x = 116isize;
+        let source_y = 83isize;
+        let destination_x = 153isize;
+        let destination_y = 120isize;
+        let destination_delta_pixels = ((destination_y - source_y) * plane_pitch_pixels as isize
+            + (destination_x - source_x)) as usize;
+        let width = 426usize;
+        let height = 153usize;
+
+        for row_index in 0..height {
+            let source_offset = source_first_offset - row_index as u32 * plane_pitch_bytes;
+            let source_high_pixel =
+                decrement_source_high_pixel(source_offset, pegc.state.shift_read) as usize;
+            for pixel_index in 0..width {
+                vram[source_high_pixel - pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(31)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(17);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in 0..height {
+            let mut source_offset = source_first_offset - row_index as u32 * plane_pitch_bytes;
+            let mut destination_offset =
+                destination_first_offset - row_index as u32 * plane_pitch_bytes;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset = source_offset.wrapping_sub(2);
+                destination_offset = destination_offset.wrapping_sub(2);
+            }
+        }
+
+        for row_index in 0..height {
+            let source_offset = source_first_offset - row_index as u32 * plane_pitch_bytes;
+            let source_high_pixel =
+                decrement_source_high_pixel(source_offset, pegc.state.shift_read) as usize;
+            let destination_high_pixel = source_high_pixel + destination_delta_pixels;
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_high_pixel - pixel_index],
+                    original[source_high_pixel - pixel_index],
+                    "down-right trace row {row_index} pixel {pixel_index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plane_mode_decrement_vram_source_down_left_trace_skips_padding_before_destination() {
+        let mut pegc = decrement_vram_source_copy(425, 13, 2);
+
+        let mut vram = vec![0xF6u8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let plane_pitch_bytes = plane_pitch_pixels as u32 / 8;
+        let source_first_offset = 0xB0848u32 - 0xA8000;
+        let destination_first_offset = 0xB1AC4u32 - 0xA8000;
+        let row_index = 30usize;
+        let width = 426usize;
+
+        let source_offset = source_first_offset - row_index as u32 * plane_pitch_bytes;
+        let destination_offset = destination_first_offset - row_index as u32 * plane_pitch_bytes;
+        let source_high_pixel =
+            decrement_source_high_pixel(source_offset, pegc.state.shift_read) as usize;
+        let destination_high_pixel =
+            decrement_destination_high_pixel(destination_offset, pegc.state.shift_write, false)
+                as usize;
+        let destination_left_pixel = destination_high_pixel + 1 - width;
+
+        assert_eq!(source_high_pixel % plane_pitch_pixels, 578);
+        assert_eq!(destination_high_pixel % plane_pitch_pixels, 541);
+        assert_eq!(destination_left_pixel % plane_pitch_pixels, 116);
+
+        for pixel_index in 0..width {
+            vram[source_high_pixel - pixel_index] = (pixel_index as u8)
+                .wrapping_mul(19)
+                .wrapping_add(row_index as u8)
+                .wrapping_add(7);
+        }
+        for pixel_index in width..(width + 16) {
+            vram[source_high_pixel - pixel_index] = 0x00;
+        }
+        let original = vram.clone();
+
+        let mut source_word_offset = source_offset;
+        let mut destination_word_offset = destination_offset;
+        loop {
+            pegc.plane_read_word(source_word_offset, &vram);
+            pegc.plane_write_word(destination_word_offset, 0, &mut vram);
+            source_word_offset = source_word_offset.wrapping_sub(2);
+            destination_word_offset = destination_word_offset.wrapping_sub(2);
+            if pegc.state.remain == 0 {
+                break;
+            }
+        }
+
+        pegc.plane_read_word(source_word_offset, &vram);
+        pegc.plane_write_word(destination_word_offset, 0, &mut vram);
+
+        for pixel_index in 0..width {
+            assert_eq!(
+                vram[destination_high_pixel - pixel_index],
+                original[source_high_pixel - pixel_index],
+                "down-left padding trace logical pixel {pixel_index}"
+            );
+        }
+        for x in (destination_left_pixel - 10)..destination_left_pixel {
+            assert_eq!(
+                vram[x], original[x],
+                "down-left padding trace wrote before logical destination x={x}"
+            );
+        }
+    }
+
+    #[test]
+    fn plane_mode_asymmetric_decrement_vram_source_micro_down_left_trace_copies_window() {
+        let mut pegc = decrement_vram_source_copy(425, 1, 2);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let source_start = 117usize;
+        let destination_start = 116usize;
+        let width = 426usize;
+        let height = 153usize;
+        let source_right_edge = source_start + width - 1;
+        let destination_right_edge = destination_start + width - 1;
+        let source_first_word_x = source_right_edge + 1 - (16 - pegc.state.shift_read as usize);
+        let destination_first_word_x =
+            destination_right_edge + 1 - (16 - pegc.state.shift_write as usize);
+
+        for row_index in 0..height {
+            let source_row = 117usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            for pixel_index in 0..width {
+                vram[source_base + pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(61)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(13);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in (0..height).rev() {
+            let source_row = 117usize + row_index;
+            let destination_row = 118usize + row_index;
+            let mut source_offset =
+                ((source_row * plane_pitch_pixels + source_first_word_x) / 8) as u32;
+            let mut destination_offset =
+                ((destination_row * plane_pitch_pixels + destination_first_word_x) / 8) as u32;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset = source_offset.wrapping_sub(2);
+                destination_offset = destination_offset.wrapping_sub(2);
+            }
+        }
+
+        for row_index in 0..height {
+            let source_row = 117usize + row_index;
+            let destination_row = 118usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            let destination_base = destination_row * plane_pitch_pixels + destination_start;
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_base + pixel_index],
+                    original[source_base + pixel_index],
+                    "micro down-left row {row_index} pixel {pixel_index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plane_mode_zero_source_shift_decrement_vram_source_down_right_trace_uses_logical_edge() {
+        let mut pegc = decrement_vram_source_copy(425, 0, 4);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let plane_pitch_bytes = plane_pitch_pixels as u32 / 8;
+        let source_first_offset = 0xAF544u32 - 0xA8000;
+        let destination_first_offset = 0xB0846u32 - 0xA8000;
+        let source_x = 134isize;
+        let source_y = 82isize;
+        let destination_x = 146isize;
+        let destination_y = 120isize;
+        let destination_delta_pixels = ((destination_y - source_y) * plane_pitch_pixels as isize
+            + (destination_x - source_x)) as usize;
+        let width = 426usize;
+        let height = 153usize;
+
+        for row_index in 0..height {
+            let source_offset = source_first_offset - row_index as u32 * plane_pitch_bytes;
+            let source_high_pixel =
+                decrement_source_high_pixel(source_offset, pegc.state.shift_read) as usize;
+            for pixel_index in 0..width {
+                vram[source_high_pixel - pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(47)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(23);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in 0..height {
+            let mut source_offset = source_first_offset - row_index as u32 * plane_pitch_bytes;
+            let mut destination_offset =
+                destination_first_offset - row_index as u32 * plane_pitch_bytes;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset = source_offset.wrapping_sub(2);
+                destination_offset = destination_offset.wrapping_sub(2);
+            }
+        }
+
+        for row_index in 0..height {
+            let source_offset = source_first_offset - row_index as u32 * plane_pitch_bytes;
+            let source_high_pixel =
+                decrement_source_high_pixel(source_offset, pegc.state.shift_read) as usize;
+            let destination_high_pixel = source_high_pixel + destination_delta_pixels;
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_high_pixel - pixel_index],
+                    original[source_high_pixel - pixel_index],
+                    "zero-source-shift down-right trace row {row_index} pixel {pixel_index}"
+                );
+            }
         }
     }
 
@@ -1834,6 +2122,499 @@ mod tests {
                     vram[destination_base + pixel_index],
                     original[source_base + pixel_index],
                     "same-shift decrement row {row_index} pixel {pixel_index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plane_mode_unshifted_decrement_vram_source_down_trace_copies_right_edge() {
+        let mut pegc = decrement_vram_source_copy(425, 0, 0);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let width = 426usize;
+        let source_first_offset = 0xAF5C8u32 - 0xA8000;
+        let destination_first_offset = 0xB0EC8u32 - 0xA8000;
+        let source_high_pixel = source_first_offset as usize * 8 + 15;
+        let destination_high_pixel = destination_first_offset as usize * 8 + 15;
+
+        for pixel_index in 0..width {
+            vram[source_high_pixel - pixel_index] =
+                (pixel_index as u8).wrapping_mul(29).wrapping_add(11);
+        }
+        let original = vram.clone();
+
+        run_decrement_word_copy(
+            &mut pegc,
+            source_first_offset,
+            destination_first_offset,
+            &mut vram,
+        );
+
+        for pixel_index in 0..width {
+            assert_eq!(
+                vram[destination_high_pixel - pixel_index],
+                original[source_high_pixel - pixel_index],
+                "unshifted down trace pixel {pixel_index}"
+            );
+        }
+    }
+
+    #[test]
+    fn plane_mode_increment_shifted_vram_source_up_left_trace_skips_leading_padding() {
+        let mut pegc = increment_vram_source_copy(425, 10, 5);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let source_start = 74usize;
+        let destination_start = 37usize;
+        let width = 426usize;
+        let height = 153usize;
+        let first_source_word_x = source_start - pegc.state.shift_read as usize;
+        let first_destination_word_x = destination_start - pegc.state.shift_write as usize - 16;
+
+        for row_index in 0..height {
+            let source_row = 168usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            for pixel_index in 0..width {
+                vram[source_base + pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(41)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(9);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in 0..height {
+            let source_row = 168usize + row_index;
+            let destination_row = 131usize + row_index;
+            let mut source_offset =
+                ((source_row * plane_pitch_pixels + first_source_word_x) / 8) as u32;
+            let mut destination_offset =
+                ((destination_row * plane_pitch_pixels + first_destination_word_x) / 8) as u32;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset += 2;
+                destination_offset += 2;
+            }
+        }
+
+        for row_index in 0..height {
+            let source_row = 168usize + row_index;
+            let destination_row = 131usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            let destination_base = destination_row * plane_pitch_pixels + destination_start;
+            for pixel_index in first_destination_word_x..destination_start {
+                assert_eq!(
+                    vram[destination_row * plane_pitch_pixels + pixel_index],
+                    original[destination_row * plane_pitch_pixels + pixel_index],
+                    "up-left trace row {row_index} touched pixel {pixel_index} before destination"
+                );
+            }
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_base + pixel_index],
+                    original[source_base + pixel_index],
+                    "up-left trace row {row_index} pixel {pixel_index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plane_mode_increment_shifted_vram_source_up_right_trace_skips_leading_padding() {
+        let mut pegc = increment_vram_source_copy(425, 15, 4);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let plane_pitch_bytes = plane_pitch_pixels as u32 / 8;
+        let source_first_offset = 0xABC08u32 - 0xA8000;
+        let destination_first_offset = 0xAA98Cu32 - 0xA8000;
+        let source_x = 79isize;
+        let source_y = 120isize;
+        let destination_x = 116isize;
+        let destination_y = 83isize;
+        let destination_delta_pixels =
+            (destination_y - source_y) * plane_pitch_pixels as isize + destination_x - source_x;
+        let width = 426usize;
+        let height = 153usize;
+        let first_destination_word_x = 96usize;
+
+        for row_index in 0..height {
+            let source_offset = source_first_offset + row_index as u32 * plane_pitch_bytes;
+            let source_left_pixel = source_offset as usize * 8 + pegc.state.shift_read as usize;
+            for pixel_index in 0..width {
+                vram[source_left_pixel + pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(43)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(21);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in 0..height {
+            let mut source_offset = source_first_offset + row_index as u32 * plane_pitch_bytes;
+            let mut destination_offset =
+                destination_first_offset + row_index as u32 * plane_pitch_bytes;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset += 2;
+                destination_offset += 2;
+            }
+        }
+
+        for row_index in 0..height {
+            let source_offset = source_first_offset + row_index as u32 * plane_pitch_bytes;
+            let source_left_pixel = source_offset as usize * 8 + pegc.state.shift_read as usize;
+            let destination_left_pixel =
+                (source_left_pixel as isize + destination_delta_pixels) as usize;
+            let destination_row = destination_y as usize + row_index;
+            for pixel_index in first_destination_word_x..destination_x as usize {
+                assert_eq!(
+                    vram[destination_row * plane_pitch_pixels + pixel_index],
+                    original[destination_row * plane_pitch_pixels + pixel_index],
+                    "up-right trace row {row_index} touched pixel {pixel_index} before destination"
+                );
+            }
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_left_pixel + pixel_index],
+                    original[source_left_pixel + pixel_index],
+                    "up-right trace row {row_index} pixel {pixel_index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plane_mode_increment_shifted_vram_source_same_word_up_right_trace_skips_leading_padding() {
+        let mut pegc = increment_vram_source_copy(425, 12, 6);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let plane_pitch_bytes = plane_pitch_pixels as u32 / 8;
+        let source_first_offset = 0xAC78Au32 - 0xA8000;
+        let destination_first_offset = 0xAA80Au32 - 0xA8000;
+        let source_x = 92isize;
+        let source_y = 143isize;
+        let destination_x = 102isize;
+        let destination_y = 80isize;
+        let destination_delta_pixels =
+            (destination_y - source_y) * plane_pitch_pixels as isize + destination_x - source_x;
+        let width = 426usize;
+        let height = 153usize;
+        let first_destination_word_x = 80usize;
+
+        for row_index in 0..height {
+            let source_offset = source_first_offset + row_index as u32 * plane_pitch_bytes;
+            let source_left_pixel = source_offset as usize * 8 + pegc.state.shift_read as usize;
+            for pixel_index in 0..width {
+                vram[source_left_pixel + pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(37)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(19);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in 0..height {
+            let mut source_offset = source_first_offset + row_index as u32 * plane_pitch_bytes;
+            let mut destination_offset =
+                destination_first_offset + row_index as u32 * plane_pitch_bytes;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset += 2;
+                destination_offset += 2;
+            }
+        }
+
+        for row_index in 0..height {
+            let source_offset = source_first_offset + row_index as u32 * plane_pitch_bytes;
+            let source_left_pixel = source_offset as usize * 8 + pegc.state.shift_read as usize;
+            let destination_left_pixel =
+                (source_left_pixel as isize + destination_delta_pixels) as usize;
+            let destination_row = destination_y as usize + row_index;
+            for pixel_index in first_destination_word_x..destination_x as usize {
+                assert_eq!(
+                    vram[destination_row * plane_pitch_pixels + pixel_index],
+                    original[destination_row * plane_pitch_pixels + pixel_index],
+                    "same-word up-right trace row {row_index} touched pixel {pixel_index} before destination"
+                );
+            }
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_left_pixel + pixel_index],
+                    original[source_left_pixel + pixel_index],
+                    "same-word up-right trace row {row_index} pixel {pixel_index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plane_mode_increment_shifted_vram_source_micro_up_left_trace_skips_leading_padding() {
+        let mut pegc = increment_vram_source_copy(425, 3, 0);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let plane_pitch_bytes = plane_pitch_pixels as u32 / 8;
+        let source_first_offset = 0xABC8Cu32 - 0xA8000;
+        let destination_first_offset = 0xABA0Au32 - 0xA8000;
+        let source_x = 99isize;
+        let source_y = 121isize;
+        let destination_x = 96isize;
+        let destination_y = 116isize;
+        let destination_delta_pixels =
+            (destination_y - source_y) * plane_pitch_pixels as isize + destination_x - source_x;
+        let width = 426usize;
+        let height = 153usize;
+        let first_destination_word_x = 80usize;
+
+        for row_index in 0..height {
+            let source_offset = source_first_offset + row_index as u32 * plane_pitch_bytes;
+            let source_left_pixel = source_offset as usize * 8 + pegc.state.shift_read as usize;
+            for pixel_index in 0..width {
+                vram[source_left_pixel + pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(59)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(31);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in 0..height {
+            let mut source_offset = source_first_offset + row_index as u32 * plane_pitch_bytes;
+            let mut destination_offset =
+                destination_first_offset + row_index as u32 * plane_pitch_bytes;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset += 2;
+                destination_offset += 2;
+            }
+        }
+
+        for row_index in 0..height {
+            let source_offset = source_first_offset + row_index as u32 * plane_pitch_bytes;
+            let source_left_pixel = source_offset as usize * 8 + pegc.state.shift_read as usize;
+            let destination_left_pixel =
+                (source_left_pixel as isize + destination_delta_pixels) as usize;
+            let destination_row = destination_y as usize + row_index;
+            for pixel_index in first_destination_word_x..destination_x as usize {
+                assert_eq!(
+                    vram[destination_row * plane_pitch_pixels + pixel_index],
+                    original[destination_row * plane_pitch_pixels + pixel_index],
+                    "micro up-left trace row {row_index} touched pixel {pixel_index} before destination"
+                );
+            }
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_left_pixel + pixel_index],
+                    original[source_left_pixel + pixel_index],
+                    "micro up-left trace row {row_index} pixel {pixel_index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plane_mode_increment_shifted_vram_source_zero_write_shift_skips_leading_padding() {
+        let mut pegc = increment_vram_source_copy(425, 13, 0);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let source_start = 29usize;
+        let destination_start = 32usize;
+        let width = 426usize;
+        let height = 153usize;
+        let first_source_word_x = source_start - pegc.state.shift_read as usize;
+        let first_destination_word_x = destination_start - 16;
+
+        for row_index in 0..height {
+            let source_row = 189usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            for pixel_index in 0..width {
+                vram[source_base + pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(71)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(43);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in 0..height {
+            let source_row = 189usize + row_index;
+            let destination_row = 151usize + row_index;
+            let mut source_offset =
+                ((source_row * plane_pitch_pixels + first_source_word_x) / 8) as u32;
+            let mut destination_offset =
+                ((destination_row * plane_pitch_pixels + first_destination_word_x) / 8) as u32;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset += 2;
+                destination_offset += 2;
+            }
+        }
+
+        for row_index in 0..height {
+            let source_row = 189usize + row_index;
+            let destination_row = 151usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            let destination_base = destination_row * plane_pitch_pixels + destination_start;
+            for pixel_index in first_destination_word_x..destination_start {
+                assert_eq!(
+                    vram[destination_row * plane_pitch_pixels + pixel_index],
+                    original[destination_row * plane_pitch_pixels + pixel_index],
+                    "zero-dest-shift up-right trace row {row_index} touched pixel {pixel_index} before destination"
+                );
+            }
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_base + pixel_index],
+                    original[source_base + pixel_index],
+                    "zero-dest-shift up-right trace row {row_index} pixel {pixel_index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plane_mode_increment_shifted_vram_source_up_left_trace_keeps_right_padding() {
+        let mut pegc = increment_vram_source_copy(425, 4, 13);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let source_start = 212usize;
+        let destination_start = 61usize;
+        let width = 426usize;
+        let height = 153usize;
+        let first_source_word_x = source_start - pegc.state.shift_read as usize;
+        let first_destination_word_x = destination_start - pegc.state.shift_write as usize;
+
+        for row_index in 0..height {
+            let source_row = 161usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            for pixel_index in 0..(width + 16) {
+                vram[source_base + pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(67)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(37);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in 0..height {
+            let source_row = 161usize + row_index;
+            let destination_row = 56usize + row_index;
+            let mut source_offset =
+                ((source_row * plane_pitch_pixels + first_source_word_x) / 8) as u32;
+            let mut destination_offset =
+                ((destination_row * plane_pitch_pixels + first_destination_word_x) / 8) as u32;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset += 2;
+                destination_offset += 2;
+            }
+        }
+
+        for row_index in 0..height {
+            let source_row = 161usize + row_index;
+            let destination_row = 56usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            let destination_base = destination_row * plane_pitch_pixels + destination_start;
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_base + pixel_index],
+                    original[source_base + pixel_index],
+                    "up-left right-padding trace row {row_index} pixel {pixel_index}"
+                );
+            }
+            for pixel_index in width..(width + 16) {
+                assert_eq!(
+                    vram[destination_base + pixel_index],
+                    original[destination_base + pixel_index],
+                    "up-left right-padding trace row {row_index} touched pixel {pixel_index} after destination"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plane_mode_increment_same_shift_vram_source_micro_up_trace_copies_window() {
+        let mut pegc = increment_vram_source_copy(425, 4, 4);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let source_start = 116usize;
+        let destination_start = 116usize;
+        let width = 426usize;
+        let height = 153usize;
+        let first_source_word_x = source_start - pegc.state.shift_read as usize;
+        let first_destination_word_x = destination_start - pegc.state.shift_write as usize;
+
+        for row_index in 0..height {
+            let source_row = 117usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            for pixel_index in 0..width {
+                vram[source_base + pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(53)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(29);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in 0..height {
+            let source_row = 117usize + row_index;
+            let destination_row = 116usize + row_index;
+            let mut source_offset =
+                ((source_row * plane_pitch_pixels + first_source_word_x) / 8) as u32;
+            let mut destination_offset =
+                ((destination_row * plane_pitch_pixels + first_destination_word_x) / 8) as u32;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset += 2;
+                destination_offset += 2;
+            }
+        }
+
+        for row_index in 0..height {
+            let source_row = 117usize + row_index;
+            let destination_row = 116usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            let destination_base = destination_row * plane_pitch_pixels + destination_start;
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_base + pixel_index],
+                    original[source_base + pixel_index],
+                    "same-shift micro up row {row_index} pixel {pixel_index}"
                 );
             }
         }
@@ -2100,11 +2881,18 @@ mod tests {
         pegc.plane_read_word(source_offset + 6, &vram);
         pegc.plane_write_word(destination_offset + 6, 0, &mut vram);
 
-        for i in 12..48u32 {
+        for i in 12..39u32 {
             assert_eq!(
                 vram[(destination_pixel_base + i) as usize],
                 0xA0,
-                "logical and flushed pixel {i}"
+                "logical pixel {i}"
+            );
+        }
+        for i in 39..48u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + i) as usize],
+                0x00,
+                "unwritten tail pixel {i}"
             );
         }
         for i in 48..64u32 {
@@ -2172,6 +2960,52 @@ mod tests {
         assert_eq!(vram[(destination_pixel_base + 17) as usize], 0x77);
         assert_eq!(pegc.state.remain, 0);
         assert_eq!(pegc.state.last_data_length, 0);
+    }
+
+    #[test]
+    fn plane_mode_shifted_cpu_source_width_23_skips_leading_padding_word_trace() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x0100;
+        pegc.state.write_mask = 0xFFFF;
+        pegc.state.block_length = 22;
+        pegc.state.remain = 23;
+        pegc.state.shift_read = 9;
+        pegc.state.shift_write = 5;
+
+        let mut vram = vec![0x77u8; PEGC_VRAM_SIZE];
+        let destination_offset = 0x2000u32;
+        let destination_pixel_base = destination_offset * 8;
+
+        pegc.plane_write_word(destination_offset, 0xFFFF, &mut vram);
+        pegc.plane_write_word(destination_offset + 2, 0xFFFF, &mut vram);
+        pegc.plane_write_word(destination_offset + 4, 0x0000, &mut vram);
+
+        for pixel in 0..21u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + pixel) as usize],
+                0x77,
+                "pixel {pixel} before the logical destination"
+            );
+        }
+        for pixel in 21..44u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + pixel) as usize],
+                0xFF,
+                "logical pixel {pixel}"
+            );
+        }
+        for pixel in 44..53u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + pixel) as usize],
+                0x77,
+                "padding pixel {pixel}"
+            );
+        }
+        assert_eq!(pegc.state.remain, 0);
+        assert_eq!(pegc.state.last_data_length, 0);
+        assert!(!pegc.state.skip_next_shifted_padding_write);
     }
 
     #[test]

--- a/crates/device/src/pegc.rs
+++ b/crates/device/src/pegc.rs
@@ -693,8 +693,14 @@ impl Pegc {
     /// Writes a dword to PEGC VRAM in plane mode with ROP operations.
     ///
     /// Same semantics as `plane_write_word` but processes 32 pixels per call.
-    /// Shift register bit 4 is valid and the write mask covers all 32 pixels.
+    /// Shift register bit 4 is valid and the write mask is applied to each word.
     pub fn plane_write_dword(&mut self, offset: u32, value: u32, vram: &mut [u8]) {
+        if self.state.block_length < 16 {
+            self.plane_write_impl(offset, value & 0xFFFF, vram, 16);
+            self.plane_write_impl(offset + 2, value >> 16, vram, 16);
+            return;
+        }
+
         self.plane_write_impl(offset, value, vram, 32);
     }
 
@@ -712,7 +718,9 @@ impl Pegc {
 
         if self.state.remain == 0 {
             self.state.remain = block_length + 1;
-            self.state.last_data_length = 0;
+            if source_from_cpu {
+                self.state.last_data_length = 0;
+            }
             if self.state.skip_next_shifted_cpu_write {
                 self.state.skip_next_shifted_cpu_write = false;
                 return;
@@ -745,15 +753,12 @@ impl Pegc {
             } else {
                 base_address.wrapping_add(i as u32) & (PEGC_VRAM_SIZE as u32 - 1)
             };
-            let pixel_mask_bit = pixel_mask_position(i as u32);
+            let source_bit = source_bit_position(i as u32);
+            let pixel_mask_bit = write_mask_position(i as u32);
 
             if pixel_mask & pixel_mask_bit != 0 {
                 let source = if source_from_cpu {
-                    if value & pixel_mask_bit != 0 {
-                        0xFF
-                    } else {
-                        0x00
-                    }
+                    if value & source_bit != 0 { 0xFF } else { 0x00 }
                 } else if (i as usize) < source_buffer_length {
                     self.state.last_vram_data[i as usize]
                 } else {
@@ -824,14 +829,21 @@ impl Pegc {
     }
 }
 
-/// Computes the pixel mask bit position for a given pixel index within a 16-pixel group.
+/// Computes the CPU source bit position for a given pixel index.
 ///
-/// The bit layout maps pixel index to bit position within the 32-bit mask:
-/// pixels 0-7 map to bits 7-0 (reversed), pixels 8-15 map to bits 15-8 (reversed).
-fn pixel_mask_position(pixel_index: u32) -> u32 {
+/// The bit layout maps pixels 0-7 to bits 7-0, pixels 8-15 to bits 15-8,
+/// and repeats that byte order across bits 16-31 for dword CPU writes.
+fn source_bit_position(pixel_index: u32) -> u32 {
     let byte_group = (pixel_index / 8) * 8;
     let bit_within_byte = 7 - (pixel_index & 7);
     1 << (byte_group + bit_within_byte)
+}
+
+/// Computes the write-mask bit for a pixel index.
+///
+/// PEGC applies the 16-pixel write mask to each word lane of a dword write.
+fn write_mask_position(pixel_index: u32) -> u32 {
+    source_bit_position(pixel_index & 0x0F)
 }
 
 /// Applies the 8-bit ROP truth table to source, destination, and pattern values.
@@ -1436,7 +1448,7 @@ mod tests {
         pegc.plane_write_word(0, 0xFF00, &mut vram);
 
         for i in 0..8 {
-            let expected_source: u8 = if 0xFF00u16 & pixel_mask_position(i) as u16 != 0 {
+            let expected_source: u8 = if 0xFF00u16 & source_bit_position(i) as u16 != 0 {
                 0xFF
             } else {
                 0x00
@@ -1549,17 +1561,29 @@ mod tests {
     }
 
     #[test]
-    fn pixel_mask_position_layout() {
-        assert_eq!(pixel_mask_position(0), 0x80);
-        assert_eq!(pixel_mask_position(1), 0x40);
-        assert_eq!(pixel_mask_position(7), 0x01);
-        assert_eq!(pixel_mask_position(8), 0x8000);
-        assert_eq!(pixel_mask_position(15), 0x0100);
-        // The same formula maps pixels 16..31 to bits 16..31 of the mask.
-        assert_eq!(pixel_mask_position(16), 0x0080_0000);
-        assert_eq!(pixel_mask_position(23), 0x0001_0000);
-        assert_eq!(pixel_mask_position(24), 0x8000_0000);
-        assert_eq!(pixel_mask_position(31), 0x0100_0000);
+    fn source_bit_position_layout() {
+        assert_eq!(source_bit_position(0), 0x80);
+        assert_eq!(source_bit_position(1), 0x40);
+        assert_eq!(source_bit_position(7), 0x01);
+        assert_eq!(source_bit_position(8), 0x8000);
+        assert_eq!(source_bit_position(15), 0x0100);
+        assert_eq!(source_bit_position(16), 0x0080_0000);
+        assert_eq!(source_bit_position(23), 0x0001_0000);
+        assert_eq!(source_bit_position(24), 0x8000_0000);
+        assert_eq!(source_bit_position(31), 0x0100_0000);
+    }
+
+    #[test]
+    fn write_mask_position_repeats_for_dword_lanes() {
+        assert_eq!(write_mask_position(0), 0x80);
+        assert_eq!(write_mask_position(1), 0x40);
+        assert_eq!(write_mask_position(7), 0x01);
+        assert_eq!(write_mask_position(8), 0x8000);
+        assert_eq!(write_mask_position(15), 0x0100);
+        assert_eq!(write_mask_position(16), 0x80);
+        assert_eq!(write_mask_position(23), 0x01);
+        assert_eq!(write_mask_position(24), 0x8000);
+        assert_eq!(write_mask_position(31), 0x0100);
     }
 
     #[test]
@@ -1581,6 +1605,84 @@ mod tests {
         for (i, byte) in vram.iter().enumerate().take(32) {
             let expected = if i % 2 == 0 { 0xFF } else { 0x00 };
             assert_eq!(*byte, expected, "pixel {i}: expected {expected:#04X}");
+        }
+    }
+
+    #[test]
+    fn plane_dword_write_mask_repeats_for_second_word() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x0100; // source = CPU data
+        pegc.state.write_mask = 0x0000_FFFF;
+        pegc.state.block_length = 0x0FFF;
+
+        let mut vram = vec![0u8; PEGC_VRAM_SIZE];
+        pegc.plane_write_dword(0, 0xFFFF_FFFF, &mut vram);
+
+        for (i, byte) in vram.iter().enumerate().take(32) {
+            assert_eq!(*byte, 0xFF, "pixel {i} should be written");
+        }
+    }
+
+    #[test]
+    fn plane_dword_cpu_source_uses_upper_value_bits() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x0100; // source = CPU data
+        pegc.state.write_mask = 0x0000_FFFF;
+        pegc.state.block_length = 0x0FFF;
+
+        let mut vram = vec![0xAA; PEGC_VRAM_SIZE];
+        pegc.plane_write_dword(0, 0xFFFF_0000, &mut vram);
+
+        for (i, byte) in vram.iter().enumerate().take(16) {
+            assert_eq!(*byte, 0x00, "pixel {i} should use low source bits");
+        }
+        for (i, byte) in vram.iter().enumerate().take(32).skip(16) {
+            assert_eq!(*byte, 0xFF, "pixel {i} should use upper source bits");
+        }
+    }
+
+    #[test]
+    fn plane_dword_word_sized_block_writes_both_words() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x0100; // source = CPU data
+        pegc.state.write_mask = 0x0000_FFFF;
+        pegc.state.block_length = 0x000F;
+
+        let mut vram = vec![0u8; PEGC_VRAM_SIZE];
+        pegc.plane_write_dword(0, 0xFFFF_FFFF, &mut vram);
+
+        for (i, byte) in vram.iter().enumerate().take(32) {
+            assert_eq!(*byte, 0xFF, "pixel {i} should be written");
+        }
+    }
+
+    #[test]
+    fn plane_dword_word_sized_block_consumes_vram_source_by_word() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x0000; // source = preceding VRAM read
+        pegc.state.write_mask = 0x0000_FFFF;
+        pegc.state.block_length = 0x000F;
+
+        let mut vram = vec![0u8; PEGC_VRAM_SIZE];
+        vram[..16].fill(0x11);
+        vram[16..32].fill(0x22);
+
+        pegc.plane_read_dword(0, &vram);
+        pegc.plane_write_dword(8, 0, &mut vram);
+
+        for (i, byte) in vram.iter().enumerate().skip(64).take(16) {
+            assert_eq!(*byte, 0x11, "pixel {i} should use the first source word");
+        }
+        for (i, byte) in vram.iter().enumerate().skip(80).take(16) {
+            assert_eq!(*byte, 0x22, "pixel {i} should use the second source word");
         }
     }
 

--- a/crates/device/src/pegc.rs
+++ b/crates/device/src/pegc.rs
@@ -97,8 +97,16 @@ pub struct PegcState {
     pub skip_next_shifted_padding_write: bool,
     /// Pixel address used by the shifted decrement padding write.
     pub shifted_padding_base_address: u32,
+    /// Source offset expected for a shifted padding read.
+    pub shifted_padding_source_offset: u32,
+    /// Destination offset expected for a shifted padding write.
+    pub shifted_padding_destination_offset: u32,
     /// Number of pixels written by the shifted decrement padding write.
     pub shifted_padding_pixels: u32,
+    /// Last VRAM source read offset in plane mode.
+    pub last_plane_read_offset: u32,
+    /// Whether an increment shifted VRAM-source leading padding write was skipped.
+    pub leading_shifted_padding_write_skipped: bool,
     /// 256-color palette: 256 entries of [green, red, blue], 8-bit components.
     pub palette_256: Box<[[u8; 3]; 256]>,
     /// Currently selected palette index (port 0xA8 in PEGC mode).
@@ -143,7 +151,11 @@ impl Pegc {
                 remain: 0,
                 skip_next_shifted_padding_write: false,
                 shifted_padding_base_address: 0,
+                shifted_padding_source_offset: 0,
+                shifted_padding_destination_offset: 0,
                 shifted_padding_pixels: 0,
+                last_plane_read_offset: 0,
+                leading_shifted_padding_write_skipped: false,
                 palette_256: Box::new([[0u8; 3]; 256]),
                 palette_index: 0,
             },
@@ -197,8 +209,15 @@ impl Pegc {
     fn reset_transfer_state_from_length(&mut self) {
         self.state.remain = u32::from(self.state.block_length) + 1;
         self.state.last_data_length = 0;
+        self.state.leading_shifted_padding_write_skipped = false;
+        self.clear_shifted_padding_state();
+    }
+
+    fn clear_shifted_padding_state(&mut self) {
         self.state.skip_next_shifted_padding_write = false;
         self.state.shifted_padding_base_address = 0;
+        self.state.shifted_padding_source_offset = 0;
+        self.state.shifted_padding_destination_offset = 0;
         self.state.shifted_padding_pixels = 0;
     }
 
@@ -666,24 +685,45 @@ impl Pegc {
         let plane_mask = self.state.plane_access_mask;
         let palette1 = self.state.palette_color_1;
 
-        let base_address = offset.wrapping_mul(8).wrapping_add(source_shift);
-        let base_address = if self.state.remain != block_length + 1 {
-            if shift_direction_decrement {
-                if dest_shift == 0 {
-                    base_address
+        let decrement_shifted_vram_source =
+            !source_from_cpu && shift_direction_decrement && source_shift != 0;
+        if self.state.remain == 0
+            && self.state.skip_next_shifted_padding_write
+            && !source_from_cpu
+            && offset != self.state.shifted_padding_source_offset
+        {
+            self.clear_shifted_padding_state();
+            self.state.last_vram_data.fill(0);
+            self.state.last_data_length = 0;
+            self.state.leading_shifted_padding_write_skipped = false;
+        }
+
+        let block_start = (self.state.remain == block_length + 1
+            && !self.state.leading_shifted_padding_write_skipped)
+            || (self.state.remain == 0 && !self.state.skip_next_shifted_padding_write);
+        let base_address = if decrement_shifted_vram_source {
+            offset.wrapping_mul(8).wrapping_add(pixels - source_shift)
+        } else {
+            let base_address = offset.wrapping_mul(8).wrapping_add(source_shift);
+            if !block_start {
+                if shift_direction_decrement {
+                    if dest_shift == 0 {
+                        base_address
+                    } else {
+                        base_address.wrapping_add(pixels - dest_shift)
+                    }
                 } else {
-                    base_address.wrapping_add(pixels - dest_shift)
+                    base_address.wrapping_sub(dest_shift)
                 }
             } else {
-                base_address.wrapping_sub(dest_shift)
+                base_address
             }
-        } else {
-            base_address
         };
 
         let mut result: u32 = 0;
 
         if !source_from_cpu {
+            self.state.last_plane_read_offset = offset;
             for i in 0u32..pixels {
                 let pixel_address = if shift_direction_decrement {
                     base_address.wrapping_sub(i + 1) & (PEGC_VRAM_SIZE as u32 - 1)
@@ -725,12 +765,6 @@ impl Pegc {
     /// Same semantics as `plane_write_word` but processes 32 pixels per call.
     /// Shift register bit 4 is valid and the write mask is applied to each word.
     pub fn plane_write_dword(&mut self, offset: u32, value: u32, vram: &mut [u8]) {
-        if self.state.block_length < 16 {
-            self.plane_write_impl(offset, value & 0xFFFF, vram, 16);
-            self.plane_write_impl(offset + 2, value >> 16, vram, 16);
-            return;
-        }
-
         self.plane_write_impl(offset, value, vram, 32);
     }
 
@@ -746,6 +780,12 @@ impl Pegc {
         let block_length = u32::from(self.state.block_length);
         let source_shift = u32::from(self.state.shift_read);
         let dest_shift = u32::from(self.state.shift_write);
+        let decrement_shifted_vram_source =
+            !source_from_cpu && shift_direction_decrement && source_shift != 0;
+        let increment_shifted_vram_source =
+            !source_from_cpu && !shift_direction_decrement && source_shift != 0;
+        let same_shift_decrement_vram_source =
+            decrement_shifted_vram_source && source_shift == dest_shift;
 
         if self.state.remain == 0 {
             self.state.remain = block_length + 1;
@@ -753,72 +793,102 @@ impl Pegc {
                 self.state.last_data_length = 0;
             }
             if self.state.skip_next_shifted_padding_write {
-                self.state.skip_next_shifted_padding_write = false;
-                let padding_pixels = self
-                    .state
-                    .shifted_padding_pixels
-                    .min(self.source_buffer_length() as u32);
-                if padding_pixels != 0 {
-                    let base_address = if shift_direction_decrement {
-                        self.state.shifted_padding_base_address
-                    } else {
-                        offset.wrapping_mul(8)
-                    } & (PEGC_VRAM_SIZE as u32 - 1);
-                    for i in 0..padding_pixels {
-                        let pixel_address = if shift_direction_decrement {
-                            base_address.wrapping_sub(i + 1) & (PEGC_VRAM_SIZE as u32 - 1)
+                if offset != self.state.shifted_padding_destination_offset {
+                    self.clear_shifted_padding_state();
+                } else {
+                    self.state.skip_next_shifted_padding_write = false;
+                    let padding_pixels = self
+                        .state
+                        .shifted_padding_pixels
+                        .min(self.source_buffer_length() as u32);
+                    if padding_pixels != 0 {
+                        let base_address = if shift_direction_decrement {
+                            self.state.shifted_padding_base_address
                         } else {
-                            base_address.wrapping_add(i) & (PEGC_VRAM_SIZE as u32 - 1)
-                        };
-                        let source = self.state.last_vram_data[i as usize];
-                        let destination = vram[pixel_address as usize];
+                            offset.wrapping_mul(8)
+                        } & (PEGC_VRAM_SIZE as u32 - 1);
+                        for i in 0..padding_pixels {
+                            let pixel_address = if shift_direction_decrement {
+                                base_address.wrapping_sub(i + 1) & (PEGC_VRAM_SIZE as u32 - 1)
+                            } else {
+                                base_address.wrapping_add(i) & (PEGC_VRAM_SIZE as u32 - 1)
+                            };
+                            let source = self.state.last_vram_data[i as usize];
+                            let destination = vram[pixel_address as usize];
 
-                        if rop_enabled {
-                            let (pattern1, pattern2) = self.get_pattern_colors(rop_method, i);
-                            let result = apply_rop(
-                                rop_code,
-                                source,
-                                destination,
-                                pattern1,
-                                pattern2,
-                                plane_mask,
-                            );
-                            vram[pixel_address as usize] = (destination & plane_mask) | result;
-                        } else {
-                            vram[pixel_address as usize] =
-                                apply_source_copy(source, destination, plane_mask);
+                            if rop_enabled {
+                                let (pattern1, pattern2) = self.get_pattern_colors(rop_method, i);
+                                let result = apply_rop(
+                                    rop_code,
+                                    source,
+                                    destination,
+                                    pattern1,
+                                    pattern2,
+                                    plane_mask,
+                                );
+                                vram[pixel_address as usize] = (destination & plane_mask) | result;
+                            } else {
+                                vram[pixel_address as usize] =
+                                    apply_source_copy(source, destination, plane_mask);
+                            }
+                        }
+                        if !shift_direction_decrement {
+                            self.state.remain = self.state.remain.saturating_sub(padding_pixels);
                         }
                     }
-                    if !shift_direction_decrement {
-                        self.state.remain = self.state.remain.saturating_sub(padding_pixels);
-                    }
+                    self.clear_shifted_padding_state();
+                    self.state.last_data_length = 0;
+                    return;
                 }
-                self.state.shifted_padding_base_address = 0;
-                self.state.shifted_padding_pixels = 0;
-                self.state.last_data_length = 0;
-                return;
             }
         } else {
-            self.state.skip_next_shifted_padding_write = false;
+            self.clear_shifted_padding_state();
         }
 
         let pixels_signed = pixels as i32;
         let extended_shift_mode = !source_from_cpu || ((block_length + 1) & (pixels - 1)) != 0;
 
         let block_start = self.state.remain == block_length + 1;
+        let source_byte_in_row = self.state.last_plane_read_offset & 0x7F;
+        let destination_byte_in_row = offset & 0x7F;
+        let same_scanline = (self.state.last_plane_read_offset & !0x7F) == (offset & !0x7F);
+        if block_start
+            && increment_shifted_vram_source
+            && source_shift > dest_shift
+            && same_scanline
+            && source_byte_in_row > destination_byte_in_row
+            && !self.state.leading_shifted_padding_write_skipped
+        {
+            self.state.leading_shifted_padding_write_skipped = true;
+            return;
+        }
+
         let mut base_address = offset.wrapping_mul(8);
         let mut data_length: i32 = pixels_signed;
         let mut shifted_bit_offset = 0;
 
         if extended_shift_mode {
             if shift_direction_decrement {
-                if block_start {
-                    if dest_shift != 0 {
-                        base_address = base_address.wrapping_add(dest_shift);
-                        data_length = dest_shift as i32;
+                if decrement_shifted_vram_source && dest_shift != 0 {
+                    if block_start {
+                        if same_shift_decrement_vram_source {
+                            base_address = base_address.wrapping_add(pixels - dest_shift);
+                        } else {
+                            base_address = base_address.wrapping_sub(dest_shift);
+                        }
+                        data_length -= dest_shift as i32;
+                    } else if same_shift_decrement_vram_source {
+                        base_address = base_address.wrapping_add(pixels);
                     }
-                } else if dest_shift != 0 {
-                    base_address = base_address.wrapping_add(pixels);
+                } else {
+                    if block_start {
+                        if dest_shift != 0 {
+                            base_address = base_address.wrapping_add(dest_shift);
+                            data_length = dest_shift as i32;
+                        }
+                    } else if dest_shift != 0 {
+                        base_address = base_address.wrapping_add(pixels);
+                    }
                 }
             } else if block_start {
                 base_address = base_address.wrapping_add(dest_shift);
@@ -928,11 +998,22 @@ impl Pegc {
         }
 
         if self.state.remain == 0
+            && !same_shift_decrement_vram_source
             && ((!extended_shift_mode && dest_shift != 0)
                 || (!source_from_cpu && source_shift != 0))
         {
             self.state.skip_next_shifted_padding_write = true;
             self.state.shifted_padding_base_address = 0;
+            self.state.shifted_padding_source_offset = if shift_direction_decrement {
+                self.state.last_plane_read_offset.wrapping_sub(pixels / 8)
+            } else {
+                self.state.last_plane_read_offset.wrapping_add(pixels / 8)
+            };
+            self.state.shifted_padding_destination_offset = if shift_direction_decrement {
+                offset.wrapping_sub(pixels / 8)
+            } else {
+                offset.wrapping_add(pixels / 8)
+            };
             self.state.shifted_padding_pixels = 0;
             if !source_from_cpu
                 && shift_direction_decrement
@@ -958,9 +1039,22 @@ impl Pegc {
             if self.state.remain == 0 {
                 self.state.last_vram_data.fill(0);
                 self.state.last_data_length = 0;
+                self.state.leading_shifted_padding_write_skipped = false;
             }
         } else {
-            self.consume_source_buffer(pixels as usize);
+            let consume_pixels = if decrement_shifted_vram_source {
+                processed_pixels
+            } else {
+                pixels as usize
+            };
+            self.consume_source_buffer(consume_pixels);
+            if self.state.remain == 0 && same_shift_decrement_vram_source {
+                self.state.last_vram_data.fill(0);
+                self.state.last_data_length = 0;
+            }
+            if self.state.remain == 0 {
+                self.state.leading_shifted_padding_write_skipped = false;
+            }
         }
     }
 
@@ -1588,32 +1682,64 @@ mod tests {
         assert_eq!(vram[11], 0x77);
     }
 
-    #[test]
-    fn plane_mode_decrement_shifted_vram_source_overlaps_toward_higher_pixels() {
+    fn decrement_vram_source_copy(block_length: u16, shift_read: u8, shift_write: u8) -> Pegc {
         let mut pegc = Pegc::new();
         pegc.state.mode_register = 1;
         pegc.state.plane_access_mask = 0x00;
         pegc.state.rop_register = 0x12F0;
         pegc.state.write_mask = 0xFFFF;
-        pegc.state.block_length = 25;
-        pegc.state.remain = 26;
-        pegc.state.shift_read = 4;
-        pegc.state.shift_write = 5;
+        pegc.state.block_length = block_length;
+        pegc.state.remain = u32::from(block_length) + 1;
+        pegc.state.shift_read = shift_read;
+        pegc.state.shift_write = shift_write;
+        pegc
+    }
+
+    fn decrement_source_high_pixel(offset: u32, shift_read: u8) -> u32 {
+        offset * 8 + 16 - u32::from(shift_read) - 1
+    }
+
+    fn decrement_destination_high_pixel(offset: u32, shift_write: u8, same_shift: bool) -> u32 {
+        if same_shift {
+            offset * 8 + 16 - u32::from(shift_write) - 1
+        } else {
+            offset * 8 - u32::from(shift_write) - 1
+        }
+    }
+
+    fn run_decrement_word_copy(
+        pegc: &mut Pegc,
+        mut source_offset: u32,
+        mut destination_offset: u32,
+        vram: &mut [u8],
+    ) {
+        loop {
+            pegc.plane_read_word(source_offset, vram);
+            pegc.plane_write_word(destination_offset, 0, vram);
+            if pegc.state.remain == 0 {
+                break;
+            }
+            source_offset -= 2;
+            destination_offset -= 2;
+        }
+    }
+
+    #[test]
+    fn plane_mode_asymmetric_decrement_vram_source_keeps_tail_across_words() {
+        let mut pegc = decrement_vram_source_copy(25, 4, 5);
 
         let mut vram = vec![0u8; PEGC_VRAM_SIZE];
-        let source_high_pixel = 0x1000u32 * 8 + 3;
-        let destination_high_pixel = 0x2000u32 * 8 + 4;
+        let source_offset = 0x1000u32;
+        let destination_offset = 0x2000u32;
+        let source_high_pixel = decrement_source_high_pixel(source_offset, pegc.state.shift_read);
+        let destination_high_pixel =
+            decrement_destination_high_pixel(destination_offset, pegc.state.shift_write, false);
 
         for index in 0..26u32 {
             vram[(source_high_pixel - index) as usize] = (index + 1) as u8;
         }
 
-        pegc.plane_read_word(0x1000, &vram);
-        pegc.plane_write_word(0x2000, 0, &mut vram);
-        pegc.plane_read_word(0x0FFE, &vram);
-        pegc.plane_write_word(0x1FFE, 0, &mut vram);
-        pegc.plane_read_word(0x0FFC, &vram);
-        pegc.plane_write_word(0x1FFC, 0, &mut vram);
+        run_decrement_word_copy(&mut pegc, source_offset, destination_offset, &mut vram);
 
         for index in 0..26u32 {
             assert_eq!(
@@ -1626,41 +1752,182 @@ mod tests {
     }
 
     #[test]
-    fn plane_mode_decrement_shifted_vram_source_padding_fills_previous_byte() {
+    fn plane_mode_asymmetric_decrement_vram_source_copies_right_edge_span() {
+        let mut pegc = decrement_vram_source_copy(425, 12, 3);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let source_start = 74usize;
+        let destination_start = 99usize;
+        let width = 426usize;
+        for i in 0..width {
+            vram[source_start + i] = (i as u8).wrapping_mul(13).wrapping_add(1);
+        }
+        let original = vram.clone();
+
+        let mut source_offset = 62u32;
+        let mut destination_offset = 66u32;
+        while pegc.state.remain != 0 {
+            pegc.plane_read_word(source_offset, &vram);
+            pegc.plane_write_word(destination_offset, 0, &mut vram);
+            source_offset = source_offset.wrapping_sub(2);
+            destination_offset = destination_offset.wrapping_sub(2);
+        }
+
+        for i in 0..width {
+            assert_eq!(
+                vram[destination_start + i],
+                original[source_start + i],
+                "right-edge copy pixel {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn plane_mode_same_shift_decrement_vram_source_copies_overlapping_rows() {
+        let mut pegc = decrement_vram_source_copy(425, 3, 3);
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let source_start = 99usize;
+        let destination_start = 99usize;
+        let width = 426usize;
+        let height = 153usize;
+        let right_edge_x = source_start + width - 1;
+        let first_word_x = right_edge_x + 1 - (16 - pegc.state.shift_read as usize);
+
+        for row_index in 0..height {
+            let source_row = 94usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            for pixel_index in 0..width {
+                vram[source_base + pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(17)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(3);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in (0..height).rev() {
+            let source_row = 94usize + row_index;
+            let destination_row = 119usize + row_index;
+            let mut source_offset = ((source_row * plane_pitch_pixels + first_word_x) / 8) as u32;
+            let mut destination_offset =
+                ((destination_row * plane_pitch_pixels + first_word_x) / 8) as u32;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset = source_offset.wrapping_sub(2);
+                destination_offset = destination_offset.wrapping_sub(2);
+            }
+        }
+
+        for row_index in 0..height {
+            let source_row = 94usize + row_index;
+            let destination_row = 119usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            let destination_base = destination_row * plane_pitch_pixels + destination_start;
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_base + pixel_index],
+                    original[source_base + pixel_index],
+                    "same-shift decrement row {row_index} pixel {pixel_index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plane_mode_increment_shifted_vram_source_copies_left_edge_trace() {
         let mut pegc = Pegc::new();
         pegc.state.mode_register = 1;
         pegc.state.plane_access_mask = 0x00;
-        pegc.state.rop_register = 0x12F0;
+        pegc.state.rop_register = 0x10F0;
         pegc.state.write_mask = 0xFFFF;
-        pegc.state.block_length = 25;
-        pegc.state.remain = 26;
-        pegc.state.shift_read = 1;
-        pegc.state.shift_write = 12;
+        pegc.state.block_length = 425;
+        pegc.state.remain = 426;
+        pegc.state.shift_read = 12;
+        pegc.state.shift_write = 10;
+
+        let mut vram = vec![0xEEu8; PEGC_VRAM_SIZE];
+        let plane_pitch_pixels = 1024usize;
+        let source_start = 124usize;
+        let destination_start = 74usize;
+        let width = 426usize;
+        let height = 153usize;
+        let first_source_word_x = source_start - pegc.state.shift_read as usize;
+        let first_destination_word_x = destination_start - pegc.state.shift_write as usize - 16;
+
+        for row_index in 0..height {
+            let source_row = 144usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            for pixel_index in 0..width {
+                vram[source_base + pixel_index] = (pixel_index as u8)
+                    .wrapping_mul(19)
+                    .wrapping_add(row_index as u8)
+                    .wrapping_add(7);
+            }
+        }
+        let original = vram.clone();
+
+        for row_index in 0..height {
+            let source_row = 144usize + row_index;
+            let destination_row = 144usize + row_index;
+            let mut source_offset =
+                ((source_row * plane_pitch_pixels + first_source_word_x) / 8) as u32;
+            let mut destination_offset =
+                ((destination_row * plane_pitch_pixels + first_destination_word_x) / 8) as u32;
+            loop {
+                pegc.plane_read_word(source_offset, &vram);
+                pegc.plane_write_word(destination_offset, 0, &mut vram);
+                if pegc.state.remain == 0 {
+                    break;
+                }
+                source_offset += 2;
+                destination_offset += 2;
+            }
+        }
+
+        for row_index in 0..height {
+            let source_row = 144usize + row_index;
+            let destination_row = 144usize + row_index;
+            let source_base = source_row * plane_pitch_pixels + source_start;
+            let destination_base = destination_row * plane_pitch_pixels + destination_start;
+            for pixel_index in 48..destination_start {
+                assert_eq!(
+                    vram[destination_row * plane_pitch_pixels + pixel_index],
+                    original[destination_row * plane_pitch_pixels + pixel_index],
+                    "increment shifted copy row {row_index} touched pixel {pixel_index} before destination"
+                );
+            }
+            for pixel_index in 0..width {
+                assert_eq!(
+                    vram[destination_base + pixel_index],
+                    original[source_base + pixel_index],
+                    "increment shifted copy row {row_index} pixel {pixel_index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plane_mode_same_shift_decrement_vram_source_discards_tail_at_block_end() {
+        let mut pegc = decrement_vram_source_copy(25, 3, 3);
 
         let mut vram = vec![0u8; PEGC_VRAM_SIZE];
         let source_offset = 0x1004u32;
         let destination_offset = 0x2004u32;
-        let destination_high_pixel = destination_offset * 8 + 11;
+        let source_high_pixel = decrement_source_high_pixel(source_offset, pegc.state.shift_read);
+        let destination_high_pixel =
+            decrement_destination_high_pixel(destination_offset, pegc.state.shift_write, true);
 
-        for offset in [0x1004u32, 0x1002, 0x1000] {
-            let source_base = offset * 8;
-            for i in 0..16u32 {
-                vram[(source_base - i) as usize] = 0xA0;
-            }
-        }
-        let padding_source_base = 0x1000u32 * 8;
-        for i in 0..16u32 {
-            vram[(padding_source_base + 4 - i) as usize] = 0x5A;
+        for index in 0..26u32 {
+            vram[(source_high_pixel - index) as usize] = 0xA0;
         }
 
-        pegc.plane_read_word(source_offset, &vram);
-        pegc.plane_write_word(destination_offset, 0, &mut vram);
-        pegc.plane_read_word(source_offset - 2, &vram);
-        pegc.plane_write_word(destination_offset - 2, 0, &mut vram);
-        assert_eq!(pegc.state.remain, 0);
-
-        pegc.plane_read_word(source_offset - 4, &vram);
-        pegc.plane_write_word(destination_offset - 4, 0, &mut vram);
+        run_decrement_word_copy(&mut pegc, source_offset, destination_offset, &mut vram);
 
         for index in 0..26u32 {
             assert_eq!(
@@ -1672,12 +1939,34 @@ mod tests {
         for index in 0..8u32 {
             assert_eq!(
                 vram[(destination_high_pixel - 26 - index) as usize],
-                0x5A,
-                "padding decrement pixel {index}"
+                0x00,
+                "pixel {index} after the decrement block should be untouched"
             );
         }
-        assert_eq!(pegc.state.remain, 26);
+        assert_eq!(pegc.state.remain, 0);
         assert_eq!(pegc.state.last_data_length, 0);
+        assert!(!pegc.state.skip_next_shifted_padding_write);
+
+        let next_source_offset = 0x3004u32;
+        let next_destination_offset = 0x4004u32;
+        let next_source_high_pixel =
+            decrement_source_high_pixel(next_source_offset, pegc.state.shift_read);
+        let next_destination_high_pixel =
+            decrement_destination_high_pixel(next_destination_offset, pegc.state.shift_write, true);
+        for index in 0..26u32 {
+            vram[(next_source_high_pixel - index) as usize] = 0x5A;
+        }
+
+        pegc.plane_read_word(next_source_offset, &vram);
+        pegc.plane_write_word(next_destination_offset, 0, &mut vram);
+
+        for index in 0..4u32 {
+            assert_eq!(
+                vram[(next_destination_high_pixel - index) as usize],
+                0x5A,
+                "next decrement block pixel {index}"
+            );
+        }
     }
 
     #[test]
@@ -1908,6 +2197,81 @@ mod tests {
     }
 
     #[test]
+    fn plane_dword_small_block_does_not_restart_upper_word() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x0100;
+        pegc.state.write_mask = 0xFFFF_FFFF;
+        pegc.state.block_length = 2;
+        pegc.state.remain = 3;
+
+        let mut vram = vec![0x77u8; PEGC_VRAM_SIZE];
+        pegc.plane_write_dword(0, 0xFFFF_FFFF, &mut vram);
+
+        for (i, byte) in vram.iter().enumerate().take(3) {
+            assert_eq!(*byte, 0xFF, "pixel {i} within the small block");
+        }
+        for (i, byte) in vram.iter().enumerate().take(32).skip(3) {
+            assert_eq!(*byte, 0x77, "pixel {i} outside the small block");
+        }
+        assert_eq!(pegc.state.remain, 0);
+    }
+
+    #[test]
+    fn plane_dword_shifted_pattern_xor_small_block_writes_only_shifted_pixels() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x9166;
+        pegc.state.write_mask = 0xFFFF_FFFF;
+        pegc.state.block_length = 2;
+        pegc.state.remain = 3;
+        pegc.state.shift_write = 10;
+        for pixel in 10..13u32 {
+            pegc.mmio_write_byte(MMIO2_BASE + REG_PATTERN + pixel * 4, 0xFF);
+        }
+
+        let mut vram = vec![0x55u8; PEGC_VRAM_SIZE];
+        pegc.plane_write_dword(0, 0, &mut vram);
+
+        for (i, byte) in vram.iter().enumerate().take(10) {
+            assert_eq!(*byte, 0x55, "pixel {i} before the shifted block");
+        }
+        for (i, byte) in vram.iter().enumerate().take(13).skip(10) {
+            assert_eq!(*byte, 0xAA, "pixel {i} toggled by the XOR pattern");
+        }
+        for (i, byte) in vram.iter().enumerate().take(32).skip(13) {
+            assert_eq!(*byte, 0x55, "pixel {i} outside the shifted block");
+        }
+        assert_eq!(pegc.state.remain, 0);
+    }
+
+    #[test]
+    fn plane_dword_shifted_pattern_xor_small_block_is_self_erasing() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x9166;
+        pegc.state.write_mask = 0xFFFF_FFFF;
+        pegc.state.block_length = 2;
+        pegc.state.remain = 3;
+        pegc.state.shift_write = 10;
+        for pixel in 10..13u32 {
+            pegc.mmio_write_byte(MMIO2_BASE + REG_PATTERN + pixel * 4, 0xFF);
+        }
+
+        let mut vram = vec![0x55u8; PEGC_VRAM_SIZE];
+        pegc.plane_write_dword(0, 0, &mut vram);
+        pegc.state.remain = 3;
+        pegc.plane_write_dword(0, 0, &mut vram);
+
+        for (i, byte) in vram.iter().enumerate().take(32) {
+            assert_eq!(*byte, 0x55, "pixel {i} after the second XOR");
+        }
+    }
+
+    #[test]
     fn plane_mode_word_write_simple_no_rop() {
         let mut pegc = Pegc::new();
         pegc.state.mode_register = 1;
@@ -2122,7 +2486,7 @@ mod tests {
     }
 
     #[test]
-    fn plane_dword_word_sized_block_writes_both_words() {
+    fn plane_dword_word_sized_block_writes_one_configured_block() {
         let mut pegc = Pegc::new();
         pegc.state.mode_register = 1;
         pegc.state.plane_access_mask = 0x00;
@@ -2133,13 +2497,17 @@ mod tests {
         let mut vram = vec![0u8; PEGC_VRAM_SIZE];
         pegc.plane_write_dword(0, 0xFFFF_FFFF, &mut vram);
 
-        for (i, byte) in vram.iter().enumerate().take(32) {
+        for (i, byte) in vram.iter().enumerate().take(16) {
             assert_eq!(*byte, 0xFF, "pixel {i} should be written");
         }
+        for (i, byte) in vram.iter().enumerate().take(32).skip(16) {
+            assert_eq!(*byte, 0x00, "pixel {i} should be outside the block");
+        }
+        assert_eq!(pegc.state.remain, 0);
     }
 
     #[test]
-    fn plane_dword_word_sized_block_consumes_vram_source_by_word() {
+    fn plane_dword_word_sized_block_consumes_one_vram_source_block() {
         let mut pegc = Pegc::new();
         pegc.state.mode_register = 1;
         pegc.state.plane_access_mask = 0x00;
@@ -2158,8 +2526,9 @@ mod tests {
             assert_eq!(*byte, 0x11, "pixel {i} should use the first source word");
         }
         for (i, byte) in vram.iter().enumerate().skip(80).take(16) {
-            assert_eq!(*byte, 0x22, "pixel {i} should use the second source word");
+            assert_eq!(*byte, 0x00, "pixel {i} should be outside the block");
         }
+        assert_eq!(pegc.state.remain, 0);
     }
 
     #[test]

--- a/crates/device/src/pegc.rs
+++ b/crates/device/src/pegc.rs
@@ -87,14 +87,18 @@ pub struct PegcState {
     pub palette_color_2: u8,
     /// Pattern register raw bytes (MMIO E0120h-E019Fh, 128 bytes).
     pub pattern_data: Box<[u8; 128]>,
-    /// Last VRAM data read buffer for plane mode source operations.
+    /// Buffered plane-mode source pixels.
     pub last_vram_data: [u8; 64],
-    /// Number of valid bytes in `last_vram_data`.
+    /// Number of valid buffered source pixels.
     pub last_data_length: i32,
     /// Remaining block transfer count for plane mode.
     pub remain: u32,
-    /// Skips the padding write after a shifted CPU-source block completes.
-    pub skip_next_shifted_cpu_write: bool,
+    /// Skips the padding write after a shifted block completes.
+    pub skip_next_shifted_padding_write: bool,
+    /// Pixel address used by the shifted decrement padding write.
+    pub shifted_padding_base_address: u32,
+    /// Number of pixels written by the shifted decrement padding write.
+    pub shifted_padding_pixels: u32,
     /// 256-color palette: 256 entries of [green, red, blue], 8-bit components.
     pub palette_256: Box<[[u8; 3]; 256]>,
     /// Currently selected palette index (port 0xA8 in PEGC mode).
@@ -137,7 +141,9 @@ impl Pegc {
                 last_vram_data: [0u8; 64],
                 last_data_length: 0,
                 remain: 0,
-                skip_next_shifted_cpu_write: false,
+                skip_next_shifted_padding_write: false,
+                shifted_padding_base_address: 0,
+                shifted_padding_pixels: 0,
                 palette_256: Box::new([[0u8; 3]; 256]),
                 palette_index: 0,
             },
@@ -191,7 +197,9 @@ impl Pegc {
     fn reset_transfer_state_from_length(&mut self) {
         self.state.remain = u32::from(self.state.block_length) + 1;
         self.state.last_data_length = 0;
-        self.state.skip_next_shifted_cpu_write = false;
+        self.state.skip_next_shifted_padding_write = false;
+        self.state.shifted_padding_base_address = 0;
+        self.state.shifted_padding_pixels = 0;
     }
 
     fn source_buffer_length(&self) -> usize {
@@ -213,6 +221,20 @@ impl Pegc {
             .saturating_add(pixels as usize)
             .min(self.state.last_vram_data.len());
         self.state.last_data_length = length as i32;
+    }
+
+    fn append_cpu_source_buffer(&mut self, value: u32, pixels: u32, source_start: u32) {
+        if source_start >= pixels {
+            return;
+        }
+
+        let source_pixels = pixels - source_start;
+        for i in 0..source_pixels {
+            let source_bit = source_bit_position(source_start + i);
+            let source = if value & source_bit != 0 { 0xFF } else { 0x00 };
+            self.append_source_buffer(i as usize, source);
+        }
+        self.finish_source_buffer_append(source_pixels);
     }
 
     fn consume_source_buffer(&mut self, pixels: usize) {
@@ -646,7 +668,15 @@ impl Pegc {
 
         let base_address = offset.wrapping_mul(8).wrapping_add(source_shift);
         let base_address = if self.state.remain != block_length + 1 {
-            base_address.wrapping_sub(dest_shift)
+            if shift_direction_decrement {
+                if dest_shift == 0 {
+                    base_address
+                } else {
+                    base_address.wrapping_add(pixels - dest_shift)
+                }
+            } else {
+                base_address.wrapping_sub(dest_shift)
+            }
         } else {
             base_address
         };
@@ -656,7 +686,7 @@ impl Pegc {
         if !source_from_cpu {
             for i in 0u32..pixels {
                 let pixel_address = if shift_direction_decrement {
-                    base_address.wrapping_sub(i) & (PEGC_VRAM_SIZE as u32 - 1)
+                    base_address.wrapping_sub(i + 1) & (PEGC_VRAM_SIZE as u32 - 1)
                 } else {
                     base_address.wrapping_add(i) & (PEGC_VRAM_SIZE as u32 - 1)
                 };
@@ -714,6 +744,7 @@ impl Pegc {
         let plane_mask = self.state.plane_access_mask;
         let pixel_mask = self.state.write_mask;
         let block_length = u32::from(self.state.block_length);
+        let source_shift = u32::from(self.state.shift_read);
         let dest_shift = u32::from(self.state.shift_write);
 
         if self.state.remain == 0 {
@@ -721,48 +752,107 @@ impl Pegc {
             if source_from_cpu {
                 self.state.last_data_length = 0;
             }
-            if self.state.skip_next_shifted_cpu_write {
-                self.state.skip_next_shifted_cpu_write = false;
+            if self.state.skip_next_shifted_padding_write {
+                self.state.skip_next_shifted_padding_write = false;
+                let padding_pixels = self
+                    .state
+                    .shifted_padding_pixels
+                    .min(self.source_buffer_length() as u32);
+                if padding_pixels != 0 {
+                    let base_address = if shift_direction_decrement {
+                        self.state.shifted_padding_base_address
+                    } else {
+                        offset.wrapping_mul(8)
+                    } & (PEGC_VRAM_SIZE as u32 - 1);
+                    for i in 0..padding_pixels {
+                        let pixel_address = if shift_direction_decrement {
+                            base_address.wrapping_sub(i + 1) & (PEGC_VRAM_SIZE as u32 - 1)
+                        } else {
+                            base_address.wrapping_add(i) & (PEGC_VRAM_SIZE as u32 - 1)
+                        };
+                        let source = self.state.last_vram_data[i as usize];
+                        let destination = vram[pixel_address as usize];
+
+                        if rop_enabled {
+                            let (pattern1, pattern2) = self.get_pattern_colors(rop_method, i);
+                            let result = apply_rop(
+                                rop_code,
+                                source,
+                                destination,
+                                pattern1,
+                                pattern2,
+                                plane_mask,
+                            );
+                            vram[pixel_address as usize] = (destination & plane_mask) | result;
+                        } else {
+                            vram[pixel_address as usize] =
+                                apply_source_copy(source, destination, plane_mask);
+                        }
+                    }
+                    if !shift_direction_decrement {
+                        self.state.remain = self.state.remain.saturating_sub(padding_pixels);
+                    }
+                }
+                self.state.shifted_padding_base_address = 0;
+                self.state.shifted_padding_pixels = 0;
+                self.state.last_data_length = 0;
                 return;
             }
         } else {
-            self.state.skip_next_shifted_cpu_write = false;
+            self.state.skip_next_shifted_padding_write = false;
         }
 
         let pixels_signed = pixels as i32;
         let extended_shift_mode = !source_from_cpu || ((block_length + 1) & (pixels - 1)) != 0;
 
+        let block_start = self.state.remain == block_length + 1;
         let mut base_address = offset.wrapping_mul(8);
         let mut data_length: i32 = pixels_signed;
+        let mut shifted_bit_offset = 0;
 
         if extended_shift_mode {
-            if self.state.remain == block_length + 1 {
+            if shift_direction_decrement {
+                if block_start {
+                    if dest_shift != 0 {
+                        base_address = base_address.wrapping_add(dest_shift);
+                        data_length = dest_shift as i32;
+                    }
+                } else if dest_shift != 0 {
+                    base_address = base_address.wrapping_add(pixels);
+                }
+            } else if block_start {
                 base_address = base_address.wrapping_add(dest_shift);
                 data_length -= dest_shift as i32;
+                shifted_bit_offset = dest_shift;
             }
         } else {
             base_address = base_address.wrapping_add(dest_shift);
         }
         base_address &= PEGC_VRAM_SIZE as u32 - 1;
 
+        if source_from_cpu {
+            let source_start = if block_start { source_shift } else { 0 };
+            self.append_cpu_source_buffer(value, pixels, source_start);
+        }
+
         let source_buffer_length = self.source_buffer_length();
+        let mut processed_pixels = 0usize;
 
         for i in 0..data_length {
             let pixel_address = if shift_direction_decrement {
-                base_address.wrapping_sub(i as u32) & (PEGC_VRAM_SIZE as u32 - 1)
+                base_address.wrapping_sub(i as u32 + 1) & (PEGC_VRAM_SIZE as u32 - 1)
             } else {
                 base_address.wrapping_add(i as u32) & (PEGC_VRAM_SIZE as u32 - 1)
             };
-            let source_bit = source_bit_position(i as u32);
+            let shifted_pixel_index = shifted_bit_offset + i as u32;
             let pixel_mask_bit = write_mask_position(i as u32);
 
             if pixel_mask & pixel_mask_bit != 0 {
-                let source = if source_from_cpu {
-                    if value & source_bit != 0 { 0xFF } else { 0x00 }
-                } else if (i as usize) < source_buffer_length {
+                let source = if (i as usize) < source_buffer_length {
                     self.state.last_vram_data[i as usize]
                 } else {
                     self.state.remain -= 1;
+                    processed_pixels += 1;
                     if self.state.remain == 0 {
                         break;
                     }
@@ -772,7 +862,8 @@ impl Pegc {
                 let destination = vram[pixel_address as usize];
 
                 if rop_enabled {
-                    let (pattern1, pattern2) = self.get_pattern_colors(rop_method, i as u32);
+                    let (pattern1, pattern2) =
+                        self.get_pattern_colors(rop_method, shifted_pixel_index);
                     let result = apply_rop(
                         rop_code,
                         source,
@@ -789,17 +880,85 @@ impl Pegc {
             }
 
             self.state.remain -= 1;
+            processed_pixels += 1;
             if self.state.remain == 0 {
                 break;
             }
         }
 
-        if self.state.remain == 0 && !extended_shift_mode && dest_shift != 0 {
-            self.state.skip_next_shifted_cpu_write = true;
+        if self.state.remain == 0
+            && !source_from_cpu
+            && !shift_direction_decrement
+            && source_shift != 0
+            && dest_shift != 0
+            && processed_pixels < data_length.max(0) as usize
+        {
+            for i in processed_pixels..data_length.max(0) as usize {
+                if i >= source_buffer_length {
+                    break;
+                }
+                let pixel_mask_bit = write_mask_position(i as u32);
+                if pixel_mask & pixel_mask_bit == 0 {
+                    continue;
+                }
+
+                let pixel_address =
+                    base_address.wrapping_add(i as u32) & (PEGC_VRAM_SIZE as u32 - 1);
+                let shifted_pixel_index = shifted_bit_offset + i as u32;
+                let source = self.state.last_vram_data[i];
+                let destination = vram[pixel_address as usize];
+
+                if rop_enabled {
+                    let (pattern1, pattern2) =
+                        self.get_pattern_colors(rop_method, shifted_pixel_index);
+                    let result = apply_rop(
+                        rop_code,
+                        source,
+                        destination,
+                        pattern1,
+                        pattern2,
+                        plane_mask,
+                    );
+                    vram[pixel_address as usize] = (destination & plane_mask) | result;
+                } else {
+                    vram[pixel_address as usize] =
+                        apply_source_copy(source, destination, plane_mask);
+                }
+            }
+        }
+
+        if self.state.remain == 0
+            && ((!extended_shift_mode && dest_shift != 0)
+                || (!source_from_cpu && source_shift != 0))
+        {
+            self.state.skip_next_shifted_padding_write = true;
+            self.state.shifted_padding_base_address = 0;
+            self.state.shifted_padding_pixels = 0;
+            if !source_from_cpu
+                && shift_direction_decrement
+                && source_shift != 0
+                && dest_shift != 0
+                && processed_pixels < pixels as usize
+            {
+                self.state.shifted_padding_base_address =
+                    base_address.wrapping_sub(processed_pixels as u32);
+                self.state.shifted_padding_pixels = pixels / 2;
+            } else if !source_from_cpu
+                && !shift_direction_decrement
+                && source_shift != 0
+                && dest_shift != 0
+                && processed_pixels < data_length.max(0) as usize
+            {
+                self.state.shifted_padding_pixels = pixels;
+            }
         }
 
         if source_from_cpu {
-            self.state.last_data_length = 0;
+            self.consume_source_buffer(processed_pixels);
+            if self.state.remain == 0 {
+                self.state.last_vram_data.fill(0);
+                self.state.last_data_length = 0;
+            }
         } else {
             self.consume_source_buffer(pixels as usize);
         }
@@ -1388,6 +1547,140 @@ mod tests {
     }
 
     #[test]
+    fn plane_mode_decrement_read_starts_before_word_boundary() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x0200;
+        pegc.state.block_length = 3;
+        pegc.state.remain = 4;
+
+        let mut vram = vec![0u8; PEGC_VRAM_SIZE];
+        vram[15] = 0xA0;
+        vram[14] = 0xA1;
+        vram[13] = 0xA2;
+        vram[12] = 0xA3;
+        vram[16] = 0xEE;
+
+        pegc.plane_read_word(2, &vram);
+
+        assert_eq!(&pegc.state.last_vram_data[..4], &[0xA0, 0xA1, 0xA2, 0xA3]);
+    }
+
+    #[test]
+    fn plane_mode_decrement_write_starts_before_word_boundary() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x0300;
+        pegc.state.write_mask = 0xFFFF;
+        pegc.state.block_length = 3;
+        pegc.state.remain = 4;
+
+        let mut vram = vec![0x77u8; PEGC_VRAM_SIZE];
+        pegc.plane_write_word(2, 0x00F0, &mut vram);
+
+        assert_eq!(vram[16], 0x77);
+        assert_eq!(vram[15], 0xFF);
+        assert_eq!(vram[14], 0xFF);
+        assert_eq!(vram[13], 0xFF);
+        assert_eq!(vram[12], 0xFF);
+        assert_eq!(vram[11], 0x77);
+    }
+
+    #[test]
+    fn plane_mode_decrement_shifted_vram_source_overlaps_toward_higher_pixels() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x12F0;
+        pegc.state.write_mask = 0xFFFF;
+        pegc.state.block_length = 25;
+        pegc.state.remain = 26;
+        pegc.state.shift_read = 4;
+        pegc.state.shift_write = 5;
+
+        let mut vram = vec![0u8; PEGC_VRAM_SIZE];
+        let source_high_pixel = 0x1000u32 * 8 + 3;
+        let destination_high_pixel = 0x2000u32 * 8 + 4;
+
+        for index in 0..26u32 {
+            vram[(source_high_pixel - index) as usize] = (index + 1) as u8;
+        }
+
+        pegc.plane_read_word(0x1000, &vram);
+        pegc.plane_write_word(0x2000, 0, &mut vram);
+        pegc.plane_read_word(0x0FFE, &vram);
+        pegc.plane_write_word(0x1FFE, 0, &mut vram);
+        pegc.plane_read_word(0x0FFC, &vram);
+        pegc.plane_write_word(0x1FFC, 0, &mut vram);
+
+        for index in 0..26u32 {
+            assert_eq!(
+                vram[(destination_high_pixel - index) as usize],
+                (index + 1) as u8,
+                "decrement shifted copy pixel {index}"
+            );
+        }
+        assert_eq!(pegc.state.remain, 0);
+    }
+
+    #[test]
+    fn plane_mode_decrement_shifted_vram_source_padding_fills_previous_byte() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x12F0;
+        pegc.state.write_mask = 0xFFFF;
+        pegc.state.block_length = 25;
+        pegc.state.remain = 26;
+        pegc.state.shift_read = 1;
+        pegc.state.shift_write = 12;
+
+        let mut vram = vec![0u8; PEGC_VRAM_SIZE];
+        let source_offset = 0x1004u32;
+        let destination_offset = 0x2004u32;
+        let destination_high_pixel = destination_offset * 8 + 11;
+
+        for offset in [0x1004u32, 0x1002, 0x1000] {
+            let source_base = offset * 8;
+            for i in 0..16u32 {
+                vram[(source_base - i) as usize] = 0xA0;
+            }
+        }
+        let padding_source_base = 0x1000u32 * 8;
+        for i in 0..16u32 {
+            vram[(padding_source_base + 4 - i) as usize] = 0x5A;
+        }
+
+        pegc.plane_read_word(source_offset, &vram);
+        pegc.plane_write_word(destination_offset, 0, &mut vram);
+        pegc.plane_read_word(source_offset - 2, &vram);
+        pegc.plane_write_word(destination_offset - 2, 0, &mut vram);
+        assert_eq!(pegc.state.remain, 0);
+
+        pegc.plane_read_word(source_offset - 4, &vram);
+        pegc.plane_write_word(destination_offset - 4, 0, &mut vram);
+
+        for index in 0..26u32 {
+            assert_eq!(
+                vram[(destination_high_pixel - index) as usize],
+                0xA0,
+                "logical decrement pixel {index}"
+            );
+        }
+        for index in 0..8u32 {
+            assert_eq!(
+                vram[(destination_high_pixel - 26 - index) as usize],
+                0x5A,
+                "padding decrement pixel {index}"
+            );
+        }
+        assert_eq!(pegc.state.remain, 26);
+        assert_eq!(pegc.state.last_data_length, 0);
+    }
+
+    #[test]
     fn plane_mode_shifted_cpu_source_aligned_block_skips_padding_word() {
         let mut pegc = Pegc::new();
         pegc.state.mode_register = 1;
@@ -1428,7 +1721,190 @@ mod tests {
             );
         }
         assert_eq!(pegc.state.remain, 32);
-        assert!(!pegc.state.skip_next_shifted_cpu_write);
+        assert!(!pegc.state.skip_next_shifted_padding_write);
+    }
+
+    #[test]
+    fn plane_mode_shifted_vram_source_skips_padding_write() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x10F0;
+        pegc.state.write_mask = 0xFFFF;
+        pegc.state.block_length = 4;
+        pegc.state.remain = 5;
+        pegc.state.shift_read = 6;
+
+        let mut vram = vec![0x77u8; PEGC_VRAM_SIZE];
+        let source_offset = 0x1000u32;
+        let source_pixel_base = source_offset * 8;
+        for i in 0..32u32 {
+            vram[(source_pixel_base + 6 + i) as usize] = (0xA0 + i) as u8;
+        }
+
+        let destination_offset = 0x2000u32;
+        let destination_pixel_base = destination_offset * 8;
+        pegc.plane_read_word(source_offset, &vram);
+        pegc.plane_write_word(destination_offset, 0, &mut vram);
+
+        for i in 0..5u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + i) as usize],
+                (0xA0 + i) as u8,
+                "pixel {i} should be copied before the padding write"
+            );
+        }
+        assert_eq!(vram[(destination_pixel_base + 5) as usize], 0x77);
+        assert_eq!(pegc.state.remain, 0);
+        assert!(pegc.state.skip_next_shifted_padding_write);
+
+        let padding_destination_offset = destination_offset + 2;
+        let padding_destination_pixel_base = padding_destination_offset * 8;
+        pegc.plane_read_word(source_offset + 2, &vram);
+        pegc.plane_write_word(padding_destination_offset, 0, &mut vram);
+
+        for i in 0..16u32 {
+            assert_eq!(
+                vram[(padding_destination_pixel_base + i) as usize],
+                0x77,
+                "padding pixel {i} should be untouched"
+            );
+        }
+        assert_eq!(pegc.state.remain, 5);
+        assert_eq!(pegc.state.last_data_length, 0);
+        assert!(!pegc.state.skip_next_shifted_padding_write);
+    }
+
+    #[test]
+    fn plane_mode_increment_shifted_vram_source_padding_starts_next_span() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x10F0;
+        pegc.state.write_mask = 0xFFFF;
+        pegc.state.block_length = 26;
+        pegc.state.remain = 27;
+        pegc.state.shift_read = 1;
+        pegc.state.shift_write = 12;
+
+        let mut vram = vec![0u8; PEGC_VRAM_SIZE];
+        let source_offset = 0x1000u32;
+        let destination_offset = 0x2000u32;
+        let destination_pixel_base = destination_offset * 8;
+        let source_pixel_base = source_offset * 8;
+
+        for i in 0..64u32 {
+            vram[(source_pixel_base + i) as usize] = 0xA0;
+        }
+        for i in 37..53u32 {
+            vram[(source_pixel_base + i) as usize] = 0x5A;
+        }
+
+        pegc.plane_read_word(source_offset, &vram);
+        pegc.plane_write_word(destination_offset, 0, &mut vram);
+        pegc.plane_read_word(source_offset + 2, &vram);
+        pegc.plane_write_word(destination_offset + 2, 0, &mut vram);
+        pegc.plane_read_word(source_offset + 4, &vram);
+        pegc.plane_write_word(destination_offset + 4, 0, &mut vram);
+        assert_eq!(pegc.state.remain, 0);
+
+        pegc.plane_read_word(source_offset + 6, &vram);
+        pegc.plane_write_word(destination_offset + 6, 0, &mut vram);
+
+        for i in 12..48u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + i) as usize],
+                0xA0,
+                "logical and flushed pixel {i}"
+            );
+        }
+        for i in 48..64u32 {
+            assert_eq!(
+                vram[(destination_pixel_base + i) as usize],
+                0x5A,
+                "padding pixel {i}"
+            );
+        }
+        assert_eq!(pegc.state.remain, 11);
+        assert_eq!(pegc.state.last_data_length, 0);
+    }
+
+    #[test]
+    fn plane_mode_shifted_cpu_source_uses_shifted_source_bits() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x0100;
+        pegc.state.write_mask = 0xFFFF;
+        pegc.state.block_length = 2;
+        pegc.state.remain = 3;
+        pegc.state.shift_read = 12;
+        pegc.state.shift_write = 12;
+
+        let mut vram = vec![0x77u8; PEGC_VRAM_SIZE];
+        pegc.plane_write_word(0, 0x0400, &mut vram);
+
+        for (pixel, value) in vram.iter().enumerate().take(12) {
+            assert_eq!(*value, 0x77, "pixel {pixel} before shift");
+        }
+        assert_eq!(vram[12], 0x00);
+        assert_eq!(vram[13], 0xFF);
+        assert_eq!(vram[14], 0x00);
+        assert_eq!(vram[15], 0x77);
+        assert_eq!(pegc.state.remain, 0);
+    }
+
+    #[test]
+    fn plane_mode_shifted_cpu_source_carries_tail_bits() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x0100;
+        pegc.state.write_mask = 0xFFFF;
+        pegc.state.block_length = 11;
+        pegc.state.remain = 12;
+        pegc.state.shift_read = 4;
+        pegc.state.shift_write = 5;
+
+        let mut vram = vec![0x77u8; PEGC_VRAM_SIZE];
+        let destination_offset = 0x2000u32;
+        let destination_pixel_base = destination_offset * 8;
+
+        pegc.plane_write_word(destination_offset, 0x0100, &mut vram);
+        pegc.plane_write_word(destination_offset + 2, 0x0000, &mut vram);
+
+        for i in 0..5u32 {
+            assert_eq!(vram[(destination_pixel_base + i) as usize], 0x77);
+        }
+        for i in 5..16u32 {
+            assert_eq!(vram[(destination_pixel_base + i) as usize], 0x00);
+        }
+        assert_eq!(vram[(destination_pixel_base + 16) as usize], 0xFF);
+        assert_eq!(vram[(destination_pixel_base + 17) as usize], 0x77);
+        assert_eq!(pegc.state.remain, 0);
+        assert_eq!(pegc.state.last_data_length, 0);
+    }
+
+    #[test]
+    fn plane_mode_shifted_pattern_rop_uses_shifted_pattern_bits() {
+        let mut pegc = Pegc::new();
+        pegc.state.mode_register = 1;
+        pegc.state.plane_access_mask = 0x00;
+        pegc.state.rop_register = 0x9166;
+        pegc.state.write_mask = 0xFFFF;
+        pegc.state.block_length = 2;
+        pegc.state.remain = 3;
+        pegc.state.shift_write = 12;
+        pegc.mmio_write_byte(MMIO2_BASE + REG_PATTERN + 13 * 4, 0xFF);
+
+        let mut vram = vec![0u8; PEGC_VRAM_SIZE];
+        pegc.plane_write_word(0, 0, &mut vram);
+
+        assert_eq!(vram[12], 0x00);
+        assert_eq!(vram[13], 0xFF);
+        assert_eq!(vram[14], 0x00);
+        assert_eq!(vram[15], 0x00);
+        assert_eq!(pegc.state.remain, 0);
     }
 
     #[test]

--- a/crates/machine/tests/pegc.rs
+++ b/crates/machine/tests/pegc.rs
@@ -314,6 +314,51 @@ fn pegc_plane_dword_write_bus_dispatch() {
     }
 }
 
+#[test]
+fn pegc_plane_dword_vram_source_word_block_copies_both_word_lanes() {
+    let mut bus = create_pegc_bus();
+    enable_pegc_packed_pixel(&mut bus);
+    bus.write_word(0xE0100, 0x0001);
+    bus.write_byte(0xE0102, 0x01);
+    bus.io_write_byte(0xF2, 0);
+
+    bus.write_word(0xE0108, 0x10F0);
+    bus.write_word(0xE010C, 0xFFFF);
+    bus.write_word(0xE010E, 0x0000);
+    bus.write_word(0xE0110, 0x000F);
+
+    let source_address = 0xB7000;
+    let destination_address = 0xA9000;
+    let source_pixel_base = (source_address - PEGC_VRAM_A) * 8;
+    let destination_pixel_base = (destination_address - PEGC_VRAM_A) * 8;
+
+    for pixel in 0..32u32 {
+        let value = if pixel < 16 {
+            0x20 + pixel as u8
+        } else {
+            0x60 + (pixel - 16) as u8
+        };
+        bus.write_byte(PEGC_LINEAR_FB_LOW + source_pixel_base + pixel, value);
+        bus.write_byte(PEGC_LINEAR_FB_LOW + destination_pixel_base + pixel, 0xE7);
+    }
+
+    let _ = bus.read_dword(source_address);
+    bus.write_dword(destination_address, 0);
+
+    for pixel in 0..32u32 {
+        let expected = if pixel < 16 {
+            0x20 + pixel as u8
+        } else {
+            0x60 + (pixel - 16) as u8
+        };
+        let actual = bus.read_byte(PEGC_LINEAR_FB_LOW + destination_pixel_base + pixel);
+        assert_eq!(
+            actual, expected,
+            "pixel {pixel} should be copied by the 32-bit word-block ROP"
+        );
+    }
+}
+
 /// Verifies that the renderer reads PEGC packed-pixel VRAM with a 640-byte
 /// scanline stride when the GDC is in 2.5 MHz mode.
 #[test]

--- a/crates/machine/tests/pegc.rs
+++ b/crates/machine/tests/pegc.rs
@@ -315,7 +315,7 @@ fn pegc_plane_dword_write_bus_dispatch() {
 }
 
 #[test]
-fn pegc_plane_dword_vram_source_word_block_copies_both_word_lanes() {
+fn pegc_plane_dword_vram_source_word_block_copies_one_configured_block() {
     let mut bus = create_pegc_bus();
     enable_pegc_packed_pixel(&mut bus);
     bus.write_word(0xE0100, 0x0001);
@@ -345,16 +345,19 @@ fn pegc_plane_dword_vram_source_word_block_copies_both_word_lanes() {
     let _ = bus.read_dword(source_address);
     bus.write_dword(destination_address, 0);
 
-    for pixel in 0..32u32 {
-        let expected = if pixel < 16 {
-            0x20 + pixel as u8
-        } else {
-            0x60 + (pixel - 16) as u8
-        };
+    for pixel in 0..16u32 {
+        let expected = 0x20 + pixel as u8;
         let actual = bus.read_byte(PEGC_LINEAR_FB_LOW + destination_pixel_base + pixel);
         assert_eq!(
             actual, expected,
-            "pixel {pixel} should be copied by the 32-bit word-block ROP"
+            "pixel {pixel} should be copied by the word-sized dword ROP"
+        );
+    }
+    for pixel in 16..32u32 {
+        let actual = bus.read_byte(PEGC_LINEAR_FB_LOW + destination_pixel_base + pixel);
+        assert_eq!(
+            actual, 0xE7,
+            "pixel {pixel} should be outside the word-sized dword ROP"
         );
     }
 }


### PR DESCRIPTION
I get some rare cases of corruption sometimes, but I can't currently replicate those cases in synthetic tests, so they are something I have debug when I revisit this later for Windows 95 for example.

Seems to best work under 640x480. 640x400 seems to trigger the defect easier. But overall it's now very usable all around.

<img width="2115" height="1677" alt="Screenshot_20260522_172300" src="https://github.com/user-attachments/assets/dc03bfd6-fc69-4199-876d-3efe2d9b895c" />
