### PR TITLE
fix: HDD OS VRAM access-page transfers for Tamashii no Mon

### DIFF
--- a/crates/machine/src/bus.rs
+++ b/crates/machine/src/bus.rs
@@ -548,8 +548,16 @@ impl<T: Tracing> Pc9801Bus<T> {
         if install_fdd640k_hle {
             self.fdd640k_hle.install_rom();
         }
+        let access_page = self.access_page_index();
+        let b_bank_ems = self.b_bank_ems;
+        let vram_ems_bank = self.vram_ems_bank;
         if let Some(os) = self.os.as_mut() {
-            let memory = os_adapter::OsMemoryAccess(&mut self.memory);
+            let memory = os_adapter::OsMemoryAccess::new(
+                &mut self.memory,
+                access_page,
+                b_bank_ems,
+                vram_ems_bank,
+            );
             os.invalidate_drive_caches(&memory, 0x90 | drive as u8);
         }
     }
@@ -567,8 +575,16 @@ impl<T: Tracing> Pc9801Bus<T> {
     /// Ejects the floppy disk from the specified drive, flushing if dirty.
     pub fn eject_floppy(&mut self, drive: usize) {
         self.floppy.eject_drive(drive);
+        let access_page = self.access_page_index();
+        let b_bank_ems = self.b_bank_ems;
+        let vram_ems_bank = self.vram_ems_bank;
         if let Some(os) = self.os.as_mut() {
-            let memory = os_adapter::OsMemoryAccess(&mut self.memory);
+            let memory = os_adapter::OsMemoryAccess::new(
+                &mut self.memory,
+                access_page,
+                b_bank_ems,
+                vram_ems_bank,
+            );
             os.invalidate_drive_caches(&memory, 0x90 | drive as u8);
         }
     }
@@ -603,8 +619,16 @@ impl<T: Tracing> Pc9801Bus<T> {
                 }
             }
         }
+        let access_page = self.access_page_index();
+        let b_bank_ems = self.b_bank_ems;
+        let vram_ems_bank = self.vram_ems_bank;
         if let Some(os) = self.os.as_mut() {
-            let memory = os_adapter::OsMemoryAccess(&mut self.memory);
+            let memory = os_adapter::OsMemoryAccess::new(
+                &mut self.memory,
+                access_page,
+                b_bank_ems,
+                vram_ems_bank,
+            );
             os.invalidate_drive_caches(&memory, 0x80 | drive as u8);
         }
     }
@@ -950,8 +974,14 @@ impl<T: Tracing> Pc9801Bus<T> {
 
     /// Returns a host-formatted overview of current HLE DOS memory usage.
     pub fn debug_memory_overview_lines(&mut self) -> Option<Vec<String>> {
+        let access_page = self.access_page_index();
         let os = self.os.as_ref()?;
-        let memory = os_adapter::OsMemoryAccess(&mut self.memory);
+        let memory = os_adapter::OsMemoryAccess::new(
+            &mut self.memory,
+            access_page,
+            self.b_bank_ems,
+            self.vram_ems_bank,
+        );
         Some(os.debug_memory_overview_lines(&memory))
     }
 
@@ -1021,8 +1051,12 @@ impl<T: Tracing> Pc9801Bus<T> {
                     }
                     return 0;
                 }
-                let page_base = self.access_page_index() * GRAPHICS_PAGE_SIZE_BYTES;
-                self.memory.state.graphics_vram[page_base + (address - 0xA8000) as usize]
+                self.memory.read_byte_with_access_page(
+                    address,
+                    self.access_page_index(),
+                    self.b_bank_ems,
+                    self.vram_ems_bank,
+                )
             }
             0xB0000..=0xBFFFF => {
                 if self.pegc.is_256_color_active() && address <= 0xB7FFF {
@@ -1032,12 +1066,12 @@ impl<T: Tracing> Pc9801Bus<T> {
                     }
                     return 0;
                 }
-                if self.b_bank_ems && self.vram_ems_bank & 0x02 != 0 {
-                    self.memory.read_byte(0x100000 + (address - 0xB0000))
-                } else {
-                    let page_base = self.access_page_index() * GRAPHICS_PAGE_SIZE_BYTES;
-                    self.memory.state.graphics_vram[page_base + (address - 0xA8000) as usize]
-                }
+                self.memory.read_byte_with_access_page(
+                    address,
+                    self.access_page_index(),
+                    self.b_bank_ems,
+                    self.vram_ems_bank,
+                )
             }
             // 640KB FDD HLE ROM overlay (PC-9801-09-compatible expansion ROM area).
             0xD6000..=0xD6FFF => {
@@ -1067,12 +1101,12 @@ impl<T: Tracing> Pc9801Bus<T> {
                 if self.pegc.is_256_color_active() {
                     return self.pegc.mmio_read_byte(address - 0xE0000);
                 }
-                if self.memory.state.e_plane_enabled {
-                    let page_base = self.access_page_index() * E_PLANE_PAGE_SIZE_BYTES;
-                    self.memory.state.e_plane_vram[page_base + (address - 0xE0000) as usize]
-                } else {
-                    0xFF
-                }
+                self.memory.read_byte_with_access_page(
+                    address,
+                    self.access_page_index(),
+                    self.b_bank_ems,
+                    self.vram_ems_bank,
+                )
             }
             _ => {
                 if self.machine_model.has_pegc() {
@@ -1128,8 +1162,13 @@ impl<T: Tracing> Pc9801Bus<T> {
                     }
                     return;
                 }
-                let page_base = self.access_page_index() * GRAPHICS_PAGE_SIZE_BYTES;
-                self.memory.state.graphics_vram[page_base + (address - 0xA8000) as usize] = value;
+                self.memory.write_byte_with_access_page(
+                    address,
+                    self.access_page_index(),
+                    self.b_bank_ems,
+                    self.vram_ems_bank,
+                    value,
+                );
             }
             0xB0000..=0xBFFFF => {
                 if self.pegc.is_256_color_active() && address <= 0xB7FFF {
@@ -1140,25 +1179,26 @@ impl<T: Tracing> Pc9801Bus<T> {
                     }
                     return;
                 }
-                if self.b_bank_ems && self.vram_ems_bank & 0x02 != 0 {
-                    self.memory
-                        .write_byte(0x100000 + (address - 0xB0000), value);
-                } else {
-                    let page_base = self.access_page_index() * GRAPHICS_PAGE_SIZE_BYTES;
-                    self.memory.state.graphics_vram[page_base + (address - 0xA8000) as usize] =
-                        value;
-                }
+                self.memory.write_byte_with_access_page(
+                    address,
+                    self.access_page_index(),
+                    self.b_bank_ems,
+                    self.vram_ems_bank,
+                    value,
+                );
             }
             0xE0000..=0xE7FFF => {
                 if self.pegc.is_256_color_active() {
                     self.pegc.mmio_write_byte(address - 0xE0000, value);
                     return;
                 }
-                if self.memory.state.e_plane_enabled {
-                    let page_base = self.access_page_index() * E_PLANE_PAGE_SIZE_BYTES;
-                    self.memory.state.e_plane_vram[page_base + (address - 0xE0000) as usize] =
-                        value;
-                }
+                self.memory.write_byte_with_access_page(
+                    address,
+                    self.access_page_index(),
+                    self.b_bank_ems,
+                    self.vram_ems_bank,
+                    value,
+                );
             }
             _ => {
                 if self.machine_model.has_pegc() {

--- a/crates/machine/src/bus/bios.rs
+++ b/crates/machine/src/bus/bios.rs
@@ -194,7 +194,13 @@ impl<T: Tracing> Pc9801Bus<T> {
             0x20..=0x2A | 0x2F | 0x33 | 0x67 | 0xDC | 0xE7 | 0xFE => {
                 if let Some(mut neetan_os) = self.os.take() {
                     let mut cpu_access = OsCpuAccess(cpu);
-                    let mut mem_access = OsMemoryAccess(&mut self.memory);
+                    let access_page = self.access_page_index();
+                    let mut mem_access = OsMemoryAccess::new(
+                        &mut self.memory,
+                        access_page,
+                        self.b_bank_ems,
+                        self.vram_ems_bank,
+                    );
                     let mut disk_io = OsDiskIo {
                         floppy: &mut self.floppy,
                         sasi: &mut self.sasi,

--- a/crates/machine/src/bus/bios/bootstrap.rs
+++ b/crates/machine/src/bus/bios/bootstrap.rs
@@ -239,7 +239,13 @@ impl<T: Tracing> Pc9801Bus<T> {
 
         {
             let mut cpu_access = OsCpuAccess(cpu);
-            let mut mem_access = OsMemoryAccess(&mut self.memory);
+            let access_page = self.access_page_index();
+            let mut mem_access = OsMemoryAccess::new(
+                &mut self.memory,
+                access_page,
+                self.b_bank_ems,
+                self.vram_ems_bank,
+            );
             let mut disk_io = OsDiskIo {
                 floppy: &mut self.floppy,
                 sasi: &mut self.sasi,

--- a/crates/machine/src/bus/os_adapter.rs
+++ b/crates/machine/src/bus/os_adapter.rs
@@ -147,55 +147,87 @@ impl<C: Cpu> CpuAccess for OsCpuAccess<'_, C> {
     }
 }
 
-pub(super) struct OsMemoryAccess<'a>(pub &'a mut Pc9801Memory);
+pub(super) struct OsMemoryAccess<'a> {
+    memory: &'a mut Pc9801Memory,
+    access_page: usize,
+    b_bank_ems: bool,
+    vram_ems_bank: u8,
+}
+
+impl<'a> OsMemoryAccess<'a> {
+    pub(super) fn new(
+        memory: &'a mut Pc9801Memory,
+        access_page: usize,
+        b_bank_ems: bool,
+        vram_ems_bank: u8,
+    ) -> Self {
+        Self {
+            memory,
+            access_page,
+            b_bank_ems,
+            vram_ems_bank,
+        }
+    }
+}
 
 impl MemoryAccess for OsMemoryAccess<'_> {
     fn read_byte(&self, address: u32) -> u8 {
-        self.0.read_byte(address)
+        self.memory.read_byte_with_access_page(
+            address,
+            self.access_page,
+            self.b_bank_ems,
+            self.vram_ems_bank,
+        )
     }
 
     fn write_byte(&mut self, address: u32, value: u8) {
-        self.0.write_byte(address, value);
+        self.memory.write_byte_with_access_page(
+            address,
+            self.access_page,
+            self.b_bank_ems,
+            self.vram_ems_bank,
+            value,
+        );
     }
 
     fn read_word(&self, address: u32) -> u16 {
-        let lo = self.0.read_byte(address) as u16;
-        let hi = self.0.read_byte(address + 1) as u16;
+        let lo = self.read_byte(address) as u16;
+        let hi = self.read_byte(address + 1) as u16;
         lo | (hi << 8)
     }
 
     fn write_word(&mut self, address: u32, value: u16) {
-        self.0.write_byte(address, value as u8);
-        self.0.write_byte(address + 1, (value >> 8) as u8);
+        self.write_byte(address, value as u8);
+        self.write_byte(address + 1, (value >> 8) as u8);
     }
 
     fn read_block(&self, address: u32, buf: &mut [u8]) {
         for (i, byte) in buf.iter_mut().enumerate() {
-            *byte = self.0.read_byte(address + i as u32);
+            *byte = self.read_byte(address + i as u32);
         }
     }
 
     fn write_block(&mut self, address: u32, data: &[u8]) {
         for (i, &byte) in data.iter().enumerate() {
-            self.0.write_byte(address + i as u32, byte);
+            self.write_byte(address + i as u32, byte);
         }
     }
 
     fn extended_memory_size(&self) -> u32 {
-        self.0.extended_memory_size()
+        self.memory.extended_memory_size()
     }
 
     fn enable_ems_page_frame(&mut self) {
-        self.0.enable_ems_page_frame();
+        self.memory.enable_ems_page_frame();
     }
 
     fn map_ems_page_frame_slot(&mut self, physical_page: u8, backing_linear_addr: Option<u32>) {
-        self.0
+        self.memory
             .map_ems_page_frame_slot(physical_page, backing_linear_addr);
     }
 
     fn enable_umb_region(&mut self) {
-        self.0.enable_umb_region();
+        self.memory.enable_umb_region();
     }
 }
 

--- a/crates/machine/src/memory.rs
+++ b/crates/machine/src/memory.rs
@@ -747,6 +747,62 @@ impl Pc9801Memory {
         }
     }
 
+    pub(crate) fn read_byte_with_access_page(
+        &self,
+        address: u32,
+        access_page: usize,
+        b_bank_ems: bool,
+        vram_ems_bank: u8,
+    ) -> u8 {
+        let address = address & self.address_mask;
+        match address {
+            GRAPHICS_VRAM_START..=GRAPHICS_VRAM_END => {
+                if (0xB0000..=0xBFFFF).contains(&address) && b_bank_ems && vram_ems_bank & 0x02 != 0
+                {
+                    self.read_byte(EXTENDED_RAM_START + (address - 0xB0000))
+                } else {
+                    let page_base = access_page * GRAPHICS_VRAM_PAGE_SIZE;
+                    self.graphics_vram[page_base + (address - GRAPHICS_VRAM_START) as usize]
+                }
+            }
+            E_PLANE_VRAM_START..=E_PLANE_VRAM_END if self.e_plane_enabled => {
+                let page_base = access_page * E_PLANE_VRAM_PAGE_SIZE;
+                self.e_plane_vram[page_base + (address - E_PLANE_VRAM_START) as usize]
+            }
+            E_PLANE_VRAM_START..=E_PLANE_VRAM_END => 0xFF,
+            _ => self.read_byte(address),
+        }
+    }
+
+    pub(crate) fn write_byte_with_access_page(
+        &mut self,
+        address: u32,
+        access_page: usize,
+        b_bank_ems: bool,
+        vram_ems_bank: u8,
+        value: u8,
+    ) {
+        let address = address & self.address_mask;
+        match address {
+            GRAPHICS_VRAM_START..=GRAPHICS_VRAM_END => {
+                if (0xB0000..=0xBFFFF).contains(&address) && b_bank_ems && vram_ems_bank & 0x02 != 0
+                {
+                    self.write_byte(EXTENDED_RAM_START + (address - 0xB0000), value);
+                } else {
+                    let page_base = access_page * GRAPHICS_VRAM_PAGE_SIZE;
+                    self.graphics_vram[page_base + (address - GRAPHICS_VRAM_START) as usize] =
+                        value;
+                }
+            }
+            E_PLANE_VRAM_START..=E_PLANE_VRAM_END if self.e_plane_enabled => {
+                let page_base = access_page * E_PLANE_VRAM_PAGE_SIZE;
+                self.e_plane_vram[page_base + (address - E_PLANE_VRAM_START) as usize] = value;
+            }
+            E_PLANE_VRAM_START..=E_PLANE_VRAM_END => {}
+            _ => self.write_byte(address, value),
+        }
+    }
+
     /// Loads a V98-format font ROM (0x46800 bytes) into the internal font buffer.
     ///
     /// Converts from V98 file layout to the interleaved fontrom format used by

--- a/crates/os/tests/dos620/syscalls_int21h_file_io.rs
+++ b/crates/os/tests/dos620/syscalls_int21h_file_io.rs
@@ -1,3 +1,4 @@
+use common::Bus;
 use os::tables;
 
 use crate::harness;
@@ -343,6 +344,59 @@ fn read_from_file() {
         &read_back,
         &harness::TEST_COMMAND_COM[..2],
         "Read data should match first 2 bytes of COMMAND.COM"
+    );
+
+    close_file(&mut machine, handle);
+}
+
+#[test]
+fn read_from_file_uses_vram_access_page() {
+    let mut machine = harness::boot_hle_with_floppy();
+
+    machine.bus.io_write_byte(0xA6, 0x00);
+    machine.bus.write_byte(0xA8000, 0xAA);
+    machine.bus.io_write_byte(0xA6, 0x01);
+    machine.bus.write_byte(0xA8000, 0xAA);
+
+    let handle = open_file(&mut machine, b"A:\\TESTFILE.TXT\0");
+    let handle_lo = (handle & 0xFF) as u8;
+    let handle_hi = (handle >> 8) as u8;
+
+    #[rustfmt::skip]
+    let code: Vec<u8> = vec![
+        0xBB, handle_lo, handle_hi,         // MOV BX, handle
+        0x1E,                               // PUSH DS
+        0xB8, 0x00, 0xA8,                   // MOV AX, A800h
+        0x8E, 0xD8,                         // MOV DS, AX
+        0xB9, 0x02, 0x00,                   // MOV CX, 0002h
+        0x31, 0xD2,                         // XOR DX, DX
+        0xB4, 0x3F,                         // MOV AH, 3Fh
+        0xCD, 0x21,                         // INT 21h
+        0x9C,                               // PUSHF
+        0x50,                               // PUSH AX
+        0x0E,                               // PUSH CS
+        0x1F,                               // POP DS
+        0x58,                               // POP AX
+        0xA3, 0x00, 0x01,                   // MOV [0x0100], AX
+        0x58,                               // POP AX
+        0xA3, 0x02, 0x01,                   // MOV [0x0102], AX
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run_with_budget(&mut machine, &code, harness::INJECT_BUDGET_DISK_IO);
+
+    let flags = harness::result_word(&machine.bus, 2);
+    assert_eq!(flags & 0x0001, 0, "read should succeed");
+    assert_eq!(harness::result_word(&machine.bus, 0), 2);
+    assert_eq!(
+        machine.bus.graphics_vram()[0],
+        0xAA,
+        "page 0 must be untouched"
+    );
+    assert_eq!(
+        machine.bus.graphics_vram()[0x18000],
+        harness::TEST_FILE_CONTENT[0],
+        "file data should land on graphics access page 1"
     );
 
     close_file(&mut machine, handle);


### PR DESCRIPTION
This removes the last blocker when using the HLE OS with Tamashii no Mon. The gameplay now fully works correctly.