### PR TITLE
fix: HLE DOS memory handling for Mujintou Monogatari 3 startup

### DIFF
--- a/crates/os/src/dos.rs
+++ b/crates/os/src/dos.rs
@@ -148,6 +148,7 @@ impl NeetanOs {
             0x63 => self.int21h_63h_dbcs_support(cpu),
             0x64 => {}
             0x65 => self.int21h_65h_get_extended_country_info(cpu, memory),
+            0x67 => self.int21h_67h_set_handle_count(cpu, memory),
             0x68 | 0x6A => self.int21h_68h_commit_file(cpu, memory),
             0x69 => self.int21h_69h_get_set_media_info(cpu, memory),
             0x6B => {
@@ -1152,10 +1153,15 @@ impl NeetanOs {
         // Memory top segment.
         memory.write_word(base + tables::PSP_OFF_MEM_TOP, mem_top);
 
-        // Copy handle table from parent PSP.
         let parent_base = (self.state.current_psp as u32) << 4;
+        let (parent_jft_addr, parent_jft_size) =
+            crate::OsState::handle_table_info_for_psp(memory, self.state.current_psp);
         for i in 0..20u32 {
-            let handle = memory.read_byte(parent_base + tables::PSP_OFF_JFT + i);
+            let handle = if i < parent_jft_size as u32 {
+                memory.read_byte(parent_jft_addr + i)
+            } else {
+                0xFF
+            };
             memory.write_byte(base + tables::PSP_OFF_JFT + i, handle);
         }
 
@@ -1177,6 +1183,84 @@ impl NeetanOs {
 
         // INT 21h / RETF stub at PSP:0050h.
         memory.write_block(base + tables::PSP_OFF_INT21_STUB, &[0xCD, 0x21, 0xCB]);
+    }
+
+    /// AH=67h: Set handle count.
+    /// BX = requested number of handles for the current process.
+    fn int21h_67h_set_handle_count(
+        &mut self,
+        cpu: &mut dyn CpuAccess,
+        memory: &mut dyn MemoryAccess,
+    ) {
+        let requested = cpu.bx();
+        if requested > u8::MAX as u16 + 1 {
+            cpu.set_ax(0x0004);
+            set_iret_carry(cpu, memory, true);
+            return;
+        }
+
+        let psp_base = (self.state.current_psp as u32) << 4;
+        let (old_table_addr, current_size) = self.state.handle_table_info(memory);
+        if requested <= current_size {
+            set_iret_carry(cpu, memory, false);
+            return;
+        }
+
+        let paragraphs = requested.div_ceil(16);
+        let first_mcb = memory.read_word(self.state.sysvars_base - 2);
+        let umb_first = if self.state.umb_link
+            && self
+                .state
+                .memory_manager
+                .as_ref()
+                .is_some_and(|mm| mm.is_umb_enabled())
+        {
+            Some(tables::UMB_FIRST_MCB_SEGMENT)
+        } else {
+            None
+        };
+
+        let new_segment = match memory::allocate_dos(
+            memory,
+            first_mcb,
+            umb_first,
+            paragraphs,
+            self.state.current_psp,
+            self.state.allocation_strategy,
+        ) {
+            Ok(segment) => segment,
+            Err((error_code, largest)) => {
+                cpu.set_ax(error_code as u16);
+                cpu.set_bx(largest);
+                set_iret_carry(cpu, memory, true);
+                return;
+            }
+        };
+
+        let new_table_addr = (new_segment as u32) << 4;
+        for i in 0..requested as u32 {
+            memory.write_byte(new_table_addr + i, 0xFF);
+        }
+        for i in 0..current_size as u32 {
+            let handle = memory.read_byte(old_table_addr + i);
+            memory.write_byte(new_table_addr + i, handle);
+        }
+
+        let old_offset = memory.read_word(psp_base + tables::PSP_OFF_HANDLE_PTR);
+        let old_segment = memory.read_word(psp_base + tables::PSP_OFF_HANDLE_PTR + 2);
+        memory.write_word(psp_base + tables::PSP_OFF_HANDLE_SIZE, requested);
+        tables::write_far_ptr(
+            memory,
+            psp_base + tables::PSP_OFF_HANDLE_PTR,
+            new_segment,
+            0x0000,
+        );
+
+        if old_segment != self.state.current_psp || old_offset != tables::PSP_OFF_JFT as u16 {
+            let _ = memory::free_dos(memory, first_mcb, umb_first, old_segment);
+        }
+
+        set_iret_carry(cpu, memory, false);
     }
 
     /// AH=68h / AH=6Ah: Commit (flush) file.

--- a/crates/os/src/file_io.rs
+++ b/crates/os/src/file_io.rs
@@ -335,7 +335,7 @@ impl NeetanOs {
                 .unwrap_or(self.state.current_drive);
             let (handle, sft_index) = self.state.allocate_handle(memory)?;
             self.write_sft_for_file(memory, sft_index, &created, drive_index, 0x0002);
-            Ok(handle as u16)
+            Ok(handle)
         })();
 
         match result {
@@ -373,7 +373,7 @@ impl NeetanOs {
                     tables::DEV_EMS_OFFSET,
                     open_mode as u16,
                 );
-                return Ok(handle as u16);
+                return Ok(handle);
             }
             if is_xms_probe {
                 let (handle, sft_index) = self.state.allocate_handle(memory)?;
@@ -384,7 +384,7 @@ impl NeetanOs {
                     tables::DEV_XMS_OFFSET,
                     open_mode as u16,
                 );
-                return Ok(handle as u16);
+                return Ok(handle);
             }
 
             let read_path =
@@ -404,7 +404,7 @@ impl NeetanOs {
                     .ok_or(0x0002u16)?;
                 let (handle, sft_index) = self.state.allocate_handle(memory)?;
                 self.write_sft_for_virtual_file(memory, sft_index, ventry, open_mode as u16);
-                return Ok(handle as u16);
+                return Ok(handle);
             }
 
             let (handle, sft_index) = self.state.allocate_handle(memory)?;
@@ -437,7 +437,7 @@ impl NeetanOs {
                     self.state.open_iso_files[sft_index as usize] = Some(entry.clone());
                 }
             }
-            Ok(handle as u16)
+            Ok(handle)
         })();
 
         match result {
@@ -828,24 +828,14 @@ impl NeetanOs {
             let sft_index = self.state.handle_to_sft_index(handle, memory)?;
             let sft_addr = self.state.sft_entry_addr(sft_index).ok_or(0x0006u16)?;
 
-            // Find a free JFT slot
-            let psp_base = (self.state.current_psp as u32) << 4;
-            let mut new_handle = None;
-            for h in 0..20u16 {
-                let jft_entry = memory.read_byte(psp_base + tables::PSP_OFF_JFT + h as u32);
-                if jft_entry == 0xFF {
-                    new_handle = Some(h);
-                    break;
-                }
-            }
-            let new_h = new_handle.ok_or(0x0004u16)?;
+            let new_handle = self.state.find_free_jft_handle(memory)?;
 
             // Point new handle to same SFT entry
-            memory.write_byte(psp_base + tables::PSP_OFF_JFT + new_h as u32, sft_index);
+            self.state.write_jft_entry(new_handle, sft_index, memory)?;
             let ref_count = memory.read_word(sft_addr + tables::SFT_ENT_REF_COUNT);
             memory.write_word(sft_addr + tables::SFT_ENT_REF_COUNT, ref_count + 1);
 
-            Ok(new_h)
+            Ok(new_handle)
         })();
 
         match result {

--- a/crates/os/src/lib.rs
+++ b/crates/os/src/lib.rs
@@ -1801,6 +1801,63 @@ impl NeetanOs {
 }
 
 impl OsState {
+    pub(crate) fn handle_table_info_for_psp(
+        mem: &dyn MemoryAccess,
+        psp_segment: u16,
+    ) -> (u32, u16) {
+        let psp_base = (psp_segment as u32) << 4;
+        let size = mem.read_word(psp_base + tables::PSP_OFF_HANDLE_SIZE);
+        let offset = mem.read_word(psp_base + tables::PSP_OFF_HANDLE_PTR);
+        let segment = mem.read_word(psp_base + tables::PSP_OFF_HANDLE_PTR + 2);
+
+        if size == 0 || segment == 0 {
+            (psp_base + tables::PSP_OFF_JFT, 20)
+        } else {
+            (((segment as u32) << 4) + offset as u32, size)
+        }
+    }
+
+    pub(crate) fn handle_table_info(&self, mem: &dyn MemoryAccess) -> (u32, u16) {
+        Self::handle_table_info_for_psp(mem, self.current_psp)
+    }
+
+    fn jft_entry_addr(&self, handle: u16, mem: &dyn MemoryAccess) -> Result<u32, u16> {
+        let (table_addr, table_size) = self.handle_table_info(mem);
+        if handle >= table_size || handle > u8::MAX as u16 {
+            return Err(0x0006);
+        }
+        Ok(table_addr + handle as u32)
+    }
+
+    pub(crate) fn read_jft_entry(&self, handle: u16, mem: &dyn MemoryAccess) -> Result<u8, u16> {
+        let entry_addr = self.jft_entry_addr(handle, mem)?;
+        Ok(mem.read_byte(entry_addr))
+    }
+
+    pub(crate) fn write_jft_entry(
+        &self,
+        handle: u16,
+        sft_index: u8,
+        mem: &mut dyn MemoryAccess,
+    ) -> Result<(), u16> {
+        let entry_addr = self.jft_entry_addr(handle, mem)?;
+        mem.write_byte(entry_addr, sft_index);
+        Ok(())
+    }
+
+    pub(crate) fn find_free_jft_handle(&self, mem: &dyn MemoryAccess) -> Result<u16, u16> {
+        let (table_addr, table_size) = self.handle_table_info(mem);
+        let search_limit = table_size.min(u8::MAX as u16 + 1);
+
+        for handle in 0..search_limit {
+            if mem.read_byte(table_addr + handle as u32) == 0xFF {
+                return Ok(handle);
+            }
+        }
+
+        Err(0x0004)
+    }
+
     /// Returns the SFT entry base address for a given SFT index (0-based).
     pub(crate) fn sft_entry_addr(&self, sft_index: u8) -> Option<u32> {
         use tables::*;
@@ -1821,11 +1878,7 @@ impl OsState {
         handle: u16,
         mem: &dyn MemoryAccess,
     ) -> Result<u8, u16> {
-        let psp_base = (self.current_psp as u32) << 4;
-        if handle >= 20 {
-            return Err(0x0006); // invalid handle
-        }
-        let jft_entry = mem.read_byte(psp_base + tables::PSP_OFF_JFT + handle as u32);
+        let jft_entry = self.read_jft_entry(handle, mem)?;
         if jft_entry == 0xFF {
             return Err(0x0006);
         }
@@ -1833,23 +1886,12 @@ impl OsState {
     }
 
     /// Allocates a free JFT slot and a free SFT entry. Returns (handle, sft_index).
-    pub(crate) fn allocate_handle(&self, mem: &mut dyn MemoryAccess) -> Result<(u8, u8), u16> {
-        let psp_base = (self.current_psp as u32) << 4;
-
-        // Find free JFT slot
-        let mut free_handle = None;
-        for h in 0..20u8 {
-            let jft_entry = mem.read_byte(psp_base + tables::PSP_OFF_JFT + h as u32);
-            if jft_entry == 0xFF {
-                free_handle = Some(h);
-                break;
-            }
-        }
-        let handle = free_handle.ok_or(0x0004u16)?; // too many open files
+    pub(crate) fn allocate_handle(&self, mem: &mut dyn MemoryAccess) -> Result<(u16, u8), u16> {
+        let handle = self.find_free_jft_handle(mem)?;
 
         // Find free SFT entry (skip first 5 device entries)
         let mut free_sft = None;
-        let total_count = tables::SFT_INITIAL_COUNT + self.sft2_count;
+        let total_count = (tables::SFT_INITIAL_COUNT + self.sft2_count).min(0x00FF);
         for idx in tables::SFT_INITIAL_COUNT..total_count {
             if let Some(addr) = self.sft_entry_addr(idx as u8) {
                 let ref_count = mem.read_word(addr + tables::SFT_ENT_REF_COUNT);
@@ -1862,22 +1904,20 @@ impl OsState {
         let sft_index = free_sft.ok_or(0x0004u16)?;
 
         // Link handle to SFT entry
-        mem.write_byte(psp_base + tables::PSP_OFF_JFT + handle as u32, sft_index);
+        self.write_jft_entry(handle, sft_index, mem)?;
 
         Ok((handle, sft_index))
     }
 
     /// Frees a handle: sets JFT entry to 0xFF, decrements SFT ref_count.
     pub(crate) fn free_handle(&self, handle: u16, mem: &mut dyn MemoryAccess) {
-        let psp_base = (self.current_psp as u32) << 4;
-        if handle >= 20 {
+        let Ok(sft_index) = self.read_jft_entry(handle, mem) else {
             return;
-        }
-        let sft_index = mem.read_byte(psp_base + tables::PSP_OFF_JFT + handle as u32);
+        };
         if sft_index == 0xFF {
             return;
         }
-        mem.write_byte(psp_base + tables::PSP_OFF_JFT + handle as u32, 0xFF);
+        let _ = self.write_jft_entry(handle, 0xFF, mem);
         if let Some(sft_addr) = self.sft_entry_addr(sft_index) {
             let ref_count = mem.read_word(sft_addr + tables::SFT_ENT_REF_COUNT);
             if ref_count > 0 {

--- a/crates/os/src/memory.rs
+++ b/crates/os/src/memory.rs
@@ -849,6 +849,15 @@ pub(crate) fn resize(
     let current_size = read_mcb_size(mem, target_mcb);
     let block_type = read_mcb_type(mem, target_mcb);
 
+    if block_type != MCB_TYPE_Z {
+        let next_segment = target_mcb + current_size + 1;
+        if is_valid_mcb_type(read_mcb_type(mem, next_segment))
+            && read_mcb_owner(mem, next_segment) == MCB_OWNER_FREE
+        {
+            coalesce_chain_from(mem, next_segment);
+        }
+    }
+
     // Compute the maximum size this particular block could grow to (current
     // plus any immediately-following free block). Used for both the
     // query-only path (new_paragraphs == 0xFFFF) and as the error-return
@@ -1000,6 +1009,15 @@ pub(crate) fn resize_without_grow_failure(
 
     let current_size = read_mcb_size(mem, target_mcb);
     let block_type = read_mcb_type(mem, target_mcb);
+    if block_type != MCB_TYPE_Z {
+        let next_segment = target_mcb + current_size + 1;
+        if is_valid_mcb_type(read_mcb_type(mem, next_segment))
+            && read_mcb_owner(mem, next_segment) == MCB_OWNER_FREE
+        {
+            coalesce_chain_from(mem, next_segment);
+        }
+    }
+
     let max_growable = if block_type == MCB_TYPE_Z {
         current_size
     } else {
@@ -1246,6 +1264,23 @@ fn coalesce_chain(mem: &mut dyn MemoryAccess, first_mcb_segment: u16) {
             return;
         }
         current = current + read_mcb_size(mem, current) + 1;
+    }
+}
+
+fn coalesce_chain_from(mem: &mut dyn MemoryAccess, segment: u16) {
+    loop {
+        let block_type = read_mcb_type(mem, segment);
+        if block_type != MCB_TYPE_M || read_mcb_owner(mem, segment) != MCB_OWNER_FREE {
+            return;
+        }
+
+        let next_segment = segment + read_mcb_size(mem, segment) + 1;
+        let next_type = read_mcb_type(mem, next_segment);
+        if !is_valid_mcb_type(next_type) || read_mcb_owner(mem, next_segment) != MCB_OWNER_FREE {
+            return;
+        }
+
+        coalesce_forward(mem, segment);
     }
 }
 

--- a/crates/os/src/process.rs
+++ b/crates/os/src/process.rs
@@ -40,6 +40,11 @@ pub(crate) struct SftBases {
     pub secondary: u32,
 }
 
+fn allocated_block_end_segment(mem: &dyn MemoryAccess, data_segment: u16) -> u16 {
+    let mcb_addr = ((data_segment - 1) as u32) << 4;
+    data_segment.wrapping_add(mem.read_word(mcb_addr + MCB_OFF_SIZE))
+}
+
 /// Writes a 256-byte Program Segment Prefix at the given segment.
 ///
 /// `psp_segment`: segment where the PSP is placed.
@@ -293,10 +298,11 @@ pub(crate) fn write_psp_command_tail(
 fn write_environment_program_path(
     mem: &mut dyn MemoryAccess,
     env_segment: u16,
+    env_paragraphs: u16,
     program_path: &[u8],
 ) {
     let base = (env_segment as u32) << 4;
-    let block_size = ENV_BLOCK_PARAGRAPHS as u32 * 16;
+    let block_size = env_paragraphs as u32 * 16;
 
     let mut offset = 0u32;
     while offset + 1 < block_size {
@@ -324,6 +330,22 @@ fn write_environment_program_path(
     mem.write_byte(base + offset + path_len as u32, 0x00);
 }
 
+fn environment_block_size_bytes(mem: &dyn MemoryAccess, env_segment: u16) -> usize {
+    let mcb_addr = ((env_segment.wrapping_sub(1)) as u32) << 4;
+    mem.read_word(mcb_addr + MCB_OFF_SIZE) as usize * 16
+}
+
+fn environment_strings_len(mem: &dyn MemoryAccess, env_segment: u16, max_bytes: usize) -> usize {
+    let base = (env_segment as u32) << 4;
+    for offset in 0..max_bytes.saturating_sub(1) {
+        if mem.read_byte(base + offset as u32) == 0 && mem.read_byte(base + offset as u32 + 1) == 0
+        {
+            return offset + 2;
+        }
+    }
+    2
+}
+
 fn allocate_child_environment(
     mem: &mut dyn MemoryAccess,
     first_mcb: u16,
@@ -332,27 +354,40 @@ fn allocate_child_environment(
     allocation_strategy: u16,
     program_path: &[u8],
 ) -> Result<u16, u16> {
+    let env_paragraphs = if source_env == 0 {
+        environment_block_paragraphs(b"Z:\\COMMAND.COM", 0)
+            .max(environment_block_paragraphs(program_path, 0))
+    } else {
+        let source_size = environment_block_size_bytes(mem, source_env);
+        let strings_len = environment_strings_len(mem, source_env, source_size);
+        (strings_len + 2 + program_path.len() + 1).div_ceil(16) as u16
+    };
+
     let env_segment = memory::allocate_dos(
         mem,
         first_mcb,
         umb_first_mcb,
-        ENV_BLOCK_PARAGRAPHS,
+        env_paragraphs,
         MCB_OWNER_DOS,
         allocation_strategy,
     )
     .map_err(|(e, _)| e as u16)?;
 
     if source_env == 0 {
-        write_environment_block(mem, env_segment, ENV_BLOCK_PARAGRAPHS, b"Z:\\COMMAND.COM");
+        write_environment_block(mem, env_segment, env_paragraphs, b"Z:\\COMMAND.COM");
     } else {
         let source_base = (source_env as u32) << 4;
         let dest_base = (env_segment as u32) << 4;
-        let mut env_data = [0u8; ENV_BLOCK_PARAGRAPHS as usize * 16];
-        mem.read_block(source_base, &mut env_data);
+        let source_size = environment_block_size_bytes(mem, source_env);
+        let strings_len = environment_strings_len(mem, source_env, source_size);
+        let mut env_data = vec![0u8; env_paragraphs as usize * 16];
+        for (offset, byte) in env_data.iter_mut().take(strings_len).enumerate() {
+            *byte = mem.read_byte(source_base + offset as u32);
+        }
         mem.write_block(dest_base, &env_data);
     }
 
-    write_environment_program_path(mem, env_segment, program_path);
+    write_environment_program_path(mem, env_segment, env_paragraphs, program_path);
 
     Ok(env_segment)
 }
@@ -372,6 +407,52 @@ fn dos_allocation_umb_first(state: &OsState) -> Option<u16> {
 
 fn child_allocation_owner() -> u16 {
     MCB_OWNER_DOS
+}
+
+fn allocate_exe_memory(
+    mem: &mut dyn MemoryAccess,
+    first_mcb: u16,
+    umb_first: Option<u16>,
+    allocation_strategy: u16,
+    image_paragraphs: u16,
+    min_alloc: u16,
+    max_alloc: u16,
+) -> Result<u16, u16> {
+    let required = 0x10u32 + image_paragraphs as u32;
+    let min_needed = required + min_alloc as u32;
+    if min_needed > u16::MAX as u32 {
+        return Err(0x0008);
+    }
+
+    let min_needed = min_needed as u16;
+    let requested = (required + max_alloc as u32)
+        .min(u16::MAX as u32)
+        .max(min_needed as u32) as u16;
+
+    match memory::allocate_dos(
+        mem,
+        first_mcb,
+        umb_first,
+        requested,
+        child_allocation_owner(),
+        allocation_strategy,
+    ) {
+        Ok(segment) => Ok(segment),
+        Err((error_code, largest)) => {
+            if largest < min_needed {
+                return Err(error_code as u16);
+            }
+            memory::allocate_dos(
+                mem,
+                first_mcb,
+                umb_first,
+                largest,
+                child_allocation_owner(),
+                allocation_strategy,
+            )
+            .map_err(|(e, _)| e as u16)
+        }
+    }
 }
 
 /// Writes the COMMAND.COM code stub at PSP:0100h.
@@ -397,11 +478,15 @@ pub(crate) fn write_child_psp(
     write_psp(mem, child_psp, parent_psp, env_segment, mem_top);
 
     let child_base = (child_psp as u32) << 4;
-    let parent_base = (parent_psp as u32) << 4;
 
-    // Inherit parent's JFT and increment SFT ref counts.
+    // Inherit the first 20 parent handles and increment SFT ref counts.
+    let (parent_jft_addr, parent_jft_size) = OsState::handle_table_info_for_psp(mem, parent_psp);
     for i in 0..20u32 {
-        let sft_index = mem.read_byte(parent_base + PSP_OFF_JFT + i);
+        let sft_index = if i < parent_jft_size as u32 {
+            mem.read_byte(parent_jft_addr + i)
+        } else {
+            0xFF
+        };
         mem.write_byte(child_base + PSP_OFF_JFT + i, sft_index);
         if sft_index != 0xFF
             && let Some(sft_addr) =
@@ -669,12 +754,13 @@ impl NeetanOs {
         mem.write_word(((mcb_segment as u32) << 4) + MCB_OFF_OWNER, child_psp);
         mem.write_word(((env_segment as u32 - 1) << 4) + MCB_OFF_OWNER, child_psp);
 
+        let child_mem_top = allocated_block_end_segment(mem, child_psp);
         write_child_psp(
             mem,
             child_psp,
             self.state.current_psp,
             env_segment,
-            MEMORY_TOP_SEGMENT,
+            child_mem_top,
             params,
             SftBases {
                 primary: SFT_BASE,
@@ -745,47 +831,30 @@ impl NeetanOs {
             program_path,
         )?;
 
-        let total_needed = psp_paragraphs
-            .saturating_add(image_paragraphs)
-            .saturating_add(max_alloc);
-        let child_psp = match memory::allocate_dos(
+        let child_psp = allocate_exe_memory(
             mem,
             first_mcb,
             umb_first,
-            total_needed,
-            child_allocation_owner(),
             self.state.allocation_strategy,
-        ) {
-            Ok(seg) => seg,
-            Err(_) => {
-                let min_needed = psp_paragraphs
-                    .saturating_add(image_paragraphs)
-                    .saturating_add(min_alloc);
-                memory::allocate_dos(
-                    mem,
-                    first_mcb,
-                    umb_first,
-                    min_needed,
-                    child_allocation_owner(),
-                    self.state.allocation_strategy,
-                )
-                .map_err(|(e, _)| {
-                    let _ = memory::free_dos(mem, first_mcb, umb_first, env_segment);
-                    e as u16
-                })?
-            }
-        };
+            image_paragraphs,
+            min_alloc,
+            max_alloc,
+        )
+        .inspect_err(|_| {
+            let _ = memory::free_dos(mem, first_mcb, umb_first, env_segment);
+        })?;
 
         let mcb_segment = child_psp - 1;
         mem.write_word(((mcb_segment as u32) << 4) + MCB_OFF_OWNER, child_psp);
         mem.write_word(((env_segment as u32 - 1) << 4) + MCB_OFF_OWNER, child_psp);
 
+        let child_mem_top = allocated_block_end_segment(mem, child_psp);
         write_child_psp(
             mem,
             child_psp,
             self.state.current_psp,
             env_segment,
-            MEMORY_TOP_SEGMENT,
+            child_mem_top,
             params,
             SftBases {
                 primary: SFT_BASE,
@@ -875,12 +944,13 @@ impl NeetanOs {
         mem.write_word(((env_segment as u32 - 1) << 4) + MCB_OFF_OWNER, child_psp);
 
         // Write child PSP with inherited handles, command tail, FCBs.
+        let child_mem_top = allocated_block_end_segment(mem, child_psp);
         write_child_psp(
             mem,
             child_psp,
             self.state.current_psp,
             env_segment,
-            MEMORY_TOP_SEGMENT,
+            child_mem_top,
             params,
             SftBases {
                 primary: SFT_BASE,
@@ -969,37 +1039,18 @@ impl NeetanOs {
             program_path,
         )?;
 
-        // Try with max_alloc first, fall back to min_alloc.
-        let total_needed = psp_paragraphs
-            .saturating_add(image_paragraphs)
-            .saturating_add(max_alloc);
-        let child_psp = match memory::allocate_dos(
+        let child_psp = allocate_exe_memory(
             mem,
             first_mcb,
             umb_first,
-            total_needed,
-            child_allocation_owner(),
             self.state.allocation_strategy,
-        ) {
-            Ok(seg) => seg,
-            Err(_) => {
-                let min_needed = psp_paragraphs
-                    .saturating_add(image_paragraphs)
-                    .saturating_add(min_alloc);
-                memory::allocate_dos(
-                    mem,
-                    first_mcb,
-                    umb_first,
-                    min_needed,
-                    child_allocation_owner(),
-                    self.state.allocation_strategy,
-                )
-                .map_err(|(e, _)| {
-                    let _ = memory::free_dos(mem, first_mcb, umb_first, env_segment);
-                    e as u16
-                })?
-            }
-        };
+            image_paragraphs,
+            min_alloc,
+            max_alloc,
+        )
+        .inspect_err(|_| {
+            let _ = memory::free_dos(mem, first_mcb, umb_first, env_segment);
+        })?;
 
         // Set MCB owner to child PSP.
         let mcb_segment = child_psp - 1;
@@ -1007,12 +1058,13 @@ impl NeetanOs {
         mem.write_word(((env_segment as u32 - 1) << 4) + MCB_OFF_OWNER, child_psp);
 
         // Write child PSP.
+        let child_mem_top = allocated_block_end_segment(mem, child_psp);
         write_child_psp(
             mem,
             child_psp,
             self.state.current_psp,
             env_segment,
-            MEMORY_TOP_SEGMENT,
+            child_mem_top,
             params,
             SftBases {
                 primary: SFT_BASE,
@@ -1123,12 +1175,9 @@ impl NeetanOs {
         let child_psp_base = (child_psp as u32) << 4;
         let is_shell_process = self.shells.remove(&child_psp).is_some();
 
-        // Close all JFT handles owned by the child.
-        for handle in 0..20u16 {
-            let sft_index = mem.read_byte(child_psp_base + PSP_OFF_JFT + handle as u32);
-            if sft_index != 0xFF {
-                self.state.free_handle(handle, mem);
-            }
+        let (_, handle_count) = OsState::handle_table_info_for_psp(mem, child_psp);
+        for handle in 0..handle_count.min(u8::MAX as u16 + 1) {
+            self.state.free_handle(handle, mem);
         }
 
         // Free all MCBs owned by the child.
@@ -1207,12 +1256,9 @@ impl NeetanOs {
         let child_psp_base = (child_psp as u32) << 4;
         self.shells.remove(&child_psp);
 
-        // Close all JFT handles owned by the child.
-        for handle in 0..20u16 {
-            let sft_index = mem.read_byte(child_psp_base + PSP_OFF_JFT + handle as u32);
-            if sft_index != 0xFF {
-                self.state.free_handle(handle, mem);
-            }
+        let (_, handle_count) = OsState::handle_table_info_for_psp(mem, child_psp);
+        for handle in 0..handle_count.min(u8::MAX as u16 + 1) {
+            self.state.free_handle(handle, mem);
         }
 
         // Resize PSP's MCB and free other blocks.

--- a/crates/os/tests/dos620/environment.rs
+++ b/crates/os/tests/dos620/environment.rs
@@ -460,6 +460,12 @@ fn exec_load_only_com_uses_child_program_path() {
         child_env_seg, parent_env_seg,
         "Load-only COM should allocate a separate child environment"
     );
+    let child_env_mcb = child_env_seg.wrapping_sub(1);
+    let child_env_size = harness::read_word(&machine.bus, harness::far_to_linear(child_env_mcb, 3));
+    assert_eq!(
+        child_env_size, 5,
+        "Child environment should be compact, got {child_env_size} paragraphs"
+    );
 
     let (count, pathname) = read_program_path_from_environment(&machine.bus, child_env_seg);
     assert_eq!(

--- a/crates/os/tests/dos620/process_management.rs
+++ b/crates/os/tests/dos620/process_management.rs
@@ -585,6 +585,30 @@ fn exec_exe_and_get_return_code() {
     exec_file_and_check_return_code(&mut machine, b"A:\\TEST.EXE\x00", 0x0042);
 }
 
+#[test]
+fn exec_exe_max_alloc_gets_largest_available_block() {
+    let code: &[u8] = &[
+        0xA1, 0x02, 0x00, // MOV AX, [0002h] (PSP memory top)
+        0x16, // PUSH SS
+        0x5B, // POP BX
+        0x2B, 0xC3, // SUB AX, BX
+        0x3D, 0x00, 0x01, // CMP AX, 0100h
+        0xB0, 0x01, // MOV AL, 01h
+        0x72, 0x02, // JC short exit
+        0xB0, 0x42, // MOV AL, 42h
+        0xB4, 0x4C, // MOV AH, 4Ch
+        0xCD, 0x21, // INT 21h
+    ];
+    let exe_data = build_exe(code, 0, 0, 256);
+
+    let mut machine = boot_hle_with_floppy();
+    machine.bus.eject_floppy(0);
+    let floppy = create_test_floppy_with_program(b"TEST    EXE", &exe_data);
+    machine.bus.insert_floppy(0, floppy, None);
+
+    exec_file_and_check_return_code(&mut machine, b"A:\\TEST.EXE\x00", 0x0042);
+}
+
 /// EXEC a .EXE with a relocation entry and verify it runs correctly.
 #[test]
 fn exec_exe_with_relocation() {

--- a/crates/os/tests/dos620/syscalls_int21h.rs
+++ b/crates/os/tests/dos620/syscalls_int21h.rs
@@ -1,3 +1,5 @@
+use os::tables;
+
 use crate::harness;
 
 #[test]
@@ -82,6 +84,45 @@ fn get_set_interrupt_vector() {
         "INT 60h segment should be 0x1234 after set, got {:#06X}",
         segment
     );
+}
+
+#[test]
+fn set_handle_count_expands_jft() {
+    let mut machine = harness::boot_hle();
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xBB, 0x28, 0x00,                   // MOV BX, 40
+        0xB4, 0x67,                         // MOV AH, 67h
+        0xCD, 0x21,                         // INT 21h
+        0x9C,                               // PUSHF
+        0x58,                               // POP AX
+        0xA3, 0x00, 0x01,                   // MOV [0x0100], AX
+        0xFA,                               // CLI
+        0xF4,                               // HLT
+    ];
+    harness::inject_and_run(&mut machine, code);
+
+    let flags = harness::result_word(&machine.bus, 0);
+    assert_eq!(flags & 0x0001, 0, "AH=67h should clear carry");
+
+    let psp_segment = harness::get_psp_segment(&mut machine);
+    let psp_base = harness::far_to_linear(psp_segment, 0);
+    let handle_count = harness::read_word(&machine.bus, psp_base + tables::PSP_OFF_HANDLE_SIZE);
+    let (jft_segment, jft_offset) =
+        harness::read_far_ptr(&machine.bus, psp_base + tables::PSP_OFF_HANDLE_PTR);
+    let jft_base = harness::far_to_linear(jft_segment, jft_offset);
+
+    assert_eq!(handle_count, 40);
+    assert_ne!((jft_segment, jft_offset), (psp_segment, 0x0018));
+    for handle in 0..5u32 {
+        assert_eq!(
+            harness::read_byte(&machine.bus, jft_base + handle),
+            handle as u8
+        );
+    }
+    for handle in 5..40u32 {
+        assert_eq!(harness::read_byte(&machine.bus, jft_base + handle), 0xFF);
+    }
 }
 
 #[test]
@@ -1951,6 +1992,40 @@ fn int21h_4ah_resize_grows_into_adjacent_free_block() {
     let a_mcb = a_data.wrapping_sub(1);
     let size = harness::read_word(&machine.bus, harness::far_to_linear(a_mcb, 3));
     assert_eq!(size, 0x21, "A should be resized to 0x21, got {:#06X}", size);
+}
+
+#[test]
+fn int21h_4ah_resize_grows_into_adjacent_free_run() {
+    let mut machine = harness::boot_hle();
+    #[rustfmt::skip]
+    let code: &[u8] = &[
+        0xBB, 0x10, 0x00, 0xB4, 0x48, 0xCD, 0x21,
+        0xA3, 0x00, 0x01,                   // A
+        0xBB, 0x10, 0x00, 0xB4, 0x48, 0xCD, 0x21,
+        0xA3, 0x02, 0x01,                   // B
+        0xBB, 0x10, 0x00, 0xB4, 0x48, 0xCD, 0x21,
+        0xA3, 0x04, 0x01,                   // C
+        0xBB, 0x10, 0x00, 0xB4, 0x48, 0xCD, 0x21, // D sentinel
+        0x8B, 0x1E, 0x02, 0x01, 0x8E, 0xC3, 0xB4, 0x49, 0xCD, 0x21,
+        0x8B, 0x1E, 0x04, 0x01, 0x8E, 0xC3, 0xB4, 0x49, 0xCD, 0x21,
+        0x8B, 0x1E, 0x00, 0x01, 0x8E, 0xC3,
+        0xBB, 0x32, 0x00, 0xB4, 0x4A, 0xCD, 0x21,
+        0x9C, 0x58, 0xA3, 0x06, 0x01,
+        0xFA, 0xF4,
+    ];
+    harness::inject_and_run(&mut machine, code);
+
+    let a_data = harness::result_word(&machine.bus, 0);
+    let flags = harness::result_word(&machine.bus, 6);
+    assert_eq!(
+        flags & 1,
+        0,
+        "Grow into adjacent free run should succeed, flags={:#06X}",
+        flags
+    );
+    let a_mcb = a_data.wrapping_sub(1);
+    let size = harness::read_word(&machine.bus, harness::far_to_linear(a_mcb, 3));
+    assert_eq!(size, 0x32, "A should be resized to 0x32, got {:#06X}", size);
 }
 
 #[test]


### PR DESCRIPTION
Add INT 21h AH=67h handle-count support with relocated JFT handling, fix MZ EXE max_alloc fallback to use the largest available block, compact child EXEC environments, and allow SETBLOCK growth across adjacent free MCB runs.