### PR TITLE
fix: i386 x87 FCOMPP decode

### DIFF
--- a/crates/cpu/src/i386/fpu_dispatch.rs
+++ b/crates/cpu/src/i386/fpu_dispatch.rs
@@ -407,7 +407,8 @@ impl<const CPU_MODEL: u8> I386<CPU_MODEL> {
             match reg {
                 0 => self.fpu_faddp_sti_st0(i),
                 1 => self.fpu_fmulp_sti_st0(i),
-                2 => {
+                2 => self.clk(Self::timing(2, 2)), // reserved
+                3 => {
                     if modrm == 0xD9 {
                         self.fpu_fcompp();
                     } else {

--- a/crates/cpu/tests/x87_i386.rs
+++ b/crates/cpu/tests/x87_i386.rs
@@ -1102,6 +1102,17 @@ fn fcom_basic() {
 }
 
 #[test]
+fn fcompp_pops_both_operands() {
+    let r = run_x87(&[0xDE, 0xD9], &[Fp80::ONE, Fp80::ZERO]);
+    assert!(!r.c3());
+    assert!(!r.c2());
+    assert!(!r.c0());
+    assert_eq!(r.tag(0), 0b11);
+    assert_eq!(r.tag(1), 0b11);
+    assert!(r.no_exceptions());
+}
+
+#[test]
 fn fcom_edge_cases() {
     // QNaN -> Unordered + IE (ordered comparison raises IE on ANY NaN)
     let r = run_x87(&[0xD8, 0xD1], &[POSITIVE_QNAN, Fp80::ONE]);


### PR DESCRIPTION
Decode DE D9 through the correct x87 reg group so FCOMPP executes and pops both operands instead of being treated as reserved.