### PR TITLE
fix: HLE DOS A20 handling for Power Dolls 2 startup

### DIFF
--- a/crates/dos/src/interrupt/xms.rs
+++ b/crates/dos/src/interrupt/xms.rs
@@ -40,8 +40,8 @@ impl NeetanDos {
                 }
             },
             0x03 => {
-                // Global Enable A20. On PC-98 A20 is always physically
-                // enabled; track the XMS-visible state only.
+                // Global Enable A20. Track the XMS-visible state only; the
+                // machine A20 gate remains port-controlled.
                 mm.xms_global_enable_a20();
                 cpu.set_ax(1);
             }
@@ -73,8 +73,8 @@ impl NeetanDos {
                 }
             }
             0x07 => {
-                // Query A20 reports the XMS-visible state, not the PC-98
-                // physical line state.
+                // Query A20 reports the XMS-visible state, not the machine
+                // gate state.
                 if mm.xms_query_a20() {
                     cpu.set_ax(1);
                     cpu.set_bx(cpu.bx() & 0xFF00);

--- a/crates/dos/src/memory/memory_manager.rs
+++ b/crates/dos/src/memory/memory_manager.rs
@@ -115,10 +115,9 @@ pub(crate) struct MemoryManager {
     umb_enabled: bool,
     umb_first_mcb_segment: u16,
 
-    // XMS A20 state. PC-98 hardware has no A20 line (A20 is permanently
-    // enabled), so these fields only track API-level state so that
+    // XMS A20 state. These fields only track API-level state so that
     // applications see the correct nesting-counter semantics required by
-    // XMS 3.0 A20 Management. No machine-level gate is driven.
+    // XMS 3.0 A20 Management. The machine A20 gate remains port-controlled.
     a20_global_enabled: bool,
     a20_local_enable_count: u32,
 
@@ -231,9 +230,8 @@ impl MemoryManager {
             hma_allocated: false,
             umb_enabled,
             umb_first_mcb_segment,
-            // HIMEM globally enables the A20 line when it loads; on PC-98 it
-            // then stays enabled (real DOS reports A20 on both via the
-            // physical gate and the XMS query for the lifetime of HIMEM).
+            // HIMEM reports A20 as globally enabled through the XMS API.
+            // The physical machine gate is still controlled by hardware ports.
             a20_global_enabled: xms_enabled,
             a20_local_enable_count: 0,
             hmamin_kb: 0,
@@ -283,8 +281,8 @@ impl MemoryManager {
         Ok(())
     }
 
-    /// Function 07h: Query A20. PC-98 has no A20 gate so the physical line
-    /// is always enabled, but XMS still exposes a virtual visible state.
+    /// Function 07h: Query A20. Reports the XMS-visible state, independent
+    /// of the machine A20 gate.
     pub(crate) fn xms_query_a20(&self) -> bool {
         self.a20_global_enabled || self.a20_local_enable_count > 0
     }

--- a/crates/dos/tests/dos620/memory_manager_ems_xms.rs
+++ b/crates/dos/tests/dos620/memory_manager_ems_xms.rs
@@ -2068,7 +2068,7 @@ fn test_xms_a20_query_tracks_xms_visible_state() {
     let disabled = harness::result_word(&machine.bus, 4);
     assert_eq!(
         initial, 1,
-        "Query A20 should report enabled from HIMEM load (PC-98 keeps A20 on), got {initial:#06X}"
+        "Query A20 should report enabled from HIMEM load, got {initial:#06X}"
     );
     assert_eq!(
         enabled, 1,
@@ -2154,15 +2154,14 @@ fn test_xms_a20_global_disable_blocked_by_local_enable() {
 }
 
 #[test]
-fn test_xms_a20_calls_drive_machine_a20_gate() {
-    // Real PC-98 MS-DOS keeps the A20 line enabled for the lifetime of HIMEM:
-    // the physical gate (port 0x00F2 bit 0 == 0) and the XMS query both report
-    // enabled at the prompt and stay enabled across XMS local enable/disable.
+fn test_xms_a20_calls_do_not_drive_machine_a20_gate() {
+    // HLE XMS tracks the DOS-visible A20 state, while the PC-98 machine gate
+    // remains controlled by the hardware ports.
     let mut machine = harness::boot_hle();
     assert_eq!(
         machine.bus.io_read_byte(0x00F2) & 0x01,
-        0x00,
-        "machine A20 gate should be enabled at the prompt (HIMEM loaded)"
+        0x01,
+        "machine A20 gate should remain masked at the prompt"
     );
 
     #[rustfmt::skip]
@@ -2181,8 +2180,8 @@ fn test_xms_a20_calls_drive_machine_a20_gate() {
     );
     assert_eq!(
         machine.bus.io_read_byte(0x00F2) & 0x01,
-        0x00,
-        "machine A20 gate should stay enabled after XMS local enable"
+        0x01,
+        "XMS local enable should not unmask the machine A20 gate"
     );
 
     #[rustfmt::skip]
@@ -2201,8 +2200,8 @@ fn test_xms_a20_calls_drive_machine_a20_gate() {
     );
     assert_eq!(
         machine.bus.io_read_byte(0x00F2) & 0x01,
-        0x00,
-        "machine A20 gate should stay enabled after XMS local disable (HIMEM global enable persists)"
+        0x01,
+        "XMS local disable should not unmask the machine A20 gate"
     );
 }
 

--- a/crates/machine/src/bus/bios.rs
+++ b/crates/machine/src/bus/bios.rs
@@ -246,9 +246,6 @@ impl<T: Tracing> Pc9801Bus<T> {
                         &mut cursor_access,
                         &mut self.tracer,
                     );
-                    if let Some(a20_enabled) = neetan_dos.xms_a20_enabled() {
-                        self.a20_enabled = a20_enabled;
-                    }
                     self.dos = Some(neetan_dos);
                 }
             }


### PR DESCRIPTION
We used MS DOS 6.20 HIMEM to assert its behavior:

- HIMEM installs XMS (INT 2F AX=4300h returns AL=80h).
- XMS Query A20 returns enabled.
- XMS local enable/disable both succeed.
- PC-98 hardware A20 remains unmasked (port F2 bit0 = 0).
- Physical memory does not wrap at 1 MB.