### PR TITLE
fix: HLE DOS graphic-character menu rendering

### DIFF
--- a/crates/dos/src/console.rs
+++ b/crates/dos/src/console.rs
@@ -719,6 +719,24 @@ mod tests {
     }
 
     #[test]
+    fn process_byte_graphic_mode_does_not_pair_shift_jis_leads() {
+        let mut console = make_console();
+        let mut memory = make_memory();
+
+        feed_str(&mut console, &mut memory, "\x1b)3");
+        console.process_byte(&mut memory, 0x86);
+        console.process_byte(&mut memory, 0x86);
+
+        assert_eq!(
+            memory.read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_KANJI_HI_FLAG),
+            0x00
+        );
+        assert_vram_char(&memory, 0, 0, 0x86, 0x00);
+        assert_vram_char(&memory, 0, 1, 0x86, 0x00);
+        assert_cursor(&console, &memory, 0, 2);
+    }
+
+    #[test]
     fn process_byte_invalid_shift_jis_trail_falls_back_to_single_byte() {
         let mut console = make_console();
         let mut memory = make_memory();

--- a/crates/dos/src/console_esc.rs
+++ b/crates/dos/src/console_esc.rs
@@ -65,6 +65,10 @@ impl EscParser {
 }
 
 impl Console {
+    fn shift_jis_mode_enabled(&self, memory: &dyn MemoryAccess) -> bool {
+        memory.read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_KANJI_MODE) != 0
+    }
+
     /// Main entry point: feed one byte into the console output pipeline.
     /// Handles control characters, ESC sequences, and printable output.
     pub(crate) fn process_byte(&mut self, memory: &mut dyn MemoryAccess, byte: u8) {
@@ -84,7 +88,10 @@ impl Console {
             return;
         }
 
-        if self.esc_parser.state == EscState::Normal && is_shift_jis_lead_byte(byte) {
+        if self.esc_parser.state == EscState::Normal
+            && self.shift_jis_mode_enabled(memory)
+            && is_shift_jis_lead_byte(byte)
+        {
             self.set_pending_shift_jis_lead(memory, byte);
             return;
         }


### PR DESCRIPTION
This fixes the issue when rendering the start menu of MS DOS 3.30D.