### PR TITLE
fix: fix YMFM channel balance

### DIFF
--- a/crates/device/src/soundboard_26k.rs
+++ b/crates/device/src/soundboard_26k.rs
@@ -416,8 +416,8 @@ impl Soundboard26k {
                 self.resample_input.resize(total_native, 0.0);
             }
 
-            const FM_SCALE: f32 = 1.25 / 32768.0;
-            const SSG_SCALE: f32 = 1.0 / 32768.0;
+            const FM_SCALE: f32 = 1.0 / 32768.0;
+            const SSG_SCALE: f32 = (1.0 / 3.0) / 32768.0;
 
             for i in 0..pending_count {
                 let s = &self.pending_native[i];

--- a/crates/device/src/soundboard_86.rs
+++ b/crates/device/src/soundboard_86.rs
@@ -1409,7 +1409,7 @@ impl Soundboard86 {
                 self.resample_input.resize(total_interleaved, 0.0);
             }
 
-            const FM_SCALE: f32 = 1.25 / 32768.0;
+            const FM_SCALE: f32 = 2.0 / 32768.0;
             const SSG_SCALE: f32 = 1.0 / 32768.0;
 
             for i in 0..pending_count {


### PR DESCRIPTION
The old values made SSG channel way too loud for both the OPN and also OPNA.
YMFM seems to use different scales for FM and PSG on both OPN and OPNA.

OPN and OPNA also output now roughly the same RMS.