### PR TITLE
fix: correct SSG scaling for the 86

### DIFF
--- a/crates/device/src/soundboard_86.rs
+++ b/crates/device/src/soundboard_86.rs
@@ -1410,7 +1410,7 @@ impl Soundboard86 {
             }
 
             const FM_SCALE: f32 = 2.0 / 32768.0;
-            const SSG_SCALE: f32 = 1.0 / 32768.0;
+            const SSG_SCALE: f32 = 0.5 / 32768.0;
 
             for i in 0..pending_count {
                 let s = &self.pending_native[i];


### PR DESCRIPTION
This was the intended value int the rebalance PR, but somehow this got lost. "0.5" is the correct value for correctly sounding FM and SSG on the 86.