### PR TITLE
chore: make some core crates no_std compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "common",
  "cpu",
  "machine",
+ "software_renderer",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ sdl3-use-vcpkg = ["sdl3/use-vcpkg"]
 [dependencies]
 audio_engine = { workspace = true }
 cpu = { workspace = true }
-common = { workspace = true }
+common = { workspace = true, features = ["std"] }
 device = { workspace = true }
 machine = { workspace = true }
 dos = { workspace = true }

--- a/crates/blake3/src/lib.rs
+++ b/crates/blake3/src/lib.rs
@@ -12,6 +12,7 @@
 //! hasher.finalize(&mut extended_hash);
 //! assert_eq!(hash, extended_hash[..32]);
 //! ```
+#![cfg_attr(not(test), no_std)]
 
 use core::cmp::min;
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -7,4 +7,8 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[features]
+default = []
+std = []
+
 [dependencies]

--- a/crates/common/src/dos.rs
+++ b/crates/common/src/dos.rs
@@ -1,5 +1,7 @@
 //! Shared OS/machine bridge traits and related media types.
 
+use alloc::vec::Vec;
+
 use crate::{SegmentRegister, jis::JisChar};
 
 /// CPU register access for the HLE DOS.

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -1,16 +1,20 @@
 //! Error types, context traits, and macros for error handling.
 
-use std::borrow::Cow;
+use alloc::{
+    borrow::{Cow, ToOwned},
+    boxed::Box,
+    string::String,
+};
 
 /// An error that wraps a source error with a context message.
 pub struct ContextError {
-    source: Box<dyn std::error::Error + Send + Sync>,
+    source: Box<dyn core::error::Error + Send + Sync>,
     context: Cow<'static, str>,
 }
 
 impl ContextError {
     fn new(
-        source: impl std::error::Error + Send + Sync + 'static,
+        source: impl core::error::Error + Send + Sync + 'static,
         context: Cow<'static, str>,
     ) -> Self {
         Self {
@@ -20,8 +24,8 @@ impl ContextError {
     }
 }
 
-impl std::fmt::Display for ContextError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for ContextError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
             write!(f, "{}: {:#}", self.context, self.source)
         } else {
@@ -30,14 +34,14 @@ impl std::fmt::Display for ContextError {
     }
 }
 
-impl std::fmt::Debug for ContextError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ContextError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{self:#}")
     }
 }
 
-impl std::error::Error for ContextError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ContextError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         Some(&*self.source)
     }
 }
@@ -45,19 +49,19 @@ impl std::error::Error for ContextError {
 /// A simple string-based error.
 pub struct StringError(pub String);
 
-impl std::fmt::Display for StringError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for StringError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(&self.0)
     }
 }
 
-impl std::fmt::Debug for StringError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for StringError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{self}")
     }
 }
 
-impl std::error::Error for StringError {}
+impl core::error::Error for StringError {}
 
 /// Extension trait on `Result<T, E>` for adding context to errors.
 pub trait Context<T, E> {
@@ -68,7 +72,7 @@ pub trait Context<T, E> {
     fn with_context<F: FnOnce() -> String>(self, f: F) -> Result<T, ContextError>;
 }
 
-impl<T, E: std::error::Error + Send + Sync + 'static> Context<T, E> for Result<T, E> {
+impl<T, E: core::error::Error + Send + Sync + 'static> Context<T, E> for Result<T, E> {
     fn context(self, msg: &'static str) -> Result<T, ContextError> {
         self.map_err(|e| ContextError::new(e, Cow::Borrowed(msg)))
     }

--- a/crates/common/src/jis.rs
+++ b/crates/common/src/jis.rs
@@ -2,6 +2,8 @@
 
 mod tables;
 
+use alloc::{string::String, vec::Vec};
+
 use tables::{ANK_TO_UNICODE, JIS_TO_UNICODE, UNICODE_TO_JIS};
 
 /// A character in JIS encoding as used by the PC-98 text VRAM.

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -7,10 +7,18 @@
 
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+use alloc::string::ToString;
+use alloc::{boxed::Box, format, string::String};
 
 mod dos;
 pub mod error;
 mod jis;
+#[cfg(feature = "std")]
 pub mod log;
 mod stack_vec;
 mod text_extractor;
@@ -71,8 +79,8 @@ pub enum CpuMode {
     High,
 }
 
-impl std::fmt::Display for CpuMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for CpuMode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Low => f.write_str("low"),
             Self::High => f.write_str("high"),
@@ -80,7 +88,7 @@ impl std::fmt::Display for CpuMode {
     }
 }
 
-impl std::str::FromStr for CpuMode {
+impl core::str::FromStr for CpuMode {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -414,8 +422,8 @@ impl MachineModel {
     }
 }
 
-impl std::fmt::Display for MachineModel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for MachineModel {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::PC9801F => f.write_str("PC9801F"),
             Self::PC9801VM => f.write_str("PC9801VM"),
@@ -427,7 +435,7 @@ impl std::fmt::Display for MachineModel {
     }
 }
 
-impl std::str::FromStr for MachineModel {
+impl core::str::FromStr for MachineModel {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -1157,6 +1165,7 @@ pub trait Machine {
 
     /// Inserts a floppy disk image into the specified drive (0-based).
     /// Reads the file, auto-detects format, and inserts. Returns a description string on success.
+    #[cfg(feature = "std")]
     fn insert_floppy(&mut self, drive: usize, path: &std::path::Path) -> Result<String, String>;
 
     /// Ejects the floppy disk from the specified drive, flushing any dirty data first.
@@ -1167,6 +1176,7 @@ pub trait Machine {
     /// files, and inserts. Returns a description string on success.
     ///
     /// The default returns an error for machines without a CD-ROM drive.
+    #[cfg(feature = "std")]
     fn insert_cdrom(&mut self, _path: &std::path::Path) -> Result<String, String> {
         Err("CD-ROM is not supported on this machine".to_string())
     }
@@ -1440,6 +1450,7 @@ mod tests {
             &self.font_rom
         }
 
+        #[cfg(feature = "std")]
         fn insert_floppy(
             &mut self,
             _drive: usize,
@@ -1460,6 +1471,7 @@ mod tests {
             font_rom: Vec::new(),
         };
 
+        #[cfg(feature = "std")]
         assert!(
             machine
                 .insert_cdrom(std::path::Path::new("image.cue"))

--- a/crates/common/src/stack_vec.rs
+++ b/crates/common/src/stack_vec.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     mem::MaybeUninit,
     ops::{Deref, DerefMut},
 };
@@ -38,7 +38,7 @@ impl<T, const N: usize> Deref for StackVec<T, N> {
     fn deref(&self) -> &[T] {
         // Safety: elements 0..len are initialized.
         #![allow(unsafe_code)]
-        unsafe { std::slice::from_raw_parts(self.data.as_ptr().cast(), self.len) }
+        unsafe { core::slice::from_raw_parts(self.data.as_ptr().cast(), self.len) }
     }
 }
 
@@ -46,7 +46,7 @@ impl<T, const N: usize> DerefMut for StackVec<T, N> {
     fn deref_mut(&mut self) -> &mut [T] {
         // Safety: elements 0..len are initialized.
         #![allow(unsafe_code)]
-        unsafe { std::slice::from_raw_parts_mut(self.data.as_mut_ptr().cast(), self.len) }
+        unsafe { core::slice::from_raw_parts_mut(self.data.as_mut_ptr().cast(), self.len) }
     }
 }
 
@@ -62,7 +62,7 @@ impl<T, const N: usize> Drop for StackVec<T, N> {
 
 impl<'a, T, const N: usize> IntoIterator for &'a StackVec<T, N> {
     type Item = &'a T;
-    type IntoIter = std::slice::Iter<'a, T>;
+    type IntoIter = core::slice::Iter<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.deref().iter()
@@ -71,7 +71,7 @@ impl<'a, T, const N: usize> IntoIterator for &'a StackVec<T, N> {
 
 impl<'a, T, const N: usize> IntoIterator for &'a mut StackVec<T, N> {
     type Item = &'a mut T;
-    type IntoIter = std::slice::IterMut<'a, T>;
+    type IntoIter = core::slice::IterMut<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.deref_mut().iter_mut()

--- a/crates/cpu/src/i286.rs
+++ b/crates/cpu/src/i286.rs
@@ -20,7 +20,7 @@ mod state;
 mod string_ops;
 mod timing;
 
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use common::Cpu as _;
 pub use flags::I286Flags;

--- a/crates/cpu/src/i386.rs
+++ b/crates/cpu/src/i386.rs
@@ -24,7 +24,7 @@ mod rep;
 mod state;
 mod string_ops;
 
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use common::{Cpu as _, likely, unlikely};
 pub use flags::I386Flags;

--- a/crates/cpu/src/i8086.rs
+++ b/crates/cpu/src/i8086.rs
@@ -12,7 +12,7 @@ mod rep;
 mod state;
 mod string_ops;
 
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use biu::{
     ADDRESS_MASK, BusPendingType, BusStatus, FetchState, OperandSize, QUEUE_SIZE, QueueOp,

--- a/crates/cpu/src/lib.rs
+++ b/crates/cpu/src/lib.rs
@@ -63,6 +63,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(clippy::unnecessary_wraps)]
+#![cfg_attr(not(test), no_std)]
 
 mod i286;
 mod i386;

--- a/crates/cpu/src/vx0.rs
+++ b/crates/cpu/src/vx0.rs
@@ -25,7 +25,7 @@ mod rep;
 mod state;
 mod string_ops;
 
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use biu::{
     ADDRESS_MASK, BusPendingType, BusStatus, FetchState, MAX_QUEUE_SIZE, OperandSize, QueueOp,

--- a/crates/cpu/src/z80.rs
+++ b/crates/cpu/src/z80.rs
@@ -14,7 +14,7 @@ mod flags;
 mod interrupt;
 mod state;
 
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use common::CpuZ80;
 pub use flags::Z80Flags;

--- a/crates/device/Cargo.toml
+++ b/crates/device/Cargo.toml
@@ -12,7 +12,7 @@ mt32 = ["dep:munt_oxide"]
 sc55 = ["dep:nuked_sc55_oxide"]
 
 [dependencies]
-common = { workspace = true }
+common = { workspace = true, features = ["std"] }
 munt_oxide = { workspace = true, optional = true }
 nuked_sc55_oxide = { workspace = true, optional = true }
 resampler = { workspace = true }

--- a/crates/dos/Cargo.toml
+++ b/crates/dos/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 blake3 = { workspace = true }
-common = { workspace = true }
+common = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 cpu = { workspace = true }

--- a/crates/machine/Cargo.toml
+++ b/crates/machine/Cargo.toml
@@ -12,7 +12,7 @@ mt32 = ["device/mt32"]
 sc55 = ["device/sc55"]
 
 [dependencies]
-common = { workspace = true }
+common = { workspace = true, features = ["std"] }
 cpu = { workspace = true }
 device = { workspace = true }
 dos = { workspace = true }

--- a/crates/softfloat/src/double_f64.rs
+++ b/crates/softfloat/src/double_f64.rs
@@ -375,14 +375,28 @@ pub(crate) fn dd_to_i64_round(x: DoubleF64) -> i64 {
         return 0;
     }
     let sum = x.high + x.low;
-    // Use round_ties_even for banker's rounding
-    let rounded = sum.round_ties_even();
-    rounded as i64
+    let truncated = sum as i64;
+    let fraction = (sum - truncated as f64).abs();
+    if fraction < 0.5 {
+        truncated
+    } else if fraction > 0.5 {
+        if sum >= 0.0 {
+            truncated + 1
+        } else {
+            truncated - 1
+        }
+    } else if truncated % 2 == 0 {
+        truncated
+    } else if sum >= 0.0 {
+        truncated + 1
+    } else {
+        truncated - 1
+    }
 }
 
 pub(crate) const DD_LN2: DoubleF64 = DoubleF64::from_parts(
-    std::f64::consts::LN_2, // 0x1.62e42fefa39efp-1
-    2.3190468138462996e-17, // 0x1.abc9e3b39803fp-56 (ln2 - high)
+    core::f64::consts::LN_2, // 0x1.62e42fefa39efp-1
+    2.3190468138462996e-17,  // 0x1.abc9e3b39803fp-56 (ln2 - high)
 );
 
 pub(crate) const DD_LN2INV2: DoubleF64 = DoubleF64::from_parts(
@@ -396,30 +410,30 @@ pub(crate) const DD_SQRT3: DoubleF64 = DoubleF64::from_parts(
 );
 
 pub(crate) const DD_PI: DoubleF64 = DoubleF64::from_parts(
-    std::f64::consts::PI,   // 0x1.921fb54442d18p+1
+    core::f64::consts::PI,  // 0x1.921fb54442d18p+1
     1.2246467991473532e-16, // 0x1.1a62633145c07p-53
 );
 
 pub(crate) const DD_PI2: DoubleF64 = DoubleF64::from_parts(
-    std::f64::consts::FRAC_PI_2, // 0x1.921fb54442d18p+0
-    6.123233995736766e-17,       // 0x1.1a62633145c07p-54
+    core::f64::consts::FRAC_PI_2, // 0x1.921fb54442d18p+0
+    6.123233995736766e-17,        // 0x1.1a62633145c07p-54
 );
 
 /// p/2: half the 66-bit x87 internal approximation of pi, used for trig argument
 /// reduction. p = (0.C90FDAA22168C234C)_16 * 2^2; p/2 = 0xC90FDAA22168C234C * 2^-67.
 pub(crate) const DD_P2: DoubleF64 = DoubleF64::from_parts(
-    std::f64::consts::FRAC_PI_2, // 0x1.921fb54442d18p+0 (same high as DD_PI2)
-    6.123031769111886e-17,       // 0x1.1a6p-54 (only 15 extra fraction bits, NOT true pi)
+    core::f64::consts::FRAC_PI_2, // 0x1.921fb54442d18p+0 (same high as DD_PI2)
+    6.123031769111886e-17,        // 0x1.1a6p-54 (only 15 extra fraction bits, NOT true pi)
 );
 
 pub(crate) const DD_PI4: DoubleF64 = DoubleF64::from_parts(
-    std::f64::consts::FRAC_PI_4, // 0x1.921fb54442d18p-1
-    3.061616997868383e-17,       // 0x1.1a62633145c07p-55
+    core::f64::consts::FRAC_PI_4, // 0x1.921fb54442d18p-1
+    3.061616997868383e-17,        // 0x1.1a62633145c07p-55
 );
 
 pub(crate) const DD_PI6: DoubleF64 = DoubleF64::from_parts(
-    std::f64::consts::FRAC_PI_6, // 0x1.0c152382d7366p-1
-    -5.360408832255454e-17,      // -0x1.ee6913347c2a5p-55
+    core::f64::consts::FRAC_PI_6, // 0x1.0c152382d7366p-1
+    -5.360408832255454e-17,       // -0x1.ee6913347c2a5p-55
 );
 
 pub(crate) fn dd_3pi4() -> DoubleF64 {

--- a/crates/softfloat/src/lib.rs
+++ b/crates/softfloat/src/lib.rs
@@ -19,6 +19,7 @@
 
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
+#![cfg_attr(not(test), no_std)]
 
 mod arithmetic;
 mod compare;

--- a/crates/software_renderer/Cargo.toml
+++ b/crates/software_renderer/Cargo.toml
@@ -7,9 +7,14 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[features]
+default = []
+std = []
+
 [dependencies]
-common = { workspace = true }
 
 [dev-dependencies]
+software_renderer = { path = ".", features = ["std"] }
+common = { workspace = true }
 cpu = { workspace = true }
 machine = { workspace = true }

--- a/crates/software_renderer/src/compose.rs
+++ b/crates/software_renderer/src/compose.rs
@@ -23,6 +23,8 @@ mod avx2;
 #[allow(unsafe_code)]
 mod neon;
 
+use alloc::boxed::Box;
+
 use super::{
     GdcGraphicsInput, GraphicsInput, PegcRenderInputs, RenderInputs, SoftwareRenderer,
     TEXT_CELL_COUNT,

--- a/crates/software_renderer/src/lib.rs
+++ b/crates/software_renderer/src/lib.rs
@@ -2,7 +2,12 @@
 
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 
+extern crate alloc;
+
+use alloc::{boxed::Box, vec};
+#[cfg(feature = "std")]
 use std::{
     fs::File,
     io::{self, BufWriter, Write},
@@ -260,6 +265,7 @@ impl SoftwareRenderer {
 
     /// Writes the top-left `width * height` region of a packed RGBA framebuffer
     /// to a binary PPM (P6) file.
+    #[cfg(feature = "std")]
     pub fn write_ppm(
         path: impl AsRef<Path>,
         framebuffer: &[u8],
@@ -287,9 +293,13 @@ impl SoftwareRenderer {
 }
 
 pub(crate) fn detect_simd() -> bool {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "std"))]
     {
         is_x86_feature_detected!("avx2")
+    }
+    #[cfg(all(target_arch = "x86_64", not(feature = "std")))]
+    {
+        cfg!(target_feature = "avx2")
     }
     #[cfg(target_arch = "aarch64")]
     {

--- a/crates/ymfm_oxide/src/fm.rs
+++ b/crates/ymfm_oxide/src/fm.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use crate::{
     helpers::{bit, bitfield, clamp},
     sys::YmfmTimerUpdate,

--- a/crates/ymfm_oxide/src/lib.rs
+++ b/crates/ymfm_oxide/src/lib.rs
@@ -47,6 +47,11 @@
 
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
 
 pub(crate) mod adpcm;
 pub(crate) mod fm;


### PR DESCRIPTION
This is useful for a sister projects that I might release in the future (a SDK for writing Rust based PC-98 DOS games, with some host tooling for easier testing, for example, PMD music tracks).