### PR TITLE
feature: align loading of PC-98 ROMs to the other machines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 name = "machine"
 version = "0.1.0"
 dependencies = [
+ "blake3",
  "common",
  "cpu",
  "device",

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ apply to one family are ignored on the others.
 | `--window-mode <MODE>`       | All     | Window mode: `windowed` or `fullscreen`                                                                                                                  | `windowed`        |
 | `--force-gdc-clock <2.5\|5>` | PC-98   | Force GDC clock to 2.5 or 5 MHz. VX and later only                                                                                                       | auto              |
 | `--graphicboard <TYPE>`      | PC-98   | Graphics accelerator board: `none`, `ga1280a`                                                                                                            | `none`            |
-| `--bios-rom <PATH>`          | PC-98   | Path to BIOS ROM file                                                                                                                                    | HLE BIOS          |
-| `--font-rom <PATH>`          | PC-98   | Path to font ROM file                                                                                                                                    | Built-in          |
+| `--pc98-roms <PATH>`         | PC-98   | Directory with the PC-98 ROM set (BIOS, font, sound), matched by content hash. All ROMs optional                                                         | -                 |
+| `--bios`                     | PC-98   | Boot the real BIOS from `--pc98-roms` instead of the HLE BIOS. Ignored (warns) on PC-9821                                                                | HLE BIOS          |
 | `--soundboard <TYPE>`        | PC-98   | Sound board: `none`, `14`, `26k`, `86`, `86+26k`, `sb16`, `sb16+26k`                                                                                     | `86+26k`          |
 | `--adpcm-ram <on\|off>`      | PC-98   | ADPCM RAM option for the PC-9801-86                                                                                                                      | `on`              |
 | `--ems <on\|off>`            | PC-98   | Enable EMS expanded memory                                                                                                                               | `on`              |
@@ -187,18 +187,64 @@ The MT-32 and SC-55 modules are configured separately via `--midi`; see
 
 ### Platform options
 
-| Option                       | Description                                                          | Default  |
-|------------------------------|----------------------------------------------------------------------|----------|
-| `--soundboard <TYPE>`        | Sound board: `none`, `14`, `26k`, `86`, `86+26k`, `sb16`, `sb16+26k` | `86+26k` |
-| `--adpcm-ram <on\|off>`      | ADPCM RAM option for the PC-9801-86                                  | `on`     |
-| `--ems <on\|off>`            | Enable EMS expanded memory                                           | `on`     |
-| `--xms <on\|off>`            | Enable XMS extended memory                                           | `on`     |
-| `--force-gdc-clock <2.5\|5>` | Force GDC clock to 2.5 or 5 MHz (VX and later only)                  | auto     |
-| `--graphicboard <TYPE>`      | Graphics accelerator board: `none`, `ga1280a`                        | `none`   |
-| `--bios-rom <PATH>`          | Path to BIOS ROM file                                                | HLE BIOS |
-| `--font-rom <PATH>`          | Path to font ROM file                                                | Built-in |
+| Option                       | Description                                                           | Default  |
+|------------------------------|-----------------------------------------------------------------------|----------|
+| `--soundboard <TYPE>`        | Sound board: `none`, `14`, `26k`, `86`, `86+26k`, `sb16`, `sb16+26k`  | `86+26k` |
+| `--adpcm-ram <on\|off>`      | ADPCM RAM option for the PC-9801-86                                   | `on`     |
+| `--ems <on\|off>`            | Enable EMS expanded memory                                            | `on`     |
+| `--xms <on\|off>`            | Enable XMS extended memory                                            | `on`     |
+| `--force-gdc-clock <2.5\|5>` | Force GDC clock to 2.5 or 5 MHz (VX and later only)                   | auto     |
+| `--graphicboard <TYPE>`      | Graphics accelerator board: `none`, `ga1280a`                         | `none`   |
+| `--pc98-roms <PATH>`         | Directory with the PC-98 ROM set (BIOS, font, sound), by content hash | -        |
+| `--bios`                     | Boot the real BIOS from `--pc98-roms` instead of the HLE BIOS         | HLE BIOS |
 
 CD-ROM disc images (`--cdrom`) are supported on the PC-9821 targets only.
+
+### ROM set
+
+Unlike the other families, the PC-98 targets run on a built-in HLE BIOS and a
+built-in font by default, so a ROM set is mostly optional. Point `--pc98-roms` at
+a directory of dumps and pass `--bios` to boot the model's real BIOS instead of the
+HLE BIOS. ROMs are identified by their BLAKE3 content hash rather than by file name,
+so any dump layout works regardless of how the files are named; the directory is
+scanned non-recursively.
+
+If a game doesn't boot or has strange errors, then you might need to use a real PC-98
+BIOS file. Please open an issue in such cases, since outside BASIC games, we want to
+have full compatibility with the HLE BIOS. 
+
+With `--bios` the model's BIOS is required. The PC-9821 targets are the exception:
+they have currently no real-BIOS boot path and always fall back to HLE with a warning.
+The 26K sound ROM is loaded when a PC-9801-26K board is selected. A font ROM is best-effort:
+the model's preferred dump is used when present, otherwise the built-in font is kept.
+
+BIOS ROM (192 KiB dual-bank image, one per model):
+
+| Model      | Size    | BLAKE3                                                             |
+|------------|---------|--------------------------------------------------------------------|
+| `PC9801F`  | 192 KiB | `5587b89b968b005e81ea2bb4c2ef6fc762154d589e627920e3d9be9cd3e01b06` |
+| `PC9801VM` | 192 KiB | `4377eeba8410c57f9a313ed2d24cd929cbfb7cac40244d5c6cafd1a27bf3495e` |
+| `PC9801VX` | 192 KiB | `89ff271aa046bb6428761cdc3ec92d82e87350c5a4941974293c5b7fe2238aed` |
+| `PC9801RA` | 192 KiB | `f18e91e8097661efe4543f30558383a02021047acfaa6d0a78e06d025094aa5e` |
+| `PC9821AS` | -       | HLE only (no real BIOS)                                            |
+| `PC9821AP` | -       | HLE only (no real BIOS)                                            |
+
+Font ROM (V98 format, 282 KiB). Any of these dumps is accepted for any model; each
+model just prefers the one matching its family:
+
+| Dump         | Preferred by     | BLAKE3                                                             |
+|--------------|------------------|--------------------------------------------------------------------|
+| standard     | F / VM / VX / RA | `4b6f751f34e633e072ded2a109c25ddb90ac70350792dc55914a4cefa4dbe005` |
+| PC-9821As    | `PC9821AS`       | `a567134a3d5c2a215b9573ee07b5204fff243631052e7a40be340e863aff8eef` |
+| PC-9821Ap2   | `PC9821AP`       | `7fb96af345c33f9bd7be5c22f75c650ac41da9b543ca5f9ca7b3d3906f2abb40` |
+| PC-9801UX    | fallback         | `3c1efa858b80fc11bb7482bdc5e15004dd9a015d7d22d48159cd43ed63f540dc` |
+| PC-9821Ce2   | fallback         | `b38096265c76cf9f54cb47df905cfb6c8b4d4f27019a04835bbc3dc8782d33e1` |
+
+Sound ROM (loaded when a PC-9801-26K board is selected):
+
+| Slot    | Size   | BLAKE3                                                             |
+|---------|--------|--------------------------------------------------------------------|
+| `sound` | 16 KiB | `93816a6e42ed9a10135af634ed500e10b1d266e0b4158d3f8471910609255e24` |
 
 ### Graphic acceleration board
 
@@ -222,7 +268,7 @@ Select the PC-88 family with `--machine PC8801MC`. The emulated machine is alway
 the PC-8801MC; the `--boot-mode` option chooses which BASIC personality it powers up
 with, which is how the earlier PC-8001 family is emulated. Unlike the PC-98 targets,
 the PC-8801MC has no HLE firmware and **requires a real ROM set** (see
-[ROM set](#rom-set)).
+[ROM set](#rom-set-1)).
 
 Sound is provided by the machine's built-in OPNA (Sound Board II, which should be
 fully compatible to the Sound Board I).
@@ -315,7 +361,7 @@ the PC-8801 software. The original could run V1 and V2 BASIC games, since it's C
 had an integrated Z80. We don't implement th hybrid nature and if you need to run
 PC-8801 games, then please use the PC-8801MC target.
 
-Like the PC-8801MC, it has no HLE firmware and requires a real ROM set (see [ROM set](#rom-set-1)).
+Like the PC-8801MC, it has no HLE firmware and requires a real ROM set (see [ROM set](#rom-set-2)).
 
 ### Platform options
 
@@ -351,7 +397,7 @@ PC-6601SR have a built-in floppy drive driven directly by the main CPU.
 Cartridge and cassette images can be inserted with `--pc60-cart` and `--pc60-cass`
 (`.cas`, `.p6`, `.p6t`); the floppy drives use the shared `--fdd1` / `--fdd2`
 options. Like the PC-8801MC, none of these targets have HLE firmware and they require
-a real ROM set (see [ROM set](#rom-set-2)).
+a real ROM set (see [ROM set](#rom-set-3)).
 
 ### Platform options
 
@@ -632,33 +678,6 @@ Limitations:
   user-defined glyphs, etc.) are silently dropped.
 
 ## FAQ
-
-### Which ROM files do I need for this emulation?
-
-It depends on the emulated family:
-
-- PC-9801 / PC-9821: none. If you have the correct ROM files you CAN use them,
-  but there is no particular reason to, since our HLE BIOS has very good
-  compatibility.
-  We also include a self-created open source font ROM and provide the tools to
-  re-create / change it. With these systems in place we can run the vast majority
-  of PC-98 games and applications. There are some BIOS extensions, mainly the
-  sound API and LIO API that we currently haven't implemented, but outside
-  some odd BASIC-based games they should not be used by titles that interface with
-  the hardware I/O ports directly.
-- PC-8001 / PC-8801: a full ROM set is required and must be supplied via
-  `--pc88-roms`. The ROMs are matched by content hash, so file names do not matter;
-  see [ROM set](#rom-set) for the list of required ROMs and the extra ROMs that the
-  `n80` / `n80sr` boot modes need.
-- PC-88VA: a full ROM set is required and must be supplied via `--pc88va-roms`. The
-  ROMs are matched by content hash, so file names do not matter; see
-  [ROM set](#rom-set-1) for the list of required ROMs.
-- PC-6001 / PC-6601: a full ROM set is required and must be supplied via
-  `--pc60-roms`. The ROMs are matched by content hash, so file names do not matter;
-  see [ROM set](#rom-set-2) for the per-model list of required and optional ROMs.
-
-The optional MT-32 and SC-55 MIDI modules, also need ROM files to function correctly,
-as described in the [MIDI sound modules](#midi-sound-modules) section.
 
 ### How can I use my mouse?
 

--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -104,11 +104,15 @@
 ; ROMs
 ; ---------------------------------------------------------------------------
 
-; Path to BIOS ROM file. If not set, runs in HLE BIOS mode.
-; bios-rom = roms/bios.rom
+; PC-98 ROM set directory (BIOS, font, sound), matched by content hash. All ROMs
+; are optional; file names do not matter.
+; pc98-roms = roms
 
-; Path to font ROM file. If not set, uses built-in font ROM.
-; font-rom = roms/font.rom
+; Boot the real BIOS from pc98-roms instead of the HLE BIOS. When on, the model's
+; real BIOS (and, with a 26K sound board, the sound ROM) is loaded from pc98-roms.
+; A matching font ROM in that directory is used automatically when present. The
+; PC-9821 targets have no real-BIOS boot path and always run HLE.
+; bios = off
 
 ; PC-88 family ROM sets (required for the PC-88 targets; matched by content hash).
 ; pc88-roms = roms/pc8801mc       ; required for machine = PC8801MC

--- a/crates/machine/Cargo.toml
+++ b/crates/machine/Cargo.toml
@@ -12,6 +12,7 @@ mt32 = ["device/mt32"]
 sc55 = ["device/sc55"]
 
 [dependencies]
+blake3 = { workspace = true }
 common = { workspace = true, features = ["std"] }
 cpu = { workspace = true }
 device = { workspace = true }

--- a/crates/machine/src/lib.rs
+++ b/crates/machine/src/lib.rs
@@ -10,6 +10,7 @@ mod bus;
 mod config;
 mod machine;
 mod memory;
+mod rom;
 
 use common::MachineModel;
 pub use common::{DosBootStage, NoTracing, SchedulerState, Tracing};
@@ -29,6 +30,7 @@ pub use crate::{
     bus::{BootDevice, Pc9801Bus},
     config::ClockConfig,
     memory::Pc9801MemoryState,
+    rom::{LoadedRoms, RomError, accepted_bios_digests, load_rom_set},
 };
 
 /// CPU state snapshot, discriminated by CPU type.

--- a/crates/machine/src/rom.rs
+++ b/crates/machine/src/rom.rs
@@ -1,0 +1,278 @@
+//! PC-98 ROM set loading.
+//!
+//! ROMs are selected by content hash rather than file name: the loader scans
+//! every file in the ROM directory, computes its BLAKE3 digest, and matches it
+//! against a table of accepted digests per slot. Any dump layout works
+//! regardless of how the files are named, and stray files are ignored.
+//!
+//! Every slot is optional at this layer: the loader returns whatever it finds
+//! and leaves the decision of which ROMs are required to the caller, which
+//! depends on the machine model and whether real-BIOS mode is enabled.
+
+use std::{collections::HashMap, fmt, path::Path};
+
+use common::MachineModel;
+
+/// Dual-bank BIOS image size (ITF bank + BIOS bank), 192 KB.
+const BIOS_ROM_SIZE: usize = 0x30000;
+/// V98-format font ROM size (288768 bytes).
+const FONT_ROM_SIZE: usize = 0x46800;
+/// PC-9801-26K sound BIOS ROM size (16 KB).
+const SOUND_ROM_SIZE: usize = 0x4000;
+
+/// One ROM slot: its expected size and the BLAKE3 digests that are accepted as
+/// valid content for it. Multiple digests allow several known good dumps to
+/// satisfy the same slot.
+struct RomSlot {
+    size: usize,
+    accepted: &'static [&'static str],
+}
+
+const BIOS_F_SLOT: RomSlot = RomSlot {
+    size: BIOS_ROM_SIZE,
+    accepted: &["5587b89b968b005e81ea2bb4c2ef6fc762154d589e627920e3d9be9cd3e01b06"],
+};
+const BIOS_VM_SLOT: RomSlot = RomSlot {
+    size: BIOS_ROM_SIZE,
+    accepted: &["4377eeba8410c57f9a313ed2d24cd929cbfb7cac40244d5c6cafd1a27bf3495e"],
+};
+const BIOS_VX_SLOT: RomSlot = RomSlot {
+    size: BIOS_ROM_SIZE,
+    accepted: &["89ff271aa046bb6428761cdc3ec92d82e87350c5a4941974293c5b7fe2238aed"],
+};
+const BIOS_RA_SLOT: RomSlot = RomSlot {
+    size: BIOS_ROM_SIZE,
+    accepted: &["f18e91e8097661efe4543f30558383a02021047acfaa6d0a78e06d025094aa5e"],
+};
+const FONT_RS: &str = "4b6f751f34e633e072ded2a109c25ddb90ac70350792dc55914a4cefa4dbe005";
+const FONT_UX: &str = "3c1efa858b80fc11bb7482bdc5e15004dd9a015d7d22d48159cd43ed63f540dc";
+const FONT_AS: &str = "a567134a3d5c2a215b9573ee07b5204fff243631052e7a40be340e863aff8eef";
+const FONT_AP2: &str = "7fb96af345c33f9bd7be5c22f75c650ac41da9b543ca5f9ca7b3d3906f2abb40";
+const FONT_CE2: &str = "b38096265c76cf9f54cb47df905cfb6c8b4d4f27019a04835bbc3dc8782d33e1";
+
+const FONT_STANDARD_SLOT: RomSlot = RomSlot {
+    size: FONT_ROM_SIZE,
+    accepted: &[FONT_RS, FONT_UX, FONT_AS, FONT_AP2, FONT_CE2],
+};
+const FONT_9821AS_SLOT: RomSlot = RomSlot {
+    size: FONT_ROM_SIZE,
+    accepted: &[FONT_AS, FONT_AP2, FONT_CE2, FONT_RS, FONT_UX],
+};
+const FONT_9821AP_SLOT: RomSlot = RomSlot {
+    size: FONT_ROM_SIZE,
+    accepted: &[FONT_AP2, FONT_AS, FONT_CE2, FONT_RS, FONT_UX],
+};
+const SOUND_SLOT: RomSlot = RomSlot {
+    size: SOUND_ROM_SIZE,
+    accepted: &["93816a6e42ed9a10135af634ed500e10b1d266e0b4158d3f8471910609255e24"],
+};
+
+/// Raw bytes of the ROMs found in a PC-98 ROM directory. Every entry is
+/// optional; the caller decides which ones are required for the run.
+pub struct LoadedRoms {
+    /// Dual-bank BIOS ROM for the selected model, if present. `None` for the
+    /// PC-9821 models, which have no supported real-BIOS boot path.
+    pub bios: Option<Vec<u8>>,
+    /// V98-format font ROM for the selected model, if present.
+    pub font: Option<Vec<u8>>,
+    /// PC-9801-26K sound BIOS ROM, if present.
+    pub sound: Option<Vec<u8>>,
+}
+
+/// Error encountered while loading a PC-98 ROM set.
+#[derive(Debug)]
+pub enum RomError {
+    /// The ROM directory could not be scanned.
+    Read {
+        /// The directory that failed to scan.
+        directory: String,
+        /// The underlying I/O error message.
+        message: String,
+    },
+}
+
+impl fmt::Display for RomError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RomError::Read { directory, message } => {
+                write!(
+                    formatter,
+                    "failed to read ROM directory {directory}: {message}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for RomError {}
+
+/// Returns the accepted BLAKE3 digests for the BIOS slot of a model, or `None`
+/// for models without a supported real-BIOS boot path (PC-9821).
+fn bios_slot(model: MachineModel) -> Option<&'static RomSlot> {
+    match model {
+        MachineModel::PC9801F => Some(&BIOS_F_SLOT),
+        MachineModel::PC9801VM => Some(&BIOS_VM_SLOT),
+        MachineModel::PC9801VX => Some(&BIOS_VX_SLOT),
+        MachineModel::PC9801RA => Some(&BIOS_RA_SLOT),
+        MachineModel::PC9821AS | MachineModel::PC9821AP => None,
+    }
+}
+
+/// Returns the font slot for a model. The PC-9821 family prefers its own font
+/// dump; every other model prefers the standard font. Every slot accepts all
+/// known font dumps as a fallback.
+fn font_slot(model: MachineModel) -> &'static RomSlot {
+    match model {
+        MachineModel::PC9801F
+        | MachineModel::PC9801VM
+        | MachineModel::PC9801VX
+        | MachineModel::PC9801RA => &FONT_STANDARD_SLOT,
+        MachineModel::PC9821AS => &FONT_9821AS_SLOT,
+        MachineModel::PC9821AP => &FONT_9821AP_SLOT,
+    }
+}
+
+/// Human-readable list of the accepted digests for a slot, used in caller error
+/// messages when a required ROM is missing.
+pub fn accepted_bios_digests(model: MachineModel) -> Vec<String> {
+    bios_slot(model)
+        .map(|slot| slot.accepted.iter().map(|d| d.to_string()).collect())
+        .unwrap_or_default()
+}
+
+/// Loads the PC-98 ROMs found in `rom_dir`.
+///
+/// Every file is hashed and matched against the accepted digests for the BIOS,
+/// font, and sound slots relevant to `model`, so the dump's file names do not
+/// matter. All slots are optional here; missing ROMs come back as `None`.
+pub fn load_rom_set(model: MachineModel, rom_dir: &Path) -> Result<LoadedRoms, RomError> {
+    let by_digest = hash_directory(rom_dir)?;
+
+    let take_optional = |slot: &RomSlot| -> Option<Vec<u8>> {
+        for digest in slot.accepted {
+            if let Some(data) = by_digest.get(*digest)
+                && data.len() == slot.size
+            {
+                return Some(data.clone());
+            }
+        }
+        None
+    };
+
+    let bios = bios_slot(model).and_then(take_optional);
+    let font = take_optional(font_slot(model));
+    let sound = take_optional(&SOUND_SLOT);
+
+    Ok(LoadedRoms { bios, font, sound })
+}
+
+/// Reads every regular file in `dir` whose size matches a known ROM slot and
+/// maps its BLAKE3 digest to its contents.
+fn hash_directory(dir: &Path) -> Result<HashMap<String, Vec<u8>>, RomError> {
+    let entries = std::fs::read_dir(dir).map_err(|error| RomError::Read {
+        directory: dir.display().to_string(),
+        message: error.to_string(),
+    })?;
+
+    let mut by_digest = HashMap::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| RomError::Read {
+            directory: dir.display().to_string(),
+            message: error.to_string(),
+        })?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let data = match std::fs::read(&path) {
+            Ok(data) => data,
+            Err(_) => continue,
+        };
+        if !is_known_rom_size(data.len()) {
+            continue;
+        }
+        by_digest.entry(blake3_hex(&data)).or_insert(data);
+    }
+    Ok(by_digest)
+}
+
+fn is_known_rom_size(size: usize) -> bool {
+    [BIOS_ROM_SIZE, FONT_ROM_SIZE, SOUND_ROM_SIZE].contains(&size)
+}
+
+fn blake3_hex(data: &[u8]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(data);
+    let mut digest = [0u8; 32];
+    hasher.finalize(&mut digest);
+
+    const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        hex.push(HEX_DIGITS[(byte >> 4) as usize] as char);
+        hex.push(HEX_DIGITS[(byte & 0x0F) as usize] as char);
+    }
+    hex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bios_slot_is_model_specific() {
+        assert_eq!(
+            accepted_bios_digests(MachineModel::PC9801F),
+            BIOS_F_SLOT.accepted
+        );
+        assert_eq!(
+            accepted_bios_digests(MachineModel::PC9801VM),
+            BIOS_VM_SLOT.accepted
+        );
+        assert_eq!(
+            accepted_bios_digests(MachineModel::PC9801VX),
+            BIOS_VX_SLOT.accepted
+        );
+        assert_eq!(
+            accepted_bios_digests(MachineModel::PC9801RA),
+            BIOS_RA_SLOT.accepted
+        );
+        assert!(bios_slot(MachineModel::PC9821AS).is_none());
+        assert!(bios_slot(MachineModel::PC9821AP).is_none());
+    }
+
+    #[test]
+    fn font_slot_splits_pc9821() {
+        assert_eq!(
+            font_slot(MachineModel::PC9801VM).accepted,
+            FONT_STANDARD_SLOT.accepted
+        );
+        assert_eq!(
+            font_slot(MachineModel::PC9821AS).accepted,
+            FONT_9821AS_SLOT.accepted
+        );
+        assert_eq!(
+            font_slot(MachineModel::PC9821AP).accepted,
+            FONT_9821AP_SLOT.accepted
+        );
+    }
+
+    #[test]
+    fn load_rom_set_matches_by_hash() {
+        let dir = std::env::temp_dir().join(format!("neetan_pc98_rom_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+
+        // A file whose content hashes to the VM BIOS digest cannot be forged
+        // here, so instead verify the negative path: a directory with only a
+        // wrong-sized stray file resolves every slot to None.
+        std::fs::write(dir.join("stray.bin"), vec![0u8; 123]).expect("write stray");
+
+        let roms = load_rom_set(MachineModel::PC9801VM, &dir).expect("scan succeeds");
+        assert!(roms.bios.is_none());
+        assert!(roms.font.is_none());
+        assert!(roms.sound.is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,8 @@ Options:
       --pc88-monitor <MODE>     PC-8801 monitor timing: auto, 15k, 24k (default: auto; PC-8801 only)
       --pc88-memory-wait <MODE> PC-8801 memory wait: fast or compatible (default derives from boot mode)
       --pc88-8mhz-wait <MODE>   PC-8801 8 MHz wait: fast or compatible (default: fast; PC-8801 only)
+      --pc98-roms <PATH>        Directory with the PC-98 ROM set (optional)
+      --bios                    Use the real BIOS from --pc98-roms instead of HLE
       --pc88-roms <PATH>        Directory with the PC-8801MC ROM set (required)
       --pc88va-roms <PATH>      Directory with the PC-88VA2 ROM set (required)
       --pc60-roms <PATH>        Directory with the PC-6000 ROM set (required; PC-6000 only)
@@ -72,8 +74,6 @@ Options:
       --window-mode <MODE>      Window mode: windowed or fullscreen
       --force-gdc-clock <2.5|5> Force GDC clock to 2.5 or 5 MHz (default: auto)
       --graphicboard <TYPE>     Graphics accelerator board: none, ga1280a
-      --bios-rom <PATH>         Path to BIOS ROM file
-      --font-rom <PATH>         Path to font ROM file
       --soundboard <TYPE>       Sound board type: none, 14, 26k, 86, 86+26k, sb16, sb16+26k
       --adpcm-ram <on|off>      ADPCM RAM option for PC-9801-86 (default: on)
       --ems <on|off>            Enable EMS expanded memory (default: on)
@@ -549,6 +549,9 @@ fn parse_args_from(
                 let val = value(&flag)?;
                 config.pc88_8mhz_wait = val.parse::<EightMhzWaitMode>().map_err(StringError)?;
             }
+            "--pc98-roms" => config.pc98_roms = Some(PathBuf::from(value(&flag)?)),
+            "--bios" => config.bios = true,
+            "--debug-bios" => config.debug_bios = Some(PathBuf::from(value(&flag)?)),
             "--pc88-roms" => config.pc88_roms = Some(PathBuf::from(value(&flag)?)),
             "--pc88va-roms" => config.pc88va_roms = Some(PathBuf::from(value(&flag)?)),
             "--pc60-roms" => config.pc60_roms = Some(PathBuf::from(value(&flag)?)),
@@ -585,8 +588,6 @@ fn parse_args_from(
                 let val = value(&flag)?;
                 config.window_mode = val.parse::<WindowMode>().map_err(StringError)?;
             }
-            "--bios-rom" => config.bios_rom = Some(PathBuf::from(value(&flag)?)),
-            "--font-rom" => config.font_rom = Some(PathBuf::from(value(&flag)?)),
             "--soundboard" => {
                 let val = value(&flag)?;
                 config.soundboard = val.parse::<SoundboardType>().map_err(StringError)?;
@@ -696,8 +697,9 @@ pub struct EmulatorConfig {
     pub scaling: ScalingMode,
     pub window_mode: WindowMode,
     pub audio_volume: f32,
-    pub bios_rom: Option<PathBuf>,
-    pub font_rom: Option<PathBuf>,
+    pub pc98_roms: Option<PathBuf>,
+    pub bios: bool,
+    pub debug_bios: Option<PathBuf>,
     pub soundboard: SoundboardType,
     pub adpcm_ram: bool,
     pub force_gdc_clock: Option<ForceGdcClock>,
@@ -750,8 +752,9 @@ impl Default for EmulatorConfig {
             scaling: ScalingMode::Pixelart,
             window_mode: WindowMode::Windowed,
             audio_volume: 1.0,
-            bios_rom: None,
-            font_rom: None,
+            pc98_roms: None,
+            bios: false,
+            debug_bios: None,
             soundboard: SoundboardType::Sb86And26k,
             adpcm_ram: true,
             force_gdc_clock: None,
@@ -840,6 +843,13 @@ fn apply_config_file(
                 Ok(mode) => config.pc88_8mhz_wait = mode,
                 Err(_) => warn!("Unknown PC-88 8 MHz wait in config: {val}"),
             },
+            "pc98-roms" => config.pc98_roms = Some(PathBuf::from(val)),
+            "bios" => match val {
+                "on" => config.bios = true,
+                "off" => config.bios = false,
+                _ => warn!("Invalid bios in config: {val}, expected on or off"),
+            },
+            "debug-bios" => config.debug_bios = Some(PathBuf::from(val)),
             "pc88-roms" => config.pc88_roms = Some(PathBuf::from(val)),
             "pc88va-roms" => config.pc88va_roms = Some(PathBuf::from(val)),
             "pc60-roms" => config.pc60_roms = Some(PathBuf::from(val)),
@@ -875,8 +885,6 @@ fn apply_config_file(
                 Ok(v) => config.audio_volume = v,
                 Err(_) => warn!("Invalid audio-volume in config: {val}"),
             },
-            "bios-rom" => config.bios_rom = Some(PathBuf::from(val)),
-            "font-rom" => config.font_rom = Some(PathBuf::from(val)),
             "soundboard" => match val.parse::<SoundboardType>() {
                 Ok(sb) => config.soundboard = sb,
                 Err(_) => warn!("Unknown soundboard type in config: {val}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,15 +3,14 @@
 #![deny(unsafe_code)]
 
 use std::{
-    borrow::Cow,
     fs::File,
     time::{Duration, Instant},
 };
 
 use audio_engine::AudioEngine;
 use common::{
-    BUILTIN_FONT_ROM, Context, CpuMode, JoystickState, Machine, MachineModel, StringError, ensure,
-    error, info, warn,
+    BUILTIN_FONT_ROM, Context, CpuMode, JoystickState, Machine, MachineModel, StringError, bail,
+    ensure, error, info, warn,
 };
 use device::disk::{HddGeometry, load_hdd_image};
 use sdl3::{
@@ -1235,34 +1234,7 @@ fn selector_font_rom_data(config: &EmulatorConfig, machine: &dyn Machine) -> Vec
         return machine.font_rom_data().to_vec();
     }
 
-    let raw_font_rom = match config.font_rom {
-        Some(ref font_path) => match std::fs::read(font_path) {
-            Ok(font_rom) => {
-                info!(
-                    "Loaded selector font ROM ({} bytes) from {}",
-                    font_rom.len(),
-                    font_path.display()
-                );
-                Cow::Owned(font_rom)
-            }
-            Err(error) => {
-                error!(
-                    "Failed to read selector font ROM from {}: {error}",
-                    font_path.display()
-                );
-                Cow::Borrowed(BUILTIN_FONT_ROM)
-            }
-        },
-        None => {
-            info!(
-                "Using built-in selector font ROM ({} bytes)",
-                BUILTIN_FONT_ROM.len()
-            );
-            Cow::Borrowed(BUILTIN_FONT_ROM)
-        }
-    };
-
-    expand_selector_font_rom(&raw_font_rom)
+    expand_selector_font_rom(BUILTIN_FONT_ROM)
 }
 
 fn expand_selector_font_rom(raw_font_rom: &[u8]) -> Vec<u8> {
@@ -1471,49 +1443,69 @@ fn initialize_pc98_machine(config: &EmulatorConfig, sample_rate: u32) -> Result<
         (false, false, Some(ForceGdcClock::Force2_5)) | (false, false, None) => {}
     }
 
-    if config.bios_rom.is_some() && model.is_pc9821() {
-        warn!("Real BIOS ROM is not supported for PC-9821. Use HLE BIOS mode (omit --bios-rom).");
+    if config.bios && config.debug_bios.is_some() {
+        bail!("--bios and --debug-bios cannot be used together");
     }
 
-    if let Some(ref bios_path) = config.bios_rom {
-        let bios_rom = std::fs::read(bios_path)
-            .with_context(|| format!("Failed to read BIOS ROM from {}", bios_path.display()))?;
+    let loaded_roms = match config.pc98_roms {
+        Some(ref rom_dir) => Some(machine::load_rom_set(model, rom_dir).map_err(|error| {
+            StringError(format!(
+                "Failed to load PC-98 ROM set from {}: {error}",
+                rom_dir.display()
+            ))
+        })?),
+        None => None,
+    };
 
+    if let Some(ref debug_path) = config.debug_bios {
+        let bios_rom = std::fs::read(debug_path).with_context(|| {
+            format!(
+                "Failed to read debug BIOS ROM from {}",
+                debug_path.display()
+            )
+        })?;
         ensure!(
             model.is_valid_bios_rom_size(bios_rom.len()),
-            "BIOS ROM is {} bytes, which is not a valid size for {}: {}",
+            "Debug BIOS ROM is {} bytes, which is not a valid size for {}: {}",
             bios_rom.len(),
             model,
-            bios_path.display(),
+            debug_path.display(),
         );
-
         info!(
-            "Loaded BIOS ROM ({} bytes) from {}",
+            "Loaded debug BIOS ROM ({} bytes) from {}",
             bios_rom.len(),
-            bios_path.display()
+            debug_path.display()
         );
         bus.load_bios_rom(&bios_rom);
+    } else if config.bios {
+        let rom_dir = config
+            .pc98_roms
+            .as_ref()
+            .ok_or_else(|| StringError("--bios requires --pc98-roms <DIR>".into()))?;
+        if model.is_pc9821() {
+            warn!("No real BIOS ROM available for PC-9821; using HLE BIOS");
+        } else if let Some(bios_rom) = loaded_roms.as_ref().and_then(|roms| roms.bios.as_ref()) {
+            info!("Loaded BIOS ROM ({} bytes) for {}", bios_rom.len(), model);
+            bus.load_bios_rom(bios_rom);
+        } else {
+            bail!(
+                "no BIOS ROM for {} found in {} (accepted digests: {})",
+                model,
+                rom_dir.display(),
+                machine::accepted_bios_digests(model).join(", "),
+            );
+        }
     } else {
-        info!("No BIOS ROM provided - running in HLE BIOS mode");
+        info!("No BIOS ROM selected - running in HLE BIOS mode");
     }
 
-    match config.font_rom {
-        Some(ref font_path) => match std::fs::read(font_path) {
-            Ok(font_rom) => {
-                info!(
-                    "Loaded font ROM ({} bytes) from {}",
-                    font_rom.len(),
-                    font_path.display()
-                );
-                bus.load_font_rom(&font_rom);
-            }
-            Err(error) => {
-                error!(
-                    "Failed to read font ROM from {}: {error}",
-                    font_path.display()
-                );
-            }
-        },
+    // Font ROM is best-effort regardless of --bios: use the directory font when
+    // present, otherwise the built-in font.
+    match loaded_roms.as_ref().and_then(|roms| roms.font.as_ref()) {
+        Some(font_rom) => {
+            info!("Loaded font ROM ({} bytes) for {}", font_rom.len(), model);
+            bus.load_font_rom(font_rom);
+        }
         None => {
             info!("Using built-in font ROM ({} bytes)", BUILTIN_FONT_ROM.len());
             bus.load_font_rom(BUILTIN_FONT_ROM);
@@ -1557,6 +1549,24 @@ fn initialize_pc98_machine(config: &EmulatorConfig, sample_rate: u32) -> Result<
             info!("Installed PC-9801-26K sound board (YM2203 OPN)");
             bus.install_sound_blaster_16();
             info!("Installed Sound Blaster 16 (CT2720, YMF262 OPL3 + CT1741 DSP)");
+        }
+    }
+
+    // The PC-9801-26K sound BIOS ROM (CC000-CFFFF) is loaded only in real-BIOS
+    // mode when a 26K board is present; otherwise the built-in stub is kept.
+    let has_26k_board = matches!(
+        config.soundboard,
+        config::SoundboardType::Sb26k
+            | config::SoundboardType::Sb86And26k
+            | config::SoundboardType::Sb16And26k
+    );
+    if config.bios && has_26k_board {
+        match loaded_roms.as_ref().and_then(|roms| roms.sound.as_ref()) {
+            Some(sound_rom) => {
+                info!("Loaded PC-9801-26K sound ROM ({} bytes)", sound_rom.len());
+                bus.load_sound_rom(Some(sound_rom));
+            }
+            None => info!("No 26K sound ROM found - using built-in sound BIOS stub"),
         }
     }
 


### PR DESCRIPTION
BREAKING CHANGE: This is more flexible, since the user can now store and configure the ROM files globally.

"--bios" or "bios=true" can be used to use a real BIOS instead oh the HLE BIOS.

Fonts and sound bios are automatically used if present and applicable.