### PR TITLE
feature: rework shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,20 +506,20 @@ For example, if your global config sets `machine = PC9801RA` and you run
 
 | Key                | Action                           |
 |--------------------|----------------------------------|
-| Right Ctrl         | Toggle mouse capture             |
-| GUI + Alt + Enter  | Toggle fullscreen                |
-| GUI + Alt + Escape | Quit the emulator                |
-| GUI + Alt + R      | Hard reset                       |
-| GUI + Alt + F      | Fast forward 8x (hold)           |
-| GUI + Alt + F1     | Toggle CRT effect                |
-| GUI + Alt + F2     | Cycle scaling method             |
-| GUI + Alt + F3     | Cycle composite phase (PC-6000)  |
-| GUI + Alt + F9     | Open floppy selector for drive 1 |
-| GUI + Alt + F10    | Open floppy selector for drive 2 |
-| GUI + Alt + F11    | Open CD-ROM selector             |
-| GUI + Alt + F12    | Log HLE DOS memory overview      |
+| Right Ctrl + M     | Toggle mouse capture             |
+| Right Ctrl + Q     | Quit the emulator                |
+| Right Ctrl + Enter | Toggle fullscreen                |
+| Right Ctrl + R     | Hard reset                       |
+| Right Ctrl + F     | Fast forward 8x (hold)           |
+| Right Ctrl + C     | Toggle CRT effect                |
+| Right Ctrl + S     | Cycle scaling method             |
+| Right Ctrl + P     | Cycle composite phase (PC-6000)  |
+| Right Ctrl + 1     | Open floppy selector for drive 1 |
+| Right Ctrl + 2     | Open floppy selector for drive 2 |
+| Right Ctrl + 3     | Open CD-ROM selector             |
 
-(GUI is the Windows / Command key)
+Right Ctrl is reserved as the emulator's shortcut modifier.
+The emulated machine uses Left Ctrl.
 
 ### How do I rebind my keys?
 
@@ -574,7 +574,7 @@ cdrom = disc2.cue
 
 The first image in each list is automatically inserted at startup.
 
-Press `GUI + Alt + F9` (drive 1), `GUI + Alt + F10` (drive 2), or `GUI + Alt + F11` (CD-ROM)
+Press `Right Ctrl + 1` (drive 1), `Right Ctrl + 2` (drive 2), or `Right Ctrl + 3` (CD-ROM)
 to open the image selector and swap disks at runtime.
 
 ## MIDI sound modules
@@ -681,8 +681,8 @@ Limitations:
 
 ### How can I use my mouse?
 
-In games that support a mouse, you first need to capture the mouse pointer via the
-right CTRL key. You can release the mouse pointer by clicking the right CTRL key again.
+In games that support a mouse, you first need to capture the mouse pointer via
+`Right Ctrl + M`. You can release the mouse pointer by pressing `Right Ctrl + M` again.
 
 ### 日本語も分かりますか？
 

--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -56,7 +56,7 @@
 ; pc60-cart = path/to/cart.rom
 ; pc60-cass = path/to/tape.cas        ; .cas/.p6/.p6t
 ; Initial composite artifact-color phase (0-3); swaps the fake-color pair used by
-; Mode 4 titles such as Portopia. Cycle it live with Alt+F3.
+; Mode 4 titles such as Portopia. Cycle it live with Right Ctrl + P.
 ; pc60-phase = 0
 
 ; ---------------------------------------------------------------------------

--- a/crates/sdl3/src/keyboard.rs
+++ b/crates/sdl3/src/keyboard.rs
@@ -689,6 +689,12 @@ impl Mod {
         self.0 & 0x00C0 != 0
     }
 
+    /// Returns `true` if the Right Ctrl key specifically is held.
+    #[inline]
+    pub const fn rctrl(&self) -> bool {
+        self.0 & 0x0080 != 0
+    }
+
     /// Returns `true` if either Alt key is held.
     #[inline]
     pub const fn alt(&self) -> bool {
@@ -699,11 +705,5 @@ impl Mod {
     #[inline]
     pub const fn gui(&self) -> bool {
         self.0 & 0x0C00 != 0
-    }
-
-    /// Returns `true` if both Alt and GUI (Super/Command) are held.
-    #[inline]
-    pub const fn alt_gui(&self) -> bool {
-        self.alt() && self.gui()
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,7 +60,7 @@ Options:
       --pc60-roms <PATH>        Directory with the PC-6000 ROM set (required; PC-6000 only)
       --pc60-cart <PATH>        Cartridge ROM image to insert (PC-6000 only)
       --pc60-cass <PATH>        Cassette tape image to insert (.cas/.p6/.p6t; PC-6000 only)
-      --pc60-phase <0-3>        Initial composite artifact-color phase; cycle with Alt+F3 (PC-6000 only)
+      --pc60-phase <0-3>        Initial composite artifact-color phase; cycle with Right Ctrl + P (PC-6000 only)
       --fdd1 <PATH>             Floppy disk image for drive 1 (repeatable)
       --fdd2 <PATH>             Floppy disk image for drive 2 (repeatable)
       --hdd1 <PATH>             Hard disk image for drive 1 (SASI or IDE)
@@ -726,7 +726,7 @@ pub struct EmulatorConfig {
     pub pc60_cart: Option<PathBuf>,
     pub pc60_cass: Option<PathBuf>,
     /// Initial composite subcarrier phase select (0..3). Swaps the PC-6001
-    /// artifact-color pair; also cycled at runtime with Alt+F3.
+    /// artifact-color pair; also cycled at runtime with Right Ctrl + P.
     pub pc60_composite_phase: u32,
 }
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -230,7 +230,7 @@ impl KeyMap {
 }
 
 pub(crate) struct KeyboardForwardingState {
-    gui_modifier_active: bool,
+    shortcut_modifier_active: bool,
     guest_pressed_pc98_scancodes: [Option<u8>; Scancode::COUNT],
     pending_pressed_pc98_scancode: Option<u8>,
     pending_released_pc98_scancodes: Vec<u8>,
@@ -239,7 +239,7 @@ pub(crate) struct KeyboardForwardingState {
 impl KeyboardForwardingState {
     pub(crate) fn new() -> Self {
         Self {
-            gui_modifier_active: false,
+            shortcut_modifier_active: false,
             guest_pressed_pc98_scancodes: [None; Scancode::COUNT],
             pending_pressed_pc98_scancode: None,
             pending_released_pc98_scancodes: Vec::with_capacity(Scancode::COUNT),
@@ -249,7 +249,7 @@ impl KeyboardForwardingState {
     pub(crate) fn handle_key_down(
         &mut self,
         scancode: Option<Scancode>,
-        gui_modifier_active: bool,
+        shortcut_modifier_active: bool,
         shift_held: bool,
         ctrl_held: bool,
         repeat: bool,
@@ -261,12 +261,12 @@ impl KeyboardForwardingState {
             return;
         }
 
-        if gui_modifier_active && !self.gui_modifier_active {
+        if shortcut_modifier_active && !self.shortcut_modifier_active {
             self.release_all_guest_keys();
         }
-        self.gui_modifier_active = gui_modifier_active;
+        self.shortcut_modifier_active = shortcut_modifier_active;
 
-        if self.gui_modifier_active {
+        if self.shortcut_modifier_active {
             return;
         }
 
@@ -446,7 +446,6 @@ const fn build_default_map() -> [u8; Scancode::COUNT] {
         (NumLock, 0x72),
         (LAlt, 0x73),
         (LCtrl, 0x74),
-        (RCtrl, 0x74),
     ];
 
     let mut map = [0u8; Scancode::COUNT];
@@ -720,7 +719,6 @@ const fn build_pc88_default_map() -> [u8; Scancode::COUNT] {
         (LShift, pc88_cell(8, 6)),
         (RShift, pc88_cell(8, 6)),
         (LCtrl, pc88_cell(8, 7)),
-        (RCtrl, pc88_cell(8, 7)),
         // Matrix row 9: Stop, F1-F5, space, escape.
         (Pause, pc88_cell(9, 0)),
         (F1, pc88_cell(9, 1)),
@@ -1035,7 +1033,7 @@ mod tests {
     }
 
     #[test]
-    fn gui_combo_does_not_forward_left_alt_or_function_keys() {
+    fn right_ctrl_combo_does_not_forward_left_alt_or_function_keys() {
         let mut keyboard_forwarding_state = KeyboardForwardingState::new();
         let key_map = KeyMap::new();
 
@@ -1096,7 +1094,7 @@ mod tests {
     }
 
     #[test]
-    fn gui_activation_releases_guest_keys_that_were_already_held() {
+    fn right_ctrl_activation_releases_guest_keys_that_were_already_held() {
         let mut keyboard_forwarding_state = KeyboardForwardingState::new();
         let key_map = KeyMap::new();
 
@@ -1129,7 +1127,7 @@ mod tests {
     }
 
     #[test]
-    fn forwarding_recovers_after_gui_is_released() {
+    fn forwarding_recovers_after_right_ctrl_is_released() {
         let mut keyboard_forwarding_state = KeyboardForwardingState::new();
         let key_map = KeyMap::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,7 @@ struct Application {
     mouse_left: bool,
     mouse_right: bool,
     mouse_middle: bool,
-    /// Whether relative mouse mode is active (Right Ctrl toggles).
+    /// Whether relative mouse mode is active (Right Ctrl + M toggles).
     mouse_captured: bool,
     /// SDL3 gamepad subsystem, if it initialized. Kept alive while running.
     gamepad_subsystem: Option<GamepadSubsystem>,
@@ -375,7 +375,7 @@ struct Application {
     selector_font_rom: Vec<u8>,
     /// Whether the CRT effect is enabled.
     crt_enabled: bool,
-    /// Composite subcarrier phase select (0..3), cycled with Alt+F3. Swaps the
+    /// Composite subcarrier phase select (0..3), cycled with Right Ctrl + P. Swaps the
     /// PC-6001 artifact-color pair; only used by the composite present path.
     composite_phase: u32,
     /// Scaling method of the native texture.
@@ -581,12 +581,12 @@ impl Application {
             } => {
                 if self.image_selector.is_some() {
                     if !repeat {
-                        self.handle_selector_key(*scancode, keymod.alt_gui());
+                        self.handle_selector_key(*scancode, keymod.rctrl());
                     }
                 } else {
                     self.keyboard_forwarding_state.handle_key_down(
                         *scancode,
-                        keymod.gui(),
+                        keymod.rctrl(),
                         keymod.shift(),
                         keymod.ctrl(),
                         *repeat,
@@ -602,17 +602,13 @@ impl Application {
                         self.update_joystick();
                     }
 
-                    // Right Ctrl toggles mouse capture.
-                    if !repeat
-                        && *scancode == Some(Scancode::RCtrl)
-                        && let Some(w) = window
-                    {
-                        self.toggle_mouse_capture(w);
-                    }
-
-                    if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::Escape) {
+                    if !repeat && keymod.rctrl() && *scancode == Some(Scancode::M) {
+                        if let Some(w) = window {
+                            self.toggle_mouse_capture(w);
+                        }
+                    } else if !repeat && keymod.rctrl() && *scancode == Some(Scancode::Q) {
                         self.should_quit = true;
-                    } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::Return) {
+                    } else if !repeat && keymod.rctrl() && *scancode == Some(Scancode::Return) {
                         if let Some(w) = window {
                             if let Err(error) = w.set_fullscreen(!self.fullscreen) {
                                 warn!("Failed to toggle fullscreen: {error}");
@@ -620,21 +616,21 @@ impl Application {
                                 self.fullscreen = !self.fullscreen;
                             }
                         }
-                    } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::F1) {
+                    } else if !repeat && keymod.rctrl() && *scancode == Some(Scancode::C) {
                         self.toggle_crt();
-                    } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::F2) {
+                    } else if !repeat && keymod.rctrl() && *scancode == Some(Scancode::S) {
                         self.toggle_scaling();
-                    } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::F3) {
+                    } else if !repeat && keymod.rctrl() && *scancode == Some(Scancode::P) {
                         self.cycle_composite_phase();
-                    } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::F9) {
+                    } else if !repeat && keymod.rctrl() && *scancode == Some(Scancode::_1) {
                         self.open_or_toggle_selector(MediaType::Floppy(0));
-                    } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::F10) {
+                    } else if !repeat && keymod.rctrl() && *scancode == Some(Scancode::_2) {
                         self.open_or_toggle_selector(MediaType::Floppy(1));
-                    } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::F11) {
+                    } else if !repeat && keymod.rctrl() && *scancode == Some(Scancode::_3) {
                         self.open_or_toggle_selector(MediaType::CdRom);
-                    } else if !repeat && keymod.alt_gui() && *scancode == Some(Scancode::R) {
+                    } else if !repeat && keymod.rctrl() && *scancode == Some(Scancode::R) {
                         self.hard_reset();
-                    } else if keymod.alt_gui() && *scancode == Some(Scancode::F) {
+                    } else if keymod.rctrl() && *scancode == Some(Scancode::F) {
                         self.set_fast_forward(true);
                     }
                 }
@@ -643,10 +639,7 @@ impl Application {
                 scancode, repeat, ..
             } => {
                 if self.fast_forward
-                    && matches!(
-                        scancode,
-                        Some(Scancode::F) | Some(Scancode::LAlt) | Some(Scancode::RAlt)
-                    )
+                    && matches!(scancode, Some(Scancode::F) | Some(Scancode::RCtrl))
                 {
                     self.set_fast_forward(false);
                 }
@@ -948,7 +941,7 @@ impl Application {
         info!("Scaling set to {}", self.scaling);
     }
 
-    fn handle_selector_key(&mut self, scancode: Option<Scancode>, alt_gui_held: bool) {
+    fn handle_selector_key(&mut self, scancode: Option<Scancode>, rctrl_held: bool) {
         let Some(code) = scancode else { return };
 
         match code {
@@ -993,13 +986,13 @@ impl Application {
             Scancode::Escape => {
                 self.close_selector();
             }
-            Scancode::F9 if alt_gui_held => {
+            Scancode::_1 if rctrl_held => {
                 self.open_or_toggle_selector(MediaType::Floppy(0));
             }
-            Scancode::F10 if alt_gui_held => {
+            Scancode::_2 if rctrl_held => {
                 self.open_or_toggle_selector(MediaType::Floppy(1));
             }
-            Scancode::F11 if alt_gui_held => {
+            Scancode::_3 if rctrl_held => {
                 self.open_or_toggle_selector(MediaType::CdRom);
             }
             _ => {}


### PR DESCRIPTION
BREAKING CHANGE: All shortcuts have been changed.

| Key                | Action                           |
|--------------------|----------------------------------|
| Right Ctrl + M     | Toggle mouse capture             |
| Right Ctrl + Q     | Quit the emulator                |
| Right Ctrl + Enter | Toggle fullscreen                |
| Right Ctrl + R     | Hard reset                       |
| Right Ctrl + F     | Fast forward 8x (hold)           |
| Right Ctrl + C     | Toggle CRT effect                |
| Right Ctrl + S     | Cycle scaling method             |
| Right Ctrl + P     | Cycle composite phase (PC-6000)  |
| Right Ctrl + 1     | Open floppy selector for drive 1 |
| Right Ctrl + 2     | Open floppy selector for drive 2 |
| Right Ctrl + 3     | Open CD-ROM selector             |

Right Ctrl is reserved as the emulator's shortcut modifier. The emulated machine uses Left Ctrl.

This was necessary since some shortcuts were used by the host OS (Windows for example).

We now align to other emulators that have the same problem. Function keys are also not a good option, since MacOS for example reserves CTRL+Function keys for keyboard based navigation.