### PR TITLE
feature: Motorola 6809 CPU emulation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "crates/cpu/tests/SingleStepTests/8086"]
 	path = crates/cpu/tests/SingleStepTests/8086
 	url = https://github.com/SingleStepTests/8086
+[submodule "crates/cpu/tests/SingleStepTests/6809"]
+	path = crates/cpu/tests/SingleStepTests/6809
+	url = https://github.com/neetandev/m6809

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1168,6 +1168,90 @@ pub trait CpuZ80 {
     fn set_im(&mut self, value: u8);
 }
 
+/// Trait representing a Motorola 6809-compatible CPU core.
+///
+/// This is separate from [`Cpu`], which models the x86 CPUs used by the
+/// PC-98 machines and exposes segment-oriented state. The 6809 has a flat
+/// 16-bit address space and shares the same [`Bus`] abstraction for memory,
+/// interrupt polling, and cycle accounting.
+pub trait Cpu6809 {
+    /// Executes instructions until approximately `cycles_to_run` cycles have
+    /// been consumed, then returns the actual number of consumed cycles.
+    fn run_for(&mut self, cycles_to_run: u64, bus: &mut impl Bus) -> u64;
+
+    /// Resets the CPU to its power-on state.
+    fn reset(&mut self);
+
+    /// Returns `true` if the CPU is waiting for an interrupt.
+    fn halted(&self) -> bool;
+
+    /// Returns the configured input clock frequency in Hz.
+    fn clock_hz(&self) -> u32;
+
+    /// Updates the configured input clock frequency in Hz.
+    fn set_clock_hz(&mut self, clock_hz: u32);
+
+    /// Returns the program counter.
+    fn pc(&self) -> u16;
+
+    /// Sets the program counter.
+    fn set_pc(&mut self, value: u16);
+
+    /// Returns the hardware stack pointer.
+    fn s(&self) -> u16;
+
+    /// Sets the hardware stack pointer.
+    fn set_s(&mut self, value: u16);
+
+    /// Returns the user stack pointer.
+    fn u(&self) -> u16;
+
+    /// Sets the user stack pointer.
+    fn set_u(&mut self, value: u16);
+
+    /// Returns the X index register.
+    fn x(&self) -> u16;
+
+    /// Sets the X index register.
+    fn set_x(&mut self, value: u16);
+
+    /// Returns the Y index register.
+    fn y(&self) -> u16;
+
+    /// Sets the Y index register.
+    fn set_y(&mut self, value: u16);
+
+    /// Returns accumulator A.
+    fn a(&self) -> u8;
+
+    /// Sets accumulator A.
+    fn set_a(&mut self, value: u8);
+
+    /// Returns accumulator B.
+    fn b(&self) -> u8;
+
+    /// Sets accumulator B.
+    fn set_b(&mut self, value: u8);
+
+    /// Returns the combined D accumulator.
+    fn d(&self) -> u16;
+
+    /// Sets the combined D accumulator.
+    fn set_d(&mut self, value: u16);
+
+    /// Returns the direct page register.
+    fn dp(&self) -> u8;
+
+    /// Sets the direct page register.
+    fn set_dp(&mut self, value: u8);
+
+    /// Returns the packed condition code register.
+    fn cc(&self) -> u8;
+
+    /// Sets the packed condition code register.
+    fn set_cc(&mut self, value: u8);
+}
+
 /// Digital joystick state for a single controller.
 ///
 /// Each field is `true` while the corresponding direction or trigger is held.

--- a/crates/cpu/src/lib.rs
+++ b/crates/cpu/src/lib.rs
@@ -53,13 +53,16 @@
 //! | 80386 | Yes                    | No                   | No                  | Yes               |
 //! | 80486 | Yes                    | No                   | No                  | Yes               |
 //! | Z80   | Yes                    | Yes                  | Yes                 | No                |
+//! | 6809  | Yes                    | Yes (2)              | Yes                 | No                |
 //!
 //! Note 1: We validated the timings using the V20 testdata and the V20 bus behavior. We then
 //!         added the V30 bus behavior and verified if the cycles adjust accordingly, how we
 //!         would expect them based on the documentation NEC provided. We will use V30 testdata,
 //!         as soon as they are available, but we are very confident, that our current V30 is
 //!         already 99% cycle accurate when beeing compared to an original V30.
-
+//! Note 2: We validate the cycle-count against test files generated with MAME's m6809 core, which
+//!         is believed to be the most accurate emulation of the 6809. Once real hardware traces
+//!         become available, we will use those instead.
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(clippy::unnecessary_wraps)]
@@ -68,6 +71,7 @@
 mod i286;
 mod i386;
 mod i8086;
+mod m6809;
 mod vx0;
 mod z80;
 
@@ -80,6 +84,7 @@ pub use i386::{
     ADDRESS_WIDTH_24, ADDRESS_WIDTH_32, CPU_MODEL_386, CPU_MODEL_486, I386, I386Flags, I386State,
 };
 pub use i8086::{I8086, I8086Flags, I8086State, PC9801F_CPU_CLOCK_5MHZ, PC9801F_CPU_CLOCK_8MHZ};
+pub use m6809::{M6809, M6809Flags, M6809State};
 pub use vx0::{
     V20, V20_BUS, V30, V30_BUS, V30BusPhase, V30Flags, V30QueueOpTrace, V30State, V30TaCycle, VX0,
 };

--- a/crates/cpu/src/m6809.rs
+++ b/crates/cpu/src/m6809.rs
@@ -1,0 +1,426 @@
+//! Implements the Motorola MC6809 emulation.
+//!
+//! Following references were used to write the emulator:
+//!
+//! - Motorola, "MC6809-MC6809E Microprocessor Programming Manual" (https://www.maddes.net/m6809pm/index.htm).
+//! - Darren Atkinson, "Motorola 6809 and Hitachi 6309 Programmer's Reference".
+
+mod alu;
+mod execute;
+mod execute_page2;
+mod execute_page3;
+mod flags;
+mod indexed;
+mod interrupt;
+mod state;
+
+use core::ops::{Deref, DerefMut};
+
+use common::Cpu6809;
+pub use flags::M6809Flags;
+pub use state::M6809State;
+
+pub(crate) const VECTOR_SWI3: u16 = 0xFFF2;
+pub(crate) const VECTOR_SWI2: u16 = 0xFFF4;
+pub(crate) const VECTOR_FIRQ: u16 = 0xFFF6;
+pub(crate) const VECTOR_IRQ: u16 = 0xFFF8;
+pub(crate) const VECTOR_SWI: u16 = 0xFFFA;
+pub(crate) const VECTOR_NMI: u16 = 0xFFFC;
+pub(crate) const VECTOR_RESET: u16 = 0xFFFE;
+
+const PENDING_FIRQ: u8 = 0x04;
+
+/// Default 6809 clock frequency used by verification tests.
+pub const M6809_DEFAULT_CLOCK_HZ: u32 = 1_000_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AddressMode {
+    Immediate,
+    Direct,
+    Indexed,
+    Extended,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EffectiveAddress {
+    pub(crate) address: u16,
+    pub(crate) extra_cycles: i32,
+}
+
+/// Motorola MC6809 CPU emulator.
+pub struct M6809 {
+    /// Embedded state for save/restore.
+    pub state: M6809State,
+
+    clock_hz: u32,
+    halted: bool,
+    pending_irq: u8,
+    cycles_remaining: i64,
+    run_start_cycle: u64,
+    run_budget: u64,
+    nmi_armed: bool,
+}
+
+impl Deref for M6809 {
+    type Target = M6809State;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+impl DerefMut for M6809 {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.state
+    }
+}
+
+impl Default for M6809 {
+    fn default() -> Self {
+        Self::new(M6809_DEFAULT_CLOCK_HZ)
+    }
+}
+
+impl M6809 {
+    /// Creates a new 6809 CPU in its reset state.
+    pub fn new(clock_hz: u32) -> Self {
+        let mut cpu = Self {
+            state: M6809State::default(),
+            clock_hz,
+            halted: false,
+            pending_irq: 0,
+            cycles_remaining: 0,
+            run_start_cycle: 0,
+            run_budget: 0,
+            nmi_armed: false,
+        };
+        cpu.reset();
+        cpu
+    }
+
+    /// Loads CPU state from a snapshot, resetting runtime latches.
+    pub fn load_state(&mut self, state: &M6809State) {
+        self.state = state.clone();
+        self.halted = false;
+        self.pending_irq = 0;
+        self.nmi_armed = true;
+    }
+
+    /// Resets the CPU and fetches the reset vector from the bus.
+    pub fn reset_with_bus(&mut self, bus: &mut impl common::Bus) {
+        self.reset();
+        self.pc = self.read_word_untracked(bus, VECTOR_RESET);
+    }
+
+    /// Asserts the FIRQ input latch.
+    pub fn request_firq(&mut self) {
+        self.pending_irq |= PENDING_FIRQ;
+    }
+
+    /// Clears the FIRQ input latch.
+    pub fn clear_firq(&mut self) {
+        self.pending_irq &= !PENDING_FIRQ;
+    }
+
+    /// Executes exactly one logical instruction.
+    pub fn step(&mut self, bus: &mut impl common::Bus) {
+        let start_cycle = bus.current_cycle();
+        self.cycles_remaining = i64::MAX;
+        self.execute_one(bus);
+        self.cycles_remaining -= bus.drain_wait_cycles();
+        bus.set_current_cycle(start_cycle + self.cycles_consumed());
+        bus.on_instruction_end();
+        self.cycles_remaining -= bus.drain_wait_cycles();
+        bus.set_current_cycle(start_cycle + self.cycles_consumed());
+    }
+
+    /// Returns the number of cycles consumed by the last `step()` call.
+    pub fn cycles_consumed(&self) -> u64 {
+        (i64::MAX - self.cycles_remaining) as u64
+    }
+
+    #[inline(always)]
+    pub(crate) fn clk(&mut self, cycles: i32) {
+        self.cycles_remaining -= i64::from(cycles);
+    }
+
+    #[inline(always)]
+    pub(crate) fn read_byte(&mut self, bus: &mut impl common::Bus, address: u16) -> u8 {
+        let value = bus.read_byte(u32::from(address));
+        self.clk(1);
+        value
+    }
+
+    #[inline(always)]
+    pub(crate) fn write_byte(&mut self, bus: &mut impl common::Bus, address: u16, value: u8) {
+        bus.write_byte(u32::from(address), value);
+        self.clk(1);
+    }
+
+    #[inline(always)]
+    pub(crate) fn fetch_u8(&mut self, bus: &mut impl common::Bus) -> u8 {
+        let value = bus.fetch_opcode_byte(u32::from(self.pc));
+        self.pc = self.pc.wrapping_add(1);
+        self.clk(1);
+        value
+    }
+
+    #[inline(always)]
+    pub(crate) fn fetch_u16(&mut self, bus: &mut impl common::Bus) -> u16 {
+        let high = u16::from(self.fetch_u8(bus));
+        let low = u16::from(self.fetch_u8(bus));
+        (high << 8) | low
+    }
+
+    #[inline(always)]
+    pub(crate) fn read_word(&mut self, bus: &mut impl common::Bus, address: u16) -> u16 {
+        let high = u16::from(self.read_byte(bus, address));
+        let low = u16::from(self.read_byte(bus, address.wrapping_add(1)));
+        (high << 8) | low
+    }
+
+    #[inline(always)]
+    pub(crate) fn write_word(&mut self, bus: &mut impl common::Bus, address: u16, value: u16) {
+        self.write_byte(bus, address, (value >> 8) as u8);
+        self.write_byte(bus, address.wrapping_add(1), value as u8);
+    }
+
+    #[inline(always)]
+    fn read_word_untracked(&mut self, bus: &mut impl common::Bus, address: u16) -> u16 {
+        let high = u16::from(bus.read_byte(u32::from(address)));
+        let low = u16::from(bus.read_byte(u32::from(address.wrapping_add(1))));
+        (high << 8) | low
+    }
+
+    #[inline(always)]
+    pub(crate) fn direct_address(&mut self, bus: &mut impl common::Bus) -> u16 {
+        (u16::from(self.dp) << 8) | u16::from(self.fetch_u8(bus))
+    }
+
+    #[inline(always)]
+    pub(crate) fn finish_instruction(&mut self, cycle_start: i64, target_cycles: i32) {
+        let consumed = cycle_start - self.cycles_remaining;
+        let remaining = i64::from(target_cycles) - consumed;
+        if remaining > 0 {
+            self.cycles_remaining -= remaining;
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn mark_s_loaded(&mut self) {
+        self.nmi_armed = true;
+    }
+
+    pub(crate) fn push_byte(&mut self, bus: &mut impl common::Bus, stack: &mut u16, value: u8) {
+        *stack = stack.wrapping_sub(1);
+        self.write_byte(bus, *stack, value);
+    }
+
+    pub(crate) fn push_word(&mut self, bus: &mut impl common::Bus, stack: &mut u16, value: u16) {
+        self.push_byte(bus, stack, value as u8);
+        self.push_byte(bus, stack, (value >> 8) as u8);
+    }
+
+    pub(crate) fn pull_byte(&mut self, bus: &mut impl common::Bus, stack: &mut u16) -> u8 {
+        let value = self.read_byte(bus, *stack);
+        *stack = stack.wrapping_add(1);
+        value
+    }
+
+    pub(crate) fn pull_word(&mut self, bus: &mut impl common::Bus, stack: &mut u16) -> u16 {
+        let high = u16::from(self.pull_byte(bus, stack));
+        let low = u16::from(self.pull_byte(bus, stack));
+        (high << 8) | low
+    }
+
+    pub(crate) fn push_s_word(&mut self, bus: &mut impl common::Bus, value: u16) {
+        let mut stack = self.s;
+        self.push_word(bus, &mut stack, value);
+        self.s = stack;
+    }
+
+    pub(crate) fn pull_s_byte(&mut self, bus: &mut impl common::Bus) -> u8 {
+        let mut stack = self.s;
+        let value = self.pull_byte(bus, &mut stack);
+        self.s = stack;
+        value
+    }
+
+    pub(crate) fn pull_s_word(&mut self, bus: &mut impl common::Bus) -> u16 {
+        let mut stack = self.s;
+        let value = self.pull_word(bus, &mut stack);
+        self.s = stack;
+        value
+    }
+
+    pub(crate) fn execute_one(&mut self, bus: &mut impl common::Bus) {
+        let cycle_start = self.cycles_remaining;
+        if let Some(cycles) = self.check_interrupts(bus) {
+            self.finish_instruction(cycle_start, cycles);
+            return;
+        }
+
+        let opcode = self.fetch_u8(bus);
+        let target_cycles = match opcode {
+            0x10 => {
+                let page_opcode = self.fetch_u8(bus);
+                self.execute_page2(page_opcode, bus)
+            }
+            0x11 => {
+                let page_opcode = self.fetch_u8(bus);
+                self.execute_page3(page_opcode, bus)
+            }
+            _ => self.execute_base(opcode, bus),
+        };
+        self.finish_instruction(cycle_start, target_cycles);
+    }
+}
+
+impl Cpu6809 for M6809 {
+    fn run_for(&mut self, cycles_to_run: u64, bus: &mut impl common::Bus) -> u64 {
+        let start_cycle = bus.current_cycle();
+        self.run_start_cycle = start_cycle;
+        self.run_budget = cycles_to_run;
+        self.cycles_remaining = cycles_to_run as i64;
+
+        while self.cycles_remaining > 0 {
+            if bus.has_nmi() && self.nmi_armed {
+                self.pending_irq |= crate::PENDING_NMI;
+            }
+            if bus.has_irq() {
+                self.pending_irq |= crate::PENDING_IRQ;
+            } else {
+                self.pending_irq &= !crate::PENDING_IRQ;
+            }
+
+            if self.halted && self.pending_irq == 0 {
+                let consumed = (cycles_to_run as i64 - self.cycles_remaining) as u64;
+                bus.set_current_cycle(start_cycle + consumed);
+                return consumed;
+            }
+
+            self.execute_one(bus);
+            self.cycles_remaining -= bus.drain_wait_cycles();
+
+            let consumed = cycles_to_run as i64 - self.cycles_remaining;
+            bus.set_current_cycle(start_cycle + consumed as u64);
+
+            bus.on_instruction_end();
+            self.cycles_remaining -= bus.drain_wait_cycles();
+
+            let consumed = cycles_to_run as i64 - self.cycles_remaining;
+            bus.set_current_cycle(start_cycle + consumed as u64);
+
+            if bus.reset_pending() || bus.cpu_should_yield() {
+                break;
+            }
+        }
+
+        let actual = (cycles_to_run as i64 - self.cycles_remaining) as u64;
+        bus.set_current_cycle(start_cycle + actual);
+        actual
+    }
+
+    fn reset(&mut self) {
+        self.state = M6809State::default();
+        self.clock_hz = self.clock_hz.max(1);
+        self.flags.firq_mask = true;
+        self.flags.irq_mask = true;
+        self.halted = false;
+        self.pending_irq = 0;
+        self.nmi_armed = false;
+    }
+
+    fn halted(&self) -> bool {
+        self.halted
+    }
+
+    fn clock_hz(&self) -> u32 {
+        self.clock_hz
+    }
+
+    fn set_clock_hz(&mut self, clock_hz: u32) {
+        self.clock_hz = clock_hz.max(1);
+    }
+
+    fn pc(&self) -> u16 {
+        self.pc
+    }
+
+    fn set_pc(&mut self, value: u16) {
+        self.pc = value;
+    }
+
+    fn s(&self) -> u16 {
+        self.s
+    }
+
+    fn set_s(&mut self, value: u16) {
+        self.s = value;
+        self.mark_s_loaded();
+    }
+
+    fn u(&self) -> u16 {
+        self.u
+    }
+
+    fn set_u(&mut self, value: u16) {
+        self.u = value;
+    }
+
+    fn x(&self) -> u16 {
+        self.x
+    }
+
+    fn set_x(&mut self, value: u16) {
+        self.x = value;
+    }
+
+    fn y(&self) -> u16 {
+        self.y
+    }
+
+    fn set_y(&mut self, value: u16) {
+        self.y = value;
+    }
+
+    fn a(&self) -> u8 {
+        self.a
+    }
+
+    fn set_a(&mut self, value: u8) {
+        self.a = value;
+    }
+
+    fn b(&self) -> u8 {
+        self.b
+    }
+
+    fn set_b(&mut self, value: u8) {
+        self.b = value;
+    }
+
+    fn d(&self) -> u16 {
+        self.state.d()
+    }
+
+    fn set_d(&mut self, value: u16) {
+        self.state.set_d(value);
+    }
+
+    fn dp(&self) -> u8 {
+        self.dp
+    }
+
+    fn set_dp(&mut self, value: u8) {
+        self.dp = value;
+    }
+
+    fn cc(&self) -> u8 {
+        self.flags.compress()
+    }
+
+    fn set_cc(&mut self, value: u8) {
+        self.flags.expand(value);
+    }
+}

--- a/crates/cpu/src/m6809/alu.rs
+++ b/crates/cpu/src/m6809/alu.rs
@@ -1,0 +1,293 @@
+use super::{M6809, M6809Flags};
+
+impl M6809 {
+    #[inline(always)]
+    fn set_flags8(&mut self, mask: u8, left: u8, right: u8, result: u32) -> u8 {
+        let mut bits = self.flags.compress() & !mask;
+        if mask & M6809Flags::HALF_CARRY != 0 && ((left as u32 ^ right as u32 ^ result) & 0x10) != 0
+        {
+            bits |= M6809Flags::HALF_CARRY;
+        }
+        if mask & M6809Flags::NEGATIVE != 0 && result & 0x80 != 0 {
+            bits |= M6809Flags::NEGATIVE;
+        }
+        if mask & M6809Flags::ZERO != 0 && result as u8 == 0 {
+            bits |= M6809Flags::ZERO;
+        }
+        if mask & M6809Flags::OVERFLOW != 0
+            && ((left as u32 ^ right as u32 ^ result ^ (result >> 1)) & 0x80) != 0
+        {
+            bits |= M6809Flags::OVERFLOW;
+        }
+        if mask & M6809Flags::CARRY != 0 && result & 0x100 != 0 {
+            bits |= M6809Flags::CARRY;
+        }
+        self.flags.expand(bits);
+        result as u8
+    }
+
+    #[inline(always)]
+    fn set_flags16(&mut self, mask: u8, left: u16, right: u16, result: u32) -> u16 {
+        let mut bits = self.flags.compress() & !mask;
+        if mask & M6809Flags::HALF_CARRY != 0 && ((left as u32 ^ right as u32 ^ result) & 0x10) != 0
+        {
+            bits |= M6809Flags::HALF_CARRY;
+        }
+        if mask & M6809Flags::NEGATIVE != 0 && result & 0x8000 != 0 {
+            bits |= M6809Flags::NEGATIVE;
+        }
+        if mask & M6809Flags::ZERO != 0 && result as u16 == 0 {
+            bits |= M6809Flags::ZERO;
+        }
+        if mask & M6809Flags::OVERFLOW != 0
+            && ((left as u32 ^ right as u32 ^ result ^ (result >> 1)) & 0x8000) != 0
+        {
+            bits |= M6809Flags::OVERFLOW;
+        }
+        if mask & M6809Flags::CARRY != 0 && result & 0x1_0000 != 0 {
+            bits |= M6809Flags::CARRY;
+        }
+        self.flags.expand(bits);
+        result as u16
+    }
+
+    #[inline(always)]
+    pub(crate) fn set_nz8(&mut self, value: u8) -> u8 {
+        self.set_flags8(M6809Flags::NZ, 0, value, u32::from(value))
+    }
+
+    #[inline(always)]
+    pub(crate) fn set_nzv8(&mut self, value: u8) -> u8 {
+        self.set_flags8(M6809Flags::NZV, 0, value, u32::from(value))
+    }
+
+    #[inline(always)]
+    pub(crate) fn set_nzv16(&mut self, value: u16) -> u16 {
+        self.set_flags16(M6809Flags::NZV, 0, value, u32::from(value))
+    }
+
+    #[inline(always)]
+    pub(crate) fn set_z16(&mut self, value: u16) -> u16 {
+        self.set_flags16(M6809Flags::ZERO, 0, value, u32::from(value))
+    }
+
+    #[inline(always)]
+    pub(crate) fn neg8(&mut self, value: u8) -> u8 {
+        self.set_flags8(
+            M6809Flags::NZVC,
+            0,
+            value,
+            0u32.wrapping_sub(u32::from(value)),
+        )
+    }
+
+    #[inline(always)]
+    pub(crate) fn com8(&mut self, value: u8) -> u8 {
+        self.flags.overflow = false;
+        self.flags.carry = true;
+        self.set_nz8(!value)
+    }
+
+    #[inline(always)]
+    pub(crate) fn lsr8(&mut self, value: u8) -> u8 {
+        self.flags.carry = value & 0x01 != 0;
+        self.set_nz8(value >> 1)
+    }
+
+    #[inline(always)]
+    pub(crate) fn ror8(&mut self, value: u8) -> u8 {
+        let old_carry = self.flags.carry;
+        self.flags.carry = value & 0x01 != 0;
+        let result = (value >> 1) | if old_carry { 0x80 } else { 0 };
+        self.set_nz8(result)
+    }
+
+    #[inline(always)]
+    pub(crate) fn asr8(&mut self, value: u8) -> u8 {
+        self.flags.carry = value & 0x01 != 0;
+        self.set_nz8((value >> 1) | (value & 0x80))
+    }
+
+    #[inline(always)]
+    pub(crate) fn asl8(&mut self, value: u8) -> u8 {
+        self.set_flags8(M6809Flags::NZVC, value, value, u32::from(value) << 1)
+    }
+
+    #[inline(always)]
+    pub(crate) fn rol8(&mut self, value: u8) -> u8 {
+        let old_carry = self.flags.carry;
+        self.flags.carry = value & 0x80 != 0;
+        let result = (u32::from(value) << 1) | u32::from(old_carry);
+        self.set_flags8(M6809Flags::NZV, value, value, result)
+    }
+
+    #[inline(always)]
+    pub(crate) fn dec8(&mut self, value: u8) -> u8 {
+        self.set_flags8(M6809Flags::NZV, value, 1, u32::from(value).wrapping_sub(1))
+    }
+
+    #[inline(always)]
+    pub(crate) fn xdec8(&mut self, value: u8) -> u8 {
+        self.flags.carry = value != 0;
+        self.dec8(value)
+    }
+
+    #[inline(always)]
+    pub(crate) fn inc8(&mut self, value: u8) -> u8 {
+        self.set_flags8(M6809Flags::NZV, value, 1, u32::from(value) + 1)
+    }
+
+    #[inline(always)]
+    pub(crate) fn tst8(&mut self, value: u8) {
+        self.set_nzv8(value);
+    }
+
+    #[inline(always)]
+    pub(crate) fn clr8(&mut self) -> u8 {
+        self.flags.set_bits(M6809Flags::NZVC, M6809Flags::ZERO);
+        0
+    }
+
+    #[inline(always)]
+    pub(crate) fn xclr8(&mut self) -> u8 {
+        self.flags.set_bits(M6809Flags::NZV, M6809Flags::ZERO);
+        0
+    }
+
+    #[inline(always)]
+    pub(crate) fn sub8(&mut self, left: u8, right: u8) -> u8 {
+        self.set_flags8(
+            M6809Flags::NZVC,
+            left,
+            right,
+            u32::from(left).wrapping_sub(u32::from(right)),
+        )
+    }
+
+    #[inline(always)]
+    pub(crate) fn sbc8(&mut self, left: u8, right: u8) -> u8 {
+        let carry = u32::from(self.flags.carry);
+        self.set_flags8(
+            M6809Flags::NZVC,
+            left,
+            right,
+            u32::from(left)
+                .wrapping_sub(u32::from(right))
+                .wrapping_sub(carry),
+        )
+    }
+
+    #[inline(always)]
+    pub(crate) fn cmp8(&mut self, left: u8, right: u8) {
+        self.sub8(left, right);
+    }
+
+    #[inline(always)]
+    pub(crate) fn and8(&mut self, left: u8, right: u8) -> u8 {
+        self.flags.overflow = false;
+        self.set_nz8(left & right)
+    }
+
+    #[inline(always)]
+    pub(crate) fn bit8(&mut self, left: u8, right: u8) {
+        self.flags.overflow = false;
+        self.set_nz8(left & right);
+    }
+
+    #[inline(always)]
+    pub(crate) fn eor8(&mut self, left: u8, right: u8) -> u8 {
+        self.flags.overflow = false;
+        self.set_nz8(left ^ right)
+    }
+
+    #[inline(always)]
+    pub(crate) fn adc8(&mut self, left: u8, right: u8) -> u8 {
+        let carry = u32::from(self.flags.carry);
+        self.set_flags8(
+            M6809Flags::HNZVC,
+            left,
+            right,
+            u32::from(left) + u32::from(right) + carry,
+        )
+    }
+
+    #[inline(always)]
+    pub(crate) fn or8(&mut self, left: u8, right: u8) -> u8 {
+        self.flags.overflow = false;
+        self.set_nz8(left | right)
+    }
+
+    #[inline(always)]
+    pub(crate) fn add8(&mut self, left: u8, right: u8) -> u8 {
+        self.set_flags8(
+            M6809Flags::HNZVC,
+            left,
+            right,
+            u32::from(left) + u32::from(right),
+        )
+    }
+
+    #[inline(always)]
+    pub(crate) fn add16(&mut self, left: u16, right: u16) -> u16 {
+        self.set_flags16(
+            M6809Flags::NZVC,
+            left,
+            right,
+            u32::from(left) + u32::from(right),
+        )
+    }
+
+    #[inline(always)]
+    pub(crate) fn sub16(&mut self, left: u16, right: u16) -> u16 {
+        self.set_flags16(
+            M6809Flags::NZVC,
+            left,
+            right,
+            u32::from(left).wrapping_sub(u32::from(right)),
+        )
+    }
+
+    #[inline(always)]
+    pub(crate) fn cmp16(&mut self, left: u16, right: u16) {
+        self.sub16(left, right);
+    }
+
+    #[inline(always)]
+    pub(crate) fn daa(&mut self) {
+        let mut correction = 0u16;
+        let most_significant_nibble = self.a & 0xF0;
+        let least_significant_nibble = self.a & 0x0F;
+
+        if least_significant_nibble > 0x09 || self.flags.half_carry {
+            correction |= 0x06;
+        }
+        if most_significant_nibble > 0x80 && least_significant_nibble > 0x09 {
+            correction |= 0x60;
+        }
+        if most_significant_nibble > 0x90 || self.flags.carry {
+            correction |= 0x60;
+        }
+
+        let result = u16::from(self.a) + correction;
+        self.flags.overflow = false;
+        if result & 0x0100 != 0 {
+            self.flags.carry = true;
+        }
+        self.a = self.set_nz8(result as u8);
+    }
+
+    #[inline(always)]
+    pub(crate) fn mul(&mut self) {
+        let result = u16::from(self.a) * u16::from(self.b);
+        let value = self.set_flags16(M6809Flags::ZERO, 0, result, u32::from(result));
+        self.set_d(value);
+        self.flags.carry = self.d() & 0x0080 != 0;
+    }
+
+    #[inline(always)]
+    pub(crate) fn sex(&mut self) {
+        let value = self.b as i8 as i16 as u16;
+        let result = self.set_flags16(M6809Flags::NZ, 0, value, u32::from(value));
+        self.set_d(result);
+    }
+}

--- a/crates/cpu/src/m6809/execute.rs
+++ b/crates/cpu/src/m6809/execute.rs
@@ -1,0 +1,898 @@
+use super::{AddressMode, EffectiveAddress, M6809, M6809Flags};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UnaryOp {
+    Neg,
+    Xnc,
+    Com,
+    Lsr,
+    Ror,
+    Asr,
+    Asl,
+    Rol,
+    Dec,
+    Xdec,
+    Inc,
+    Tst,
+    Clr,
+    Xclr,
+}
+
+impl M6809 {
+    pub(crate) fn execute_base(&mut self, opcode: u8, bus: &mut impl common::Bus) -> i32 {
+        match opcode {
+            0x00 | 0x01 => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Neg, 6, bus),
+            0x02 => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Xnc, 6, bus),
+            0x03 => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Com, 6, bus),
+            0x04 | 0x05 => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Lsr, 6, bus),
+            0x06 => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Ror, 6, bus),
+            0x07 => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Asr, 6, bus),
+            0x08 => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Asl, 6, bus),
+            0x09 => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Rol, 6, bus),
+            0x0A => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Dec, 6, bus),
+            0x0B => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Xdec, 6, bus),
+            0x0C => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Inc, 6, bus),
+            0x0D => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Tst, 6, bus),
+            0x0E => {
+                self.pc = self.direct_address(bus);
+                3
+            }
+            0x0F => self.execute_memory_unary(AddressMode::Direct, UnaryOp::Clr, 6, bus),
+            0x12 | 0x1B => 2,
+            0x13 => {
+                self.sync();
+                2
+            }
+            0x14 | 0x15 | 0xCD => {
+                self.halted = true;
+                1
+            }
+            0x16 => self.long_branch(true, bus, 5),
+            0x17 => self.long_bsr(bus),
+            0x18 => self.x18(bus),
+            0x19 => {
+                self.daa();
+                2
+            }
+            0x1A => {
+                let value = self.fetch_u8(bus);
+                let condition_code = self.flags.compress();
+                self.flags.expand(condition_code | value);
+                3
+            }
+            0x1C => {
+                let value = self.fetch_u8(bus);
+                let condition_code = self.flags.compress();
+                self.flags.expand(condition_code & value);
+                3
+            }
+            0x1D => {
+                self.sex();
+                2
+            }
+            0x1E => self.exg(bus),
+            0x1F => self.tfr(bus),
+            0x20 => self.short_branch(true, bus),
+            0x21 => self.short_branch(false, bus),
+            0x22 => self.short_branch(self.condition_hi(), bus),
+            0x23 => self.short_branch(!self.condition_hi(), bus),
+            0x24 => self.short_branch(!self.flags.carry, bus),
+            0x25 => self.short_branch(self.flags.carry, bus),
+            0x26 => self.short_branch(!self.flags.zero, bus),
+            0x27 => self.short_branch(self.flags.zero, bus),
+            0x28 => self.short_branch(!self.flags.overflow, bus),
+            0x29 => self.short_branch(self.flags.overflow, bus),
+            0x2A => self.short_branch(!self.flags.negative, bus),
+            0x2B => self.short_branch(self.flags.negative, bus),
+            0x2C => self.short_branch(self.condition_ge(), bus),
+            0x2D => self.short_branch(!self.condition_ge(), bus),
+            0x2E => self.short_branch(self.condition_gt(), bus),
+            0x2F => self.short_branch(!self.condition_gt(), bus),
+            0x30 => self.lea(AddressMode::Indexed, 0, bus),
+            0x31 => self.lea(AddressMode::Indexed, 1, bus),
+            0x32 => self.lea(AddressMode::Indexed, 2, bus),
+            0x33 => self.lea(AddressMode::Indexed, 3, bus),
+            0x34 => self.push_or_pull(true, true, bus),
+            0x35 => self.push_or_pull(true, false, bus),
+            0x36 => self.push_or_pull(false, true, bus),
+            0x37 => self.push_or_pull(false, false, bus),
+            0x38 => {
+                self.clk(1);
+                let value = self.fetch_u8(bus);
+                let condition_code = self.flags.compress();
+                self.flags.expand(condition_code & value);
+                4
+            }
+            0x39 => {
+                self.pc = self.pull_s_word(bus);
+                5
+            }
+            0x3A => {
+                self.x = self.x.wrapping_add(u16::from(self.b));
+                3
+            }
+            0x3B => self.rti(bus),
+            0x3C => {
+                self.cwai(bus);
+                20
+            }
+            0x3D => {
+                self.mul();
+                11
+            }
+            0x3E => {
+                self.x_reset(bus);
+                19
+            }
+            0x3F => {
+                self.swi(bus);
+                19
+            }
+            0x40 | 0x41 => self.execute_register_unary(true, UnaryOp::Neg),
+            0x42 => self.execute_register_unary(true, UnaryOp::Xnc),
+            0x43 => self.execute_register_unary(true, UnaryOp::Com),
+            0x44 | 0x45 => self.execute_register_unary(true, UnaryOp::Lsr),
+            0x46 => self.execute_register_unary(true, UnaryOp::Ror),
+            0x47 => self.execute_register_unary(true, UnaryOp::Asr),
+            0x48 => self.execute_register_unary(true, UnaryOp::Asl),
+            0x49 => self.execute_register_unary(true, UnaryOp::Rol),
+            0x4A => self.execute_register_unary(true, UnaryOp::Dec),
+            0x4B => self.execute_register_unary(true, UnaryOp::Xdec),
+            0x4C => self.execute_register_unary(true, UnaryOp::Inc),
+            0x4D => self.execute_register_unary(true, UnaryOp::Tst),
+            0x4E => self.execute_register_unary(true, UnaryOp::Xclr),
+            0x4F => self.execute_register_unary(true, UnaryOp::Clr),
+            0x50 | 0x51 => self.execute_register_unary(false, UnaryOp::Neg),
+            0x52 => self.execute_register_unary(false, UnaryOp::Xnc),
+            0x53 => self.execute_register_unary(false, UnaryOp::Com),
+            0x54 | 0x55 => self.execute_register_unary(false, UnaryOp::Lsr),
+            0x56 => self.execute_register_unary(false, UnaryOp::Ror),
+            0x57 => self.execute_register_unary(false, UnaryOp::Asr),
+            0x58 => self.execute_register_unary(false, UnaryOp::Asl),
+            0x59 => self.execute_register_unary(false, UnaryOp::Rol),
+            0x5A => self.execute_register_unary(false, UnaryOp::Dec),
+            0x5B => self.execute_register_unary(false, UnaryOp::Xdec),
+            0x5C => self.execute_register_unary(false, UnaryOp::Inc),
+            0x5D => self.execute_register_unary(false, UnaryOp::Tst),
+            0x5E => self.execute_register_unary(false, UnaryOp::Xclr),
+            0x5F => self.execute_register_unary(false, UnaryOp::Clr),
+            0x60 | 0x61 => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Neg, 6, bus),
+            0x62 => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Xnc, 6, bus),
+            0x63 => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Com, 6, bus),
+            0x64 | 0x65 => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Lsr, 6, bus),
+            0x66 => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Ror, 6, bus),
+            0x67 => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Asr, 6, bus),
+            0x68 => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Asl, 6, bus),
+            0x69 => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Rol, 6, bus),
+            0x6A => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Dec, 6, bus),
+            0x6B => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Xdec, 6, bus),
+            0x6C => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Inc, 6, bus),
+            0x6D => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Tst, 6, bus),
+            0x6E => {
+                let ea = self.address_for_mode(AddressMode::Indexed, bus);
+                self.pc = ea.address;
+                3 + ea.extra_cycles
+            }
+            0x6F => self.execute_memory_unary(AddressMode::Indexed, UnaryOp::Clr, 6, bus),
+            0x70 | 0x71 => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Neg, 7, bus),
+            0x72 => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Xnc, 7, bus),
+            0x73 => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Com, 7, bus),
+            0x74 | 0x75 => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Lsr, 7, bus),
+            0x76 => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Ror, 7, bus),
+            0x77 => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Asr, 7, bus),
+            0x78 => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Asl, 7, bus),
+            0x79 => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Rol, 7, bus),
+            0x7A => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Dec, 7, bus),
+            0x7B => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Xdec, 7, bus),
+            0x7C => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Inc, 7, bus),
+            0x7D => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Tst, 7, bus),
+            0x7E => {
+                self.pc = self.fetch_u16(bus);
+                4
+            }
+            0x7F => self.execute_memory_unary(AddressMode::Extended, UnaryOp::Clr, 7, bus),
+            0x80..=0xFF => {
+                if opcode == 0x8D {
+                    self.short_bsr(bus)
+                } else {
+                    self.execute_load_store_alu(opcode, bus)
+                }
+            }
+            0x10 | 0x11 => 1,
+        }
+    }
+
+    pub(crate) fn address_for_mode(
+        &mut self,
+        mode: AddressMode,
+        bus: &mut impl common::Bus,
+    ) -> EffectiveAddress {
+        match mode {
+            AddressMode::Immediate => EffectiveAddress {
+                address: self.pc,
+                extra_cycles: 0,
+            },
+            AddressMode::Direct => EffectiveAddress {
+                address: self.direct_address(bus),
+                extra_cycles: 0,
+            },
+            AddressMode::Indexed => self.indexed_address(bus),
+            AddressMode::Extended => EffectiveAddress {
+                address: self.fetch_u16(bus),
+                extra_cycles: 0,
+            },
+        }
+    }
+
+    pub(crate) fn read_mode_u8(
+        &mut self,
+        mode: AddressMode,
+        bus: &mut impl common::Bus,
+    ) -> (u8, i32) {
+        match mode {
+            AddressMode::Immediate => (self.fetch_u8(bus), 0),
+            AddressMode::Direct | AddressMode::Indexed | AddressMode::Extended => {
+                let ea = self.address_for_mode(mode, bus);
+                (self.read_byte(bus, ea.address), ea.extra_cycles)
+            }
+        }
+    }
+
+    pub(crate) fn read_mode_u16(
+        &mut self,
+        mode: AddressMode,
+        bus: &mut impl common::Bus,
+    ) -> (u16, i32) {
+        match mode {
+            AddressMode::Immediate => (self.fetch_u16(bus), 0),
+            AddressMode::Direct | AddressMode::Indexed | AddressMode::Extended => {
+                let ea = self.address_for_mode(mode, bus);
+                (self.read_word(bus, ea.address), ea.extra_cycles)
+            }
+        }
+    }
+
+    pub(crate) fn write_mode_u8(
+        &mut self,
+        mode: AddressMode,
+        value: u8,
+        bus: &mut impl common::Bus,
+    ) -> i32 {
+        let ea = self.address_for_mode(mode, bus);
+        self.write_byte(bus, ea.address, value);
+        ea.extra_cycles
+    }
+
+    pub(crate) fn write_mode_u16(
+        &mut self,
+        mode: AddressMode,
+        value: u16,
+        bus: &mut impl common::Bus,
+    ) -> i32 {
+        let ea = self.address_for_mode(mode, bus);
+        self.write_word(bus, ea.address, value);
+        ea.extra_cycles
+    }
+
+    pub(crate) fn condition_hi(&self) -> bool {
+        !(self.flags.carry || self.flags.zero)
+    }
+
+    pub(crate) fn condition_ge(&self) -> bool {
+        self.flags.negative == self.flags.overflow
+    }
+
+    pub(crate) fn condition_gt(&self) -> bool {
+        self.condition_ge() && !self.flags.zero
+    }
+
+    pub(crate) fn short_branch(&mut self, condition: bool, bus: &mut impl common::Bus) -> i32 {
+        let offset = self.fetch_u8(bus) as i8;
+        if condition {
+            self.pc = self.pc.wrapping_add_signed(i16::from(offset));
+        }
+        3
+    }
+
+    pub(crate) fn long_branch(
+        &mut self,
+        condition: bool,
+        bus: &mut impl common::Bus,
+        taken_cycles: i32,
+    ) -> i32 {
+        let offset = self.fetch_u16(bus);
+        if condition {
+            self.pc = self.pc.wrapping_add(offset);
+            taken_cycles
+        } else {
+            taken_cycles - 1
+        }
+    }
+
+    fn short_bsr(&mut self, bus: &mut impl common::Bus) -> i32 {
+        let offset = self.fetch_u8(bus) as i8;
+        let target = self.pc.wrapping_add_signed(i16::from(offset));
+        self.push_s_word(bus, self.pc);
+        self.pc = target;
+        7
+    }
+
+    fn long_bsr(&mut self, bus: &mut impl common::Bus) -> i32 {
+        let offset = self.fetch_u16(bus);
+        let target = self.pc.wrapping_add(offset);
+        self.push_s_word(bus, self.pc);
+        self.pc = target;
+        9
+    }
+
+    fn execute_memory_unary(
+        &mut self,
+        mode: AddressMode,
+        operation: UnaryOp,
+        base_cycles: i32,
+        bus: &mut impl common::Bus,
+    ) -> i32 {
+        let ea = self.address_for_mode(mode, bus);
+        let value = self.read_byte(bus, ea.address);
+        match operation {
+            UnaryOp::Tst => self.tst8(value),
+            UnaryOp::Clr => {
+                let result = self.clr8();
+                self.write_byte(bus, ea.address, result);
+            }
+            UnaryOp::Xclr => {
+                let result = self.xclr8();
+                self.write_byte(bus, ea.address, result);
+            }
+            UnaryOp::Neg
+            | UnaryOp::Xnc
+            | UnaryOp::Com
+            | UnaryOp::Lsr
+            | UnaryOp::Ror
+            | UnaryOp::Asr
+            | UnaryOp::Asl
+            | UnaryOp::Rol
+            | UnaryOp::Dec
+            | UnaryOp::Xdec
+            | UnaryOp::Inc => {
+                let result = self.apply_unary(operation, value);
+                self.write_byte(bus, ea.address, result);
+            }
+        }
+        base_cycles + ea.extra_cycles
+    }
+
+    fn execute_register_unary(&mut self, accumulator_a: bool, operation: UnaryOp) -> i32 {
+        let value = if accumulator_a { self.a } else { self.b };
+        match operation {
+            UnaryOp::Tst => self.tst8(value),
+            UnaryOp::Clr => {
+                let result = self.clr8();
+                if accumulator_a {
+                    self.a = result;
+                } else {
+                    self.b = result;
+                }
+            }
+            UnaryOp::Xclr => {
+                let result = self.xclr8();
+                if accumulator_a {
+                    self.a = result;
+                } else {
+                    self.b = result;
+                }
+            }
+            UnaryOp::Neg
+            | UnaryOp::Xnc
+            | UnaryOp::Com
+            | UnaryOp::Lsr
+            | UnaryOp::Ror
+            | UnaryOp::Asr
+            | UnaryOp::Asl
+            | UnaryOp::Rol
+            | UnaryOp::Dec
+            | UnaryOp::Xdec
+            | UnaryOp::Inc => {
+                let result = self.apply_unary(operation, value);
+                if accumulator_a {
+                    self.a = result;
+                } else {
+                    self.b = result;
+                }
+            }
+        }
+        2
+    }
+
+    fn apply_unary(&mut self, operation: UnaryOp, value: u8) -> u8 {
+        match operation {
+            UnaryOp::Neg => self.neg8(value),
+            UnaryOp::Xnc => {
+                if self.flags.carry {
+                    self.com8(value)
+                } else {
+                    self.neg8(value)
+                }
+            }
+            UnaryOp::Com => self.com8(value),
+            UnaryOp::Lsr => self.lsr8(value),
+            UnaryOp::Ror => self.ror8(value),
+            UnaryOp::Asr => self.asr8(value),
+            UnaryOp::Asl => self.asl8(value),
+            UnaryOp::Rol => self.rol8(value),
+            UnaryOp::Dec => self.dec8(value),
+            UnaryOp::Xdec => self.xdec8(value),
+            UnaryOp::Inc => self.inc8(value),
+            UnaryOp::Tst => {
+                self.tst8(value);
+                value
+            }
+            UnaryOp::Clr => self.clr8(),
+            UnaryOp::Xclr => self.xclr8(),
+        }
+    }
+
+    fn push_or_pull(
+        &mut self,
+        use_hardware_stack: bool,
+        push: bool,
+        bus: &mut impl common::Bus,
+    ) -> i32 {
+        let mask = self.fetch_u8(bus);
+        if push {
+            self.push_registers(bus, use_hardware_stack, mask);
+        } else {
+            self.pull_registers(bus, use_hardware_stack, mask);
+        }
+        5 + push_pull_bytes(mask)
+    }
+
+    fn lea(&mut self, mode: AddressMode, register: u8, bus: &mut impl common::Bus) -> i32 {
+        let ea = self.address_for_mode(mode, bus);
+        match register {
+            0 => self.x = self.set_z16(ea.address),
+            1 => self.y = self.set_z16(ea.address),
+            2 => {
+                self.s = ea.address;
+                self.mark_s_loaded();
+            }
+            3 => self.u = ea.address,
+            _ => {}
+        }
+        4 + ea.extra_cycles
+    }
+
+    fn execute_load_store_alu(&mut self, opcode: u8, bus: &mut impl common::Bus) -> i32 {
+        let mode = match opcode & 0x30 {
+            0x00 => AddressMode::Immediate,
+            0x10 => AddressMode::Direct,
+            0x20 => AddressMode::Indexed,
+            0x30 => AddressMode::Extended,
+            _ => AddressMode::Immediate,
+        };
+        let low = opcode & 0x0F;
+        let accumulator_b_group = opcode >= 0xC0;
+
+        match low {
+            0x00 => self.alu8(mode, accumulator_b_group, bus, |cpu, left, right| {
+                cpu.sub8(left, right)
+            }),
+            0x01 => self.cmp8_mode(mode, accumulator_b_group, bus),
+            0x02 => self.alu8(mode, accumulator_b_group, bus, |cpu, left, right| {
+                cpu.sbc8(left, right)
+            }),
+            0x03 => {
+                if accumulator_b_group {
+                    self.addd_mode(mode, bus)
+                } else {
+                    self.subd_mode(mode, bus)
+                }
+            }
+            0x04 => self.alu8(mode, accumulator_b_group, bus, |cpu, left, right| {
+                cpu.and8(left, right)
+            }),
+            0x05 => self.bit8_mode(mode, accumulator_b_group, bus),
+            0x06 => self.ld8_mode(mode, accumulator_b_group, bus),
+            0x07 => self.st8_mode(mode, accumulator_b_group, bus),
+            0x08 => self.alu8(mode, accumulator_b_group, bus, |cpu, left, right| {
+                cpu.eor8(left, right)
+            }),
+            0x09 => self.alu8(mode, accumulator_b_group, bus, |cpu, left, right| {
+                cpu.adc8(left, right)
+            }),
+            0x0A => self.alu8(mode, accumulator_b_group, bus, |cpu, left, right| {
+                cpu.or8(left, right)
+            }),
+            0x0B => self.alu8(mode, accumulator_b_group, bus, |cpu, left, right| {
+                cpu.add8(left, right)
+            }),
+            0x0C => {
+                if accumulator_b_group {
+                    self.ldd_mode(mode, bus)
+                } else {
+                    self.cmpx_mode(mode, bus)
+                }
+            }
+            0x0D => {
+                if accumulator_b_group {
+                    self.std_mode(mode, bus)
+                } else {
+                    self.jsr_mode(mode, bus)
+                }
+            }
+            0x0E => {
+                if accumulator_b_group {
+                    self.ldu_mode(mode, bus)
+                } else {
+                    self.ldx_mode(mode, bus)
+                }
+            }
+            0x0F => {
+                if accumulator_b_group {
+                    self.stu_mode(mode, bus)
+                } else {
+                    self.stx_mode(mode, bus)
+                }
+            }
+            _ => 1,
+        }
+    }
+
+    fn alu8(
+        &mut self,
+        mode: AddressMode,
+        accumulator_b: bool,
+        bus: &mut impl common::Bus,
+        operation: fn(&mut M6809, u8, u8) -> u8,
+    ) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u8(mode, bus);
+        let value = if accumulator_b { self.b } else { self.a };
+        let result = operation(self, value, operand);
+        if accumulator_b {
+            self.b = result;
+        } else {
+            self.a = result;
+        }
+        mode_cycles(mode, 2, 4, 4, 5) + extra_cycles
+    }
+
+    fn cmp8_mode(
+        &mut self,
+        mode: AddressMode,
+        accumulator_b: bool,
+        bus: &mut impl common::Bus,
+    ) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u8(mode, bus);
+        let value = if accumulator_b { self.b } else { self.a };
+        self.cmp8(value, operand);
+        mode_cycles(mode, 2, 4, 4, 5) + extra_cycles
+    }
+
+    fn bit8_mode(
+        &mut self,
+        mode: AddressMode,
+        accumulator_b: bool,
+        bus: &mut impl common::Bus,
+    ) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u8(mode, bus);
+        let value = if accumulator_b { self.b } else { self.a };
+        self.bit8(value, operand);
+        mode_cycles(mode, 2, 4, 4, 5) + extra_cycles
+    }
+
+    fn ld8_mode(
+        &mut self,
+        mode: AddressMode,
+        accumulator_b: bool,
+        bus: &mut impl common::Bus,
+    ) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u8(mode, bus);
+        let value = self.set_nzv8(operand);
+        if accumulator_b {
+            self.b = value;
+        } else {
+            self.a = value;
+        }
+        mode_cycles(mode, 2, 4, 4, 5) + extra_cycles
+    }
+
+    fn st8_mode(
+        &mut self,
+        mode: AddressMode,
+        accumulator_b: bool,
+        bus: &mut impl common::Bus,
+    ) -> i32 {
+        let value = if accumulator_b { self.b } else { self.a };
+        self.set_nzv8(value);
+        if mode == AddressMode::Immediate {
+            let _ = self.fetch_u8(bus);
+            2
+        } else {
+            let extra_cycles = self.write_mode_u8(mode, value, bus);
+            mode_cycles(mode, 2, 4, 4, 5) + extra_cycles
+        }
+    }
+
+    fn subd_mode(&mut self, mode: AddressMode, bus: &mut impl common::Bus) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u16(mode, bus);
+        let result = self.sub16(self.d(), operand);
+        self.set_d(result);
+        mode_cycles(mode, 4, 6, 6, 7) + extra_cycles
+    }
+
+    fn addd_mode(&mut self, mode: AddressMode, bus: &mut impl common::Bus) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u16(mode, bus);
+        let result = self.add16(self.d(), operand);
+        self.set_d(result);
+        mode_cycles(mode, 4, 6, 6, 7) + extra_cycles
+    }
+
+    pub(crate) fn cmpd_mode(&mut self, mode: AddressMode, bus: &mut impl common::Bus) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u16(mode, bus);
+        self.cmp16(self.d(), operand);
+        mode_cycles(mode, 5, 7, 7, 8) + extra_cycles
+    }
+
+    fn cmpx_mode(&mut self, mode: AddressMode, bus: &mut impl common::Bus) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u16(mode, bus);
+        self.cmp16(self.x, operand);
+        mode_cycles(mode, 4, 6, 6, 7) + extra_cycles
+    }
+
+    fn ldd_mode(&mut self, mode: AddressMode, bus: &mut impl common::Bus) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u16(mode, bus);
+        let value = self.set_nzv16(operand);
+        self.set_d(value);
+        mode_cycles(mode, 3, 5, 5, 6) + extra_cycles
+    }
+
+    fn std_mode(&mut self, mode: AddressMode, bus: &mut impl common::Bus) -> i32 {
+        let value = self.d();
+        self.set_nzv16(value);
+        if mode == AddressMode::Immediate {
+            self.xst16_immediate(value, bus);
+            3
+        } else {
+            let extra_cycles = self.write_mode_u16(mode, value, bus);
+            mode_cycles(mode, 3, 5, 5, 6) + extra_cycles
+        }
+    }
+
+    fn ldx_mode(&mut self, mode: AddressMode, bus: &mut impl common::Bus) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u16(mode, bus);
+        self.x = self.set_nzv16(operand);
+        mode_cycles(mode, 3, 5, 5, 6) + extra_cycles
+    }
+
+    fn stx_mode(&mut self, mode: AddressMode, bus: &mut impl common::Bus) -> i32 {
+        if mode == AddressMode::Immediate {
+            let value = self.x;
+            self.set_nzv16(value);
+            self.xst16_immediate(value, bus);
+            3
+        } else {
+            let ea = self.address_for_mode(mode, bus);
+            let value = self.x;
+            self.set_nzv16(value);
+            self.write_word(bus, ea.address, value);
+            let extra_cycles = ea.extra_cycles;
+            mode_cycles(mode, 3, 5, 5, 6) + extra_cycles
+        }
+    }
+
+    fn ldu_mode(&mut self, mode: AddressMode, bus: &mut impl common::Bus) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u16(mode, bus);
+        self.u = self.set_nzv16(operand);
+        mode_cycles(mode, 3, 5, 5, 6) + extra_cycles
+    }
+
+    fn stu_mode(&mut self, mode: AddressMode, bus: &mut impl common::Bus) -> i32 {
+        if mode == AddressMode::Immediate {
+            let value = self.u;
+            self.set_nzv16(value);
+            self.xst16_immediate(value, bus);
+            3
+        } else {
+            let ea = self.address_for_mode(mode, bus);
+            let value = self.u;
+            self.set_nzv16(value);
+            self.write_word(bus, ea.address, value);
+            let extra_cycles = ea.extra_cycles;
+            mode_cycles(mode, 3, 5, 5, 6) + extra_cycles
+        }
+    }
+
+    fn jsr_mode(&mut self, mode: AddressMode, bus: &mut impl common::Bus) -> i32 {
+        let ea = self.address_for_mode(mode, bus);
+        self.push_s_word(bus, self.pc);
+        self.pc = ea.address;
+        mode_cycles(mode, 7, 7, 7, 8) + ea.extra_cycles
+    }
+
+    pub(crate) fn cmp_register_mode(
+        &mut self,
+        mode: AddressMode,
+        register_value: u16,
+        bus: &mut impl common::Bus,
+    ) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u16(mode, bus);
+        self.cmp16(register_value, operand);
+        mode_cycles(mode, 5, 7, 7, 8) + extra_cycles
+    }
+
+    pub(crate) fn ld_register_mode(
+        &mut self,
+        mode: AddressMode,
+        bus: &mut impl common::Bus,
+    ) -> (u16, i32) {
+        let (operand, extra_cycles) = self.read_mode_u16(mode, bus);
+        (
+            self.set_nzv16(operand),
+            mode_cycles(mode, 4, 6, 6, 7) + extra_cycles,
+        )
+    }
+
+    pub(crate) fn st_register_mode(
+        &mut self,
+        mode: AddressMode,
+        register: u8,
+        bus: &mut impl common::Bus,
+    ) -> i32 {
+        if mode == AddressMode::Immediate {
+            let value = self.register16_value(register);
+            self.set_nzv16(value);
+            self.xst16_immediate(value, bus);
+            4
+        } else {
+            let ea = self.address_for_mode(mode, bus);
+            let value = self.register16_value(register);
+            self.set_nzv16(value);
+            self.write_word(bus, ea.address, value);
+            let extra_cycles = ea.extra_cycles;
+            mode_cycles(mode, 4, 6, 6, 7) + extra_cycles
+        }
+    }
+
+    pub(crate) fn xadd16_mode(
+        &mut self,
+        mode: AddressMode,
+        register_value: u16,
+        bus: &mut impl common::Bus,
+    ) -> i32 {
+        let (operand, extra_cycles) = self.read_mode_u16(mode, bus);
+        let _ = self.add16(register_value, operand);
+        mode_cycles(mode, 5, 7, 7, 8) + extra_cycles
+    }
+
+    fn xst16_immediate(&mut self, value: u16, bus: &mut impl common::Bus) {
+        let _ = self.fetch_u8(bus);
+        self.write_byte(bus, self.pc, value as u8);
+        self.pc = self.pc.wrapping_add(1);
+    }
+
+    fn x18(&mut self, bus: &mut impl common::Bus) -> i32 {
+        let operand = self.read_byte(bus, self.pc);
+        let condition_code = self.flags.compress();
+        let value = (condition_code & operand) << 1;
+        self.flags
+            .expand(value | ((condition_code & M6809Flags::ZERO) >> 1));
+        2
+    }
+
+    fn exg(&mut self, bus: &mut impl common::Bus) -> i32 {
+        let parameter = self.fetch_u8(bus);
+        let (left, right) = if parameter & 0x80 != 0 {
+            (
+                self.read_tfr_exg_816_register(parameter >> 4),
+                self.read_tfr_exg_816_register(parameter),
+            )
+        } else {
+            (
+                self.read_exg_168_register(parameter >> 4),
+                self.read_exg_168_register(parameter),
+            )
+        };
+        self.write_exgtfr_register(parameter, left, false);
+        self.write_exgtfr_register(parameter >> 4, right, false);
+        8
+    }
+
+    fn tfr(&mut self, bus: &mut impl common::Bus) -> i32 {
+        let parameter = self.fetch_u8(bus);
+        let value = self.read_tfr_exg_816_register(parameter >> 4);
+        self.write_exgtfr_register(parameter, value, true);
+        6
+    }
+
+    fn read_tfr_exg_816_register(&self, register: u8) -> u16 {
+        match register & 0x0F {
+            0x00 => self.d(),
+            0x01 => self.x,
+            0x02 => self.y,
+            0x03 => self.u,
+            0x04 => self.s,
+            0x05 => self.pc,
+            0x08 => 0xFF00 | u16::from(self.a),
+            0x09 => 0xFF00 | u16::from(self.b),
+            0x0A => (u16::from(self.flags.compress()) << 8) | u16::from(self.flags.compress()),
+            0x0B => (u16::from(self.dp) << 8) | u16::from(self.dp),
+            0x06 | 0x07 | 0x0C | 0x0D | 0x0E | 0x0F => 0xFFFF,
+            _ => 0xFFFF,
+        }
+    }
+
+    fn read_exg_168_register(&self, register: u8) -> u16 {
+        match register & 0x0F {
+            0x00 => self.d(),
+            0x01 => self.x,
+            0x02 => self.y,
+            0x03 => self.u,
+            0x04 => self.s,
+            0x05 => self.pc,
+            0x08 => 0xFF00 | u16::from(self.a),
+            0x09 => 0xFF00 | u16::from(self.b),
+            0x0A => 0xFF00 | u16::from(self.flags.compress()),
+            0x0B => 0xFF00 | u16::from(self.dp),
+            0x06 | 0x07 | 0x0C | 0x0D | 0x0E | 0x0F => 0xFFFF,
+            _ => 0xFFFF,
+        }
+    }
+
+    fn write_exgtfr_register(&mut self, register: u8, value: u16, mark_s_loaded: bool) {
+        match register & 0x0F {
+            0x00 => self.set_d(value),
+            0x01 => self.x = value,
+            0x02 => self.y = value,
+            0x03 => self.u = value,
+            0x04 => {
+                self.s = value;
+                if mark_s_loaded {
+                    self.mark_s_loaded();
+                }
+            }
+            0x05 => self.pc = value,
+            0x08 => self.a = value as u8,
+            0x09 => self.b = value as u8,
+            0x0A => self.flags.expand(value as u8),
+            0x0B => self.dp = value as u8,
+            0x06 | 0x07 | 0x0C | 0x0D | 0x0E | 0x0F => {}
+            _ => {}
+        }
+    }
+
+    fn register16_value(&self, register: u8) -> u16 {
+        match register {
+            0 => self.x,
+            1 => self.y,
+            2 => self.u,
+            3 => self.s,
+            _ => 0xFFFF,
+        }
+    }
+}
+
+pub(crate) fn mode_cycles(
+    mode: AddressMode,
+    immediate: i32,
+    direct: i32,
+    indexed: i32,
+    extended: i32,
+) -> i32 {
+    match mode {
+        AddressMode::Immediate => immediate,
+        AddressMode::Direct => direct,
+        AddressMode::Indexed => indexed,
+        AddressMode::Extended => extended,
+    }
+}
+
+fn push_pull_bytes(mask: u8) -> i32 {
+    i32::from(mask & 0x01 != 0)
+        + i32::from(mask & 0x02 != 0)
+        + i32::from(mask & 0x04 != 0)
+        + i32::from(mask & 0x08 != 0)
+        + if mask & 0x10 != 0 { 2 } else { 0 }
+        + if mask & 0x20 != 0 { 2 } else { 0 }
+        + if mask & 0x40 != 0 { 2 } else { 0 }
+        + if mask & 0x80 != 0 { 2 } else { 0 }
+}

--- a/crates/cpu/src/m6809/execute_page2.rs
+++ b/crates/cpu/src/m6809/execute_page2.rs
@@ -1,0 +1,130 @@
+use super::{AddressMode, M6809};
+
+impl M6809 {
+    pub(crate) fn execute_page2(&mut self, opcode: u8, bus: &mut impl common::Bus) -> i32 {
+        match opcode {
+            0x20 => self.long_branch(true, bus, 6),
+            0x21 => self.long_branch(false, bus, 6),
+            0x22 => self.long_branch(self.condition_hi(), bus, 6),
+            0x23 => self.long_branch(!self.condition_hi(), bus, 6),
+            0x24 => self.long_branch(!self.flags.carry, bus, 6),
+            0x25 => self.long_branch(self.flags.carry, bus, 6),
+            0x26 => self.long_branch(!self.flags.zero, bus, 6),
+            0x27 => self.long_branch(self.flags.zero, bus, 6),
+            0x28 => self.long_branch(!self.flags.overflow, bus, 6),
+            0x29 => self.long_branch(self.flags.overflow, bus, 6),
+            0x2A => self.long_branch(!self.flags.negative, bus, 6),
+            0x2B => self.long_branch(self.flags.negative, bus, 6),
+            0x2C => self.long_branch(self.condition_ge(), bus, 6),
+            0x2D => self.long_branch(!self.condition_ge(), bus, 6),
+            0x2E => self.long_branch(self.condition_gt(), bus, 6),
+            0x2F => self.long_branch(!self.condition_gt(), bus, 6),
+            0x3E => {
+                self.x_swi2(bus);
+                20
+            }
+            0x3F => {
+                self.swi2(bus);
+                20
+            }
+            0x83 => self.cmpd_mode(AddressMode::Immediate, bus),
+            0x87 => {
+                let _ = self.fetch_u8(bus);
+                self.set_nzv8(self.a);
+                3
+            }
+            0x8C => self.cmp_register_mode(AddressMode::Immediate, self.y, bus),
+            0x8E => {
+                let (value, cycles) = self.ld_register_mode(AddressMode::Immediate, bus);
+                self.y = value;
+                cycles
+            }
+            0x8F => self.st_register_mode(AddressMode::Immediate, 1, bus),
+            0x93 => self.cmpd_mode(AddressMode::Direct, bus),
+            0x9C => self.cmp_register_mode(AddressMode::Direct, self.y, bus),
+            0x9E => {
+                let (value, cycles) = self.ld_register_mode(AddressMode::Direct, bus);
+                self.y = value;
+                cycles
+            }
+            0x9F => self.st_register_mode(AddressMode::Direct, 1, bus),
+            0xA3 => self.cmpd_mode(AddressMode::Indexed, bus),
+            0xAC => self.cmp_register_mode(AddressMode::Indexed, self.y, bus),
+            0xAE => {
+                let (value, cycles) = self.ld_register_mode(AddressMode::Indexed, bus);
+                self.y = value;
+                cycles
+            }
+            0xAF => self.st_register_mode(AddressMode::Indexed, 1, bus),
+            0xB3 => self.cmpd_mode(AddressMode::Extended, bus),
+            0xBC => self.cmp_register_mode(AddressMode::Extended, self.y, bus),
+            0xBE => {
+                let (value, cycles) = self.ld_register_mode(AddressMode::Extended, bus);
+                self.y = value;
+                cycles
+            }
+            0xBF => self.st_register_mode(AddressMode::Extended, 1, bus),
+            0xC3 => self.xadd16_mode(AddressMode::Immediate, self.d(), bus),
+            0xC7 => {
+                let _ = self.fetch_u8(bus);
+                self.set_nzv8(self.b);
+                3
+            }
+            0xCE => {
+                let (value, cycles) = self.ld_register_mode(AddressMode::Immediate, bus);
+                self.s = value;
+                self.mark_s_loaded();
+                cycles
+            }
+            0xCF => self.st_register_mode(AddressMode::Immediate, 3, bus),
+            0xD3 => self.xadd16_mode(AddressMode::Direct, self.d(), bus),
+            0xDE => {
+                let (value, cycles) = self.ld_register_mode(AddressMode::Direct, bus);
+                self.s = value;
+                self.mark_s_loaded();
+                cycles
+            }
+            0xDF => self.st_register_mode(AddressMode::Direct, 3, bus),
+            0xE3 => self.xadd16_mode(AddressMode::Indexed, self.d(), bus),
+            0xEE => {
+                let (value, cycles) = self.ld_register_mode(AddressMode::Indexed, bus);
+                self.s = value;
+                self.mark_s_loaded();
+                cycles
+            }
+            0xEF => self.st_register_mode(AddressMode::Indexed, 3, bus),
+            0xF3 => self.xadd16_mode(AddressMode::Extended, self.d(), bus),
+            0xFE => {
+                let (value, cycles) = self.ld_register_mode(AddressMode::Extended, bus);
+                self.s = value;
+                self.mark_s_loaded();
+                cycles
+            }
+            0xFF => self.st_register_mode(AddressMode::Extended, 3, bus),
+            0x00..=0x1F
+            | 0x30..=0x3D
+            | 0x40..=0x82
+            | 0x84..=0x86
+            | 0x88..=0x8B
+            | 0x8D
+            | 0x90..=0x92
+            | 0x94..=0x9B
+            | 0x9D
+            | 0xA0..=0xA2
+            | 0xA4..=0xAB
+            | 0xAD
+            | 0xB0..=0xB2
+            | 0xB4..=0xBB
+            | 0xBD
+            | 0xC0..=0xC2
+            | 0xC4..=0xC6
+            | 0xC8..=0xCD
+            | 0xD0..=0xD2
+            | 0xD4..=0xDD
+            | 0xE0..=0xE2
+            | 0xE4..=0xED
+            | 0xF0..=0xF2
+            | 0xF4..=0xFD => 2,
+        }
+    }
+}

--- a/crates/cpu/src/m6809/execute_page3.rs
+++ b/crates/cpu/src/m6809/execute_page3.rs
@@ -1,0 +1,58 @@
+use super::{AddressMode, M6809};
+
+impl M6809 {
+    pub(crate) fn execute_page3(&mut self, opcode: u8, bus: &mut impl common::Bus) -> i32 {
+        match opcode {
+            0x3E => {
+                self.x_firq(bus);
+                20
+            }
+            0x3F => {
+                self.swi3(bus);
+                20
+            }
+            0x83 => self.cmp_register_mode(AddressMode::Immediate, self.u, bus),
+            0x87 => {
+                let _ = self.fetch_u8(bus);
+                self.set_nzv8(self.a);
+                3
+            }
+            0x8C => self.cmp_register_mode(AddressMode::Immediate, self.s, bus),
+            0x8F => self.st_register_mode(AddressMode::Immediate, 0, bus),
+            0x93 => self.cmp_register_mode(AddressMode::Direct, self.u, bus),
+            0x9C => self.cmp_register_mode(AddressMode::Direct, self.s, bus),
+            0xA3 => self.cmp_register_mode(AddressMode::Indexed, self.u, bus),
+            0xAC => self.cmp_register_mode(AddressMode::Indexed, self.s, bus),
+            0xB3 => self.cmp_register_mode(AddressMode::Extended, self.u, bus),
+            0xBC => self.cmp_register_mode(AddressMode::Extended, self.s, bus),
+            0xC3 => self.xadd16_mode(AddressMode::Immediate, self.u, bus),
+            0xC7 => {
+                let _ = self.fetch_u8(bus);
+                self.set_nzv8(self.b);
+                3
+            }
+            0xCF => self.st_register_mode(AddressMode::Immediate, 2, bus),
+            0xD3 => self.xadd16_mode(AddressMode::Direct, self.u, bus),
+            0xE3 => self.xadd16_mode(AddressMode::Indexed, self.u, bus),
+            0xF3 => self.xadd16_mode(AddressMode::Extended, self.u, bus),
+            0x00..=0x3D
+            | 0x40..=0x82
+            | 0x84..=0x86
+            | 0x88..=0x8B
+            | 0x8D..=0x8E
+            | 0x90..=0x92
+            | 0x94..=0x9B
+            | 0x9D..=0xA2
+            | 0xA4..=0xAB
+            | 0xAD..=0xB2
+            | 0xB4..=0xBB
+            | 0xBD..=0xC2
+            | 0xC4..=0xC6
+            | 0xC8..=0xCE
+            | 0xD0..=0xD2
+            | 0xD4..=0xE2
+            | 0xE4..=0xF2
+            | 0xF4..=0xFF => 2,
+        }
+    }
+}

--- a/crates/cpu/src/m6809/flags.rs
+++ b/crates/cpu/src/m6809/flags.rs
@@ -1,0 +1,81 @@
+/// Motorola 6809 condition code register state.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct M6809Flags {
+    /// Entire state flag.
+    pub entire: bool,
+    /// FIRQ mask flag.
+    pub firq_mask: bool,
+    /// Half-carry flag.
+    pub half_carry: bool,
+    /// IRQ mask flag.
+    pub irq_mask: bool,
+    /// Negative flag.
+    pub negative: bool,
+    /// Zero flag.
+    pub zero: bool,
+    /// Overflow flag.
+    pub overflow: bool,
+    /// Carry flag.
+    pub carry: bool,
+}
+
+impl M6809Flags {
+    /// Entire-state bit.
+    pub const ENTIRE: u8 = 0x80;
+    /// FIRQ mask bit.
+    pub const FIRQ_MASK: u8 = 0x40;
+    /// Half-carry bit.
+    pub const HALF_CARRY: u8 = 0x20;
+    /// IRQ mask bit.
+    pub const IRQ_MASK: u8 = 0x10;
+    /// Negative bit.
+    pub const NEGATIVE: u8 = 0x08;
+    /// Zero bit.
+    pub const ZERO: u8 = 0x04;
+    /// Overflow bit.
+    pub const OVERFLOW: u8 = 0x02;
+    /// Carry bit.
+    pub const CARRY: u8 = 0x01;
+
+    pub(crate) const NZ: u8 = Self::NEGATIVE | Self::ZERO;
+    pub(crate) const NZV: u8 = Self::NEGATIVE | Self::ZERO | Self::OVERFLOW;
+    pub(crate) const NZVC: u8 = Self::NEGATIVE | Self::ZERO | Self::OVERFLOW | Self::CARRY;
+    pub(crate) const HNZVC: u8 =
+        Self::HALF_CARRY | Self::NEGATIVE | Self::ZERO | Self::OVERFLOW | Self::CARRY;
+
+    /// Creates flags from a packed condition code byte.
+    pub fn new(value: u8) -> Self {
+        let mut flags = Self::default();
+        flags.expand(value);
+        flags
+    }
+
+    /// Returns the packed condition code byte.
+    pub const fn compress(self) -> u8 {
+        (if self.entire { Self::ENTIRE } else { 0 })
+            | (if self.firq_mask { Self::FIRQ_MASK } else { 0 })
+            | (if self.half_carry { Self::HALF_CARRY } else { 0 })
+            | (if self.irq_mask { Self::IRQ_MASK } else { 0 })
+            | (if self.negative { Self::NEGATIVE } else { 0 })
+            | (if self.zero { Self::ZERO } else { 0 })
+            | (if self.overflow { Self::OVERFLOW } else { 0 })
+            | (if self.carry { Self::CARRY } else { 0 })
+    }
+
+    /// Replaces all flags from a packed condition code byte.
+    pub fn expand(&mut self, value: u8) {
+        self.entire = value & Self::ENTIRE != 0;
+        self.firq_mask = value & Self::FIRQ_MASK != 0;
+        self.half_carry = value & Self::HALF_CARRY != 0;
+        self.irq_mask = value & Self::IRQ_MASK != 0;
+        self.negative = value & Self::NEGATIVE != 0;
+        self.zero = value & Self::ZERO != 0;
+        self.overflow = value & Self::OVERFLOW != 0;
+        self.carry = value & Self::CARRY != 0;
+    }
+
+    pub(crate) fn set_bits(&mut self, mask: u8, value: u8) {
+        let next = (self.compress() & !mask) | (value & mask);
+        self.expand(next);
+    }
+}

--- a/crates/cpu/src/m6809/indexed.rs
+++ b/crates/cpu/src/m6809/indexed.rs
@@ -1,0 +1,177 @@
+use super::{EffectiveAddress, M6809};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IndexRegister {
+    X,
+    Y,
+    U,
+    S,
+}
+
+impl M6809 {
+    pub(crate) fn indexed_address(&mut self, bus: &mut impl common::Bus) -> EffectiveAddress {
+        let postbyte = self.fetch_u8(bus);
+        let index_register = match postbyte & 0x60 {
+            0x00 => IndexRegister::X,
+            0x20 => IndexRegister::Y,
+            0x40 => IndexRegister::U,
+            0x60 => IndexRegister::S,
+            _ => IndexRegister::X,
+        };
+        let extra_cycles = indexed_extra_cycles(postbyte);
+
+        let mut address = if postbyte & 0x80 == 0 {
+            let offset = ((postbyte & 0x0F) | if postbyte & 0x10 != 0 { 0xF0 } else { 0 }) as i8;
+            self.index_register(index_register)
+                .wrapping_add_signed(i16::from(offset))
+        } else {
+            match postbyte & 0x0F {
+                0x00 => {
+                    let value = self.index_register(index_register);
+                    self.set_index_register(index_register, value.wrapping_add(1));
+                    value
+                }
+                0x01 => {
+                    let value = self.index_register(index_register);
+                    self.set_index_register(index_register, value.wrapping_add(2));
+                    value
+                }
+                0x02 => {
+                    let value = self.index_register(index_register).wrapping_sub(1);
+                    self.set_index_register(index_register, value);
+                    value
+                }
+                0x03 => {
+                    let value = self.index_register(index_register).wrapping_sub(2);
+                    self.set_index_register(index_register, value);
+                    value
+                }
+                0x04 => self.index_register(index_register),
+                0x05 => self
+                    .index_register(index_register)
+                    .wrapping_add_signed(i16::from(self.b as i8)),
+                0x06 => self
+                    .index_register(index_register)
+                    .wrapping_add_signed(i16::from(self.a as i8)),
+                0x08 => {
+                    let offset = self.fetch_u8(bus) as i8;
+                    self.index_register(index_register)
+                        .wrapping_add_signed(i16::from(offset))
+                }
+                0x09 => {
+                    let offset = self.fetch_u16(bus);
+                    self.index_register(index_register).wrapping_add(offset)
+                }
+                0x0B => self.index_register(index_register).wrapping_add(self.d()),
+                0x0C => {
+                    let offset = self.fetch_u8(bus) as i8;
+                    self.pc.wrapping_add_signed(i16::from(offset))
+                }
+                0x0D => {
+                    let offset = self.fetch_u16(bus);
+                    self.pc.wrapping_add(offset)
+                }
+                0x0F => self.fetch_u16(bus),
+                0x07 | 0x0A | 0x0E => 0,
+                _ => 0,
+            }
+        };
+
+        if postbyte & 0x90 == 0x90 {
+            address = self.read_word(bus, address);
+        }
+
+        EffectiveAddress {
+            address,
+            extra_cycles,
+        }
+    }
+
+    #[inline(always)]
+    fn index_register(&self, register: IndexRegister) -> u16 {
+        match register {
+            IndexRegister::X => self.x,
+            IndexRegister::Y => self.y,
+            IndexRegister::U => self.u,
+            IndexRegister::S => self.s,
+        }
+    }
+
+    #[inline(always)]
+    fn set_index_register(&mut self, register: IndexRegister, value: u16) {
+        match register {
+            IndexRegister::X => self.x = value,
+            IndexRegister::Y => self.y = value,
+            IndexRegister::U => self.u = value,
+            IndexRegister::S => self.s = value,
+        }
+    }
+}
+
+#[inline(always)]
+fn indexed_extra_cycles(postbyte: u8) -> i32 {
+    if postbyte & 0x80 == 0 {
+        return 1;
+    }
+
+    let indirect = postbyte & 0x10 != 0;
+    match postbyte & 0x0F {
+        0x00 | 0x02 => {
+            if indirect {
+                5
+            } else {
+                2
+            }
+        }
+        0x01 | 0x03 => {
+            if indirect {
+                6
+            } else {
+                3
+            }
+        }
+        0x04 => {
+            if indirect {
+                3
+            } else {
+                0
+            }
+        }
+        0x05 | 0x06 | 0x08 | 0x0C => {
+            if indirect {
+                4
+            } else {
+                1
+            }
+        }
+        0x09 | 0x0B => {
+            if indirect {
+                7
+            } else {
+                4
+            }
+        }
+        0x0D => {
+            if indirect {
+                8
+            } else {
+                5
+            }
+        }
+        0x0F => {
+            if indirect {
+                5
+            } else {
+                2
+            }
+        }
+        0x07 | 0x0A | 0x0E => {
+            if indirect {
+                2
+            } else {
+                -1
+            }
+        }
+        _ => 0,
+    }
+}

--- a/crates/cpu/src/m6809/interrupt.rs
+++ b/crates/cpu/src/m6809/interrupt.rs
@@ -1,0 +1,214 @@
+use super::{
+    M6809, PENDING_FIRQ, VECTOR_FIRQ, VECTOR_IRQ, VECTOR_NMI, VECTOR_SWI, VECTOR_SWI2, VECTOR_SWI3,
+};
+
+const PARTIAL_STATE_MASK: u8 = 0x81;
+const ENTIRE_STATE_MASK: u8 = 0xFF;
+
+impl M6809 {
+    pub(crate) fn check_interrupts(&mut self, bus: &mut impl common::Bus) -> Option<i32> {
+        if self.pending_irq & crate::PENDING_NMI != 0 {
+            self.service_nmi(bus);
+            Some(19)
+        } else if self.pending_irq & PENDING_FIRQ != 0 && !self.flags.firq_mask {
+            self.service_firq(bus);
+            Some(10)
+        } else if self.pending_irq & crate::PENDING_IRQ != 0 && !self.flags.irq_mask {
+            self.service_irq(bus);
+            Some(19)
+        } else {
+            None
+        }
+    }
+
+    fn service_nmi(&mut self, bus: &mut impl common::Bus) {
+        self.halted = false;
+        self.flags.entire = true;
+        self.push_registers(bus, true, ENTIRE_STATE_MASK);
+        self.flags.irq_mask = true;
+        self.flags.firq_mask = true;
+        self.pc = self.read_word(bus, VECTOR_NMI);
+        self.pending_irq &= !crate::PENDING_NMI;
+        bus.acknowledge_nmi();
+    }
+
+    fn service_firq(&mut self, bus: &mut impl common::Bus) {
+        self.halted = false;
+        self.flags.entire = false;
+        self.push_registers(bus, true, PARTIAL_STATE_MASK);
+        self.flags.irq_mask = true;
+        self.flags.firq_mask = true;
+        self.pc = self.read_word(bus, VECTOR_FIRQ);
+        self.pending_irq &= !PENDING_FIRQ;
+    }
+
+    fn service_irq(&mut self, bus: &mut impl common::Bus) {
+        self.halted = false;
+        self.flags.entire = true;
+        self.push_registers(bus, true, ENTIRE_STATE_MASK);
+        self.flags.irq_mask = true;
+        self.pc = self.read_word(bus, VECTOR_IRQ);
+        self.pending_irq &= !crate::PENDING_IRQ;
+        let _ = bus.acknowledge_irq();
+    }
+
+    pub(crate) fn swi(&mut self, bus: &mut impl common::Bus) {
+        self.software_interrupt(bus, VECTOR_SWI, true, true, true);
+    }
+
+    pub(crate) fn swi2(&mut self, bus: &mut impl common::Bus) {
+        self.software_interrupt(bus, VECTOR_SWI2, false, false, true);
+    }
+
+    pub(crate) fn swi3(&mut self, bus: &mut impl common::Bus) {
+        self.software_interrupt(bus, VECTOR_SWI3, false, false, true);
+    }
+
+    pub(crate) fn x_swi2(&mut self, bus: &mut impl common::Bus) {
+        self.software_interrupt(bus, VECTOR_SWI2, false, false, false);
+    }
+
+    pub(crate) fn x_firq(&mut self, bus: &mut impl common::Bus) {
+        self.software_interrupt(bus, VECTOR_FIRQ, false, false, false);
+    }
+
+    pub(crate) fn x_reset(&mut self, bus: &mut impl common::Bus) {
+        self.software_interrupt(bus, super::VECTOR_RESET, false, false, false);
+    }
+
+    fn software_interrupt(
+        &mut self,
+        bus: &mut impl common::Bus,
+        vector: u16,
+        set_irq_mask: bool,
+        set_firq_mask: bool,
+        set_entire: bool,
+    ) {
+        if set_entire {
+            self.flags.entire = true;
+        }
+        self.push_registers(bus, true, ENTIRE_STATE_MASK);
+        if set_irq_mask {
+            self.flags.irq_mask = true;
+        }
+        if set_firq_mask {
+            self.flags.firq_mask = true;
+        }
+        self.pc = self.read_word(bus, vector);
+    }
+
+    pub(crate) fn rti(&mut self, bus: &mut impl common::Bus) -> i32 {
+        let condition_code = self.pull_s_byte(bus);
+        self.flags.expand(condition_code);
+        if self.flags.entire {
+            self.a = self.pull_s_byte(bus);
+            self.b = self.pull_s_byte(bus);
+            self.dp = self.pull_s_byte(bus);
+            self.x = self.pull_s_word(bus);
+            self.y = self.pull_s_word(bus);
+            self.u = self.pull_s_word(bus);
+            self.pc = self.pull_s_word(bus);
+            15
+        } else {
+            self.pc = self.pull_s_word(bus);
+            6
+        }
+    }
+
+    pub(crate) fn push_registers(
+        &mut self,
+        bus: &mut impl common::Bus,
+        use_hardware_stack: bool,
+        mask: u8,
+    ) {
+        let mut stack = if use_hardware_stack { self.s } else { self.u };
+        if mask & 0x80 != 0 {
+            self.push_word(bus, &mut stack, self.pc);
+        }
+        if mask & 0x40 != 0 {
+            let value = if use_hardware_stack { self.u } else { self.s };
+            self.push_word(bus, &mut stack, value);
+        }
+        if mask & 0x20 != 0 {
+            self.push_word(bus, &mut stack, self.y);
+        }
+        if mask & 0x10 != 0 {
+            self.push_word(bus, &mut stack, self.x);
+        }
+        if mask & 0x08 != 0 {
+            self.push_byte(bus, &mut stack, self.dp);
+        }
+        if mask & 0x04 != 0 {
+            self.push_byte(bus, &mut stack, self.b);
+        }
+        if mask & 0x02 != 0 {
+            self.push_byte(bus, &mut stack, self.a);
+        }
+        if mask & 0x01 != 0 {
+            self.push_byte(bus, &mut stack, self.flags.compress());
+        }
+        if use_hardware_stack {
+            self.s = stack;
+        } else {
+            self.u = stack;
+        }
+    }
+
+    pub(crate) fn pull_registers(
+        &mut self,
+        bus: &mut impl common::Bus,
+        use_hardware_stack: bool,
+        mask: u8,
+    ) {
+        let mut stack = if use_hardware_stack { self.s } else { self.u };
+        if mask & 0x01 != 0 {
+            let value = self.pull_byte(bus, &mut stack);
+            self.flags.expand(value);
+        }
+        if mask & 0x02 != 0 {
+            self.a = self.pull_byte(bus, &mut stack);
+        }
+        if mask & 0x04 != 0 {
+            self.b = self.pull_byte(bus, &mut stack);
+        }
+        if mask & 0x08 != 0 {
+            self.dp = self.pull_byte(bus, &mut stack);
+        }
+        if mask & 0x10 != 0 {
+            self.x = self.pull_word(bus, &mut stack);
+        }
+        if mask & 0x20 != 0 {
+            self.y = self.pull_word(bus, &mut stack);
+        }
+        if mask & 0x40 != 0 {
+            let value = self.pull_word(bus, &mut stack);
+            if use_hardware_stack {
+                self.u = value;
+            } else {
+                self.s = value;
+                self.mark_s_loaded();
+            }
+        }
+        if mask & 0x80 != 0 {
+            self.pc = self.pull_word(bus, &mut stack);
+        }
+        if use_hardware_stack {
+            self.s = stack;
+        } else {
+            self.u = stack;
+        }
+    }
+
+    pub(crate) fn cwai(&mut self, bus: &mut impl common::Bus) {
+        let mask = self.fetch_u8(bus);
+        let condition_code = self.flags.compress();
+        self.flags.expand(condition_code & mask);
+        self.flags.entire = true;
+        self.push_registers(bus, true, ENTIRE_STATE_MASK);
+        self.halted = true;
+    }
+
+    pub(crate) fn sync(&mut self) {
+        self.halted = true;
+    }
+}

--- a/crates/cpu/src/m6809/state.rs
+++ b/crates/cpu/src/m6809/state.rs
@@ -1,0 +1,37 @@
+use super::flags::M6809Flags;
+
+/// Snapshot of all Motorola 6809 registers.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct M6809State {
+    /// Accumulator A.
+    pub a: u8,
+    /// Accumulator B.
+    pub b: u8,
+    /// X index register.
+    pub x: u16,
+    /// Y index register.
+    pub y: u16,
+    /// Hardware stack pointer.
+    pub s: u16,
+    /// User stack pointer.
+    pub u: u16,
+    /// Program counter.
+    pub pc: u16,
+    /// Direct page register.
+    pub dp: u8,
+    /// Condition code flags.
+    pub flags: M6809Flags,
+}
+
+impl M6809State {
+    /// Returns the combined D accumulator.
+    pub fn d(&self) -> u16 {
+        (u16::from(self.a) << 8) | u16::from(self.b)
+    }
+
+    /// Sets the combined D accumulator.
+    pub fn set_d(&mut self, value: u16) {
+        self.a = (value >> 8) as u8;
+        self.b = value as u8;
+    }
+}

--- a/crates/cpu/tests/verification_6809.rs
+++ b/crates/cpu/tests/verification_6809.rs
@@ -1,0 +1,304 @@
+#![cfg(feature = "verification")]
+
+#[path = "common/verification_common.rs"]
+mod verification_common;
+
+use std::{collections::HashMap, fs, path::Path, sync::LazyLock};
+
+use cpu::{M6809, M6809State};
+use verification_common::{load_moo_tests, load_revocation_list};
+
+const REG_ORDER_6809: [&str; 9] = ["pc", "s", "u", "x", "y", "dp", "a", "b", "cc"];
+
+struct TestBus {
+    ram: Box<[u8; 65_536]>,
+    current_cycle: u64,
+    wait_cycles: i64,
+}
+
+impl TestBus {
+    fn new() -> Self {
+        Self {
+            ram: vec![0u8; 65_536].into_boxed_slice().try_into().unwrap(),
+            current_cycle: 0,
+            wait_cycles: 0,
+        }
+    }
+}
+
+impl common::Bus for TestBus {
+    fn read_byte(&mut self, address: u32) -> u8 {
+        self.ram[(address & 0xFFFF) as usize]
+    }
+
+    fn write_byte(&mut self, address: u32, value: u8) {
+        self.ram[(address & 0xFFFF) as usize] = value;
+    }
+
+    fn io_read_byte(&mut self, port: u16) -> u8 {
+        panic!("unexpected 6809 I/O read from 0x{port:04X}");
+    }
+
+    fn io_write_byte(&mut self, port: u16, value: u8) {
+        panic!("unexpected 6809 I/O write to 0x{port:04X} = 0x{value:02X}");
+    }
+
+    fn has_irq(&self) -> bool {
+        false
+    }
+
+    fn acknowledge_irq(&mut self) -> u8 {
+        0
+    }
+
+    fn has_nmi(&self) -> bool {
+        false
+    }
+
+    fn acknowledge_nmi(&mut self) {}
+
+    fn current_cycle(&self) -> u64 {
+        self.current_cycle
+    }
+
+    fn set_current_cycle(&mut self, cycle: u64) {
+        self.current_cycle = cycle;
+    }
+
+    fn drain_wait_cycles(&mut self) -> i64 {
+        let wait_cycles = self.wait_cycles;
+        self.wait_cycles = 0;
+        wait_cycles
+    }
+}
+
+fn test_dir() -> &'static Path {
+    static DIR: LazyLock<std::path::PathBuf> = LazyLock::new(|| {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/SingleStepTests/6809/v1")
+    });
+    &DIR
+}
+
+fn manifest_stems() -> Vec<String> {
+    let manifest = fs::read_to_string(test_dir().join("manifest.txt")).unwrap();
+    manifest
+        .lines()
+        .filter_map(|line| line.rsplit_once(' ').map(|(stem, _)| stem.to_string()))
+        .collect()
+}
+
+fn initial_reg_value(regs: &HashMap<String, u32>, name: &str) -> u32 {
+    regs.get(name)
+        .copied()
+        .unwrap_or_else(|| panic!("missing register in initial state: {name}"))
+}
+
+fn resolve_regs(
+    initial: &HashMap<String, u32>,
+    final_state: &HashMap<String, u32>,
+) -> HashMap<String, u32> {
+    REG_ORDER_6809
+        .iter()
+        .map(|name| {
+            let value = final_state
+                .get(*name)
+                .copied()
+                .unwrap_or_else(|| initial_reg_value(initial, name));
+            ((*name).to_string(), value)
+        })
+        .collect()
+}
+
+fn build_state(regs: &HashMap<String, u32>) -> M6809State {
+    let get = |name: &str| -> u32 {
+        regs.get(name)
+            .copied()
+            .unwrap_or_else(|| panic!("missing register: {name}"))
+    };
+
+    let mut state = M6809State {
+        pc: get("pc") as u16,
+        s: get("s") as u16,
+        u: get("u") as u16,
+        x: get("x") as u16,
+        y: get("y") as u16,
+        dp: get("dp") as u8,
+        a: get("a") as u8,
+        b: get("b") as u8,
+        ..M6809State::default()
+    };
+    state.flags.expand(get("cc") as u8);
+    state
+}
+
+fn format_flags_diff(expected: u8, actual: u8) -> String {
+    const FLAG_BITS: &[(u8, &str)] = &[
+        (0x80, "E"),
+        (0x40, "F"),
+        (0x20, "H"),
+        (0x10, "I"),
+        (0x08, "N"),
+        (0x04, "Z"),
+        (0x02, "V"),
+        (0x01, "C"),
+    ];
+
+    let diff_bits = expected ^ actual;
+    let mut changed = Vec::new();
+    for &(bit, name) in FLAG_BITS {
+        if diff_bits & bit != 0 {
+            changed.push(format!(
+                "{name}:{}->{}",
+                u8::from(expected & bit != 0),
+                u8::from(actual & bit != 0)
+            ));
+        }
+    }
+    format!(
+        "  cc: expected 0x{expected:02X}, got 0x{actual:02X} [{}]",
+        changed.join(", ")
+    )
+}
+
+fn run_test_file(stem: &str, revoked_hashes: &std::collections::HashSet<String>) {
+    let path = test_dir().join(format!("{stem}.moo.gz"));
+    let test_cases = load_moo_tests(&path, &REG_ORDER_6809, &[]);
+
+    let mut failures = Vec::new();
+
+    for (index, test) in test_cases.iter().enumerate() {
+        if test
+            .hash
+            .as_ref()
+            .is_some_and(|hash| revoked_hashes.contains(hash))
+        {
+            continue;
+        }
+
+        let mut bus = TestBus::new();
+        for &(address, value) in &test.initial.ram {
+            bus.ram[(address & 0xFFFF) as usize] = value;
+        }
+
+        let initial_regs = resolve_regs(&test.initial.regs, &HashMap::new());
+        let final_regs = resolve_regs(&test.initial.regs, &test.final_state.regs);
+        let initial_state = build_state(&initial_regs);
+        let expected = build_state(&final_regs);
+
+        let mut cpu = M6809::new(1_000_000);
+        cpu.load_state(&initial_state);
+        cpu.step(&mut bus);
+
+        let mut diffs = Vec::new();
+
+        let check_u8 = |name: &str,
+                        initial_value: u8,
+                        actual_value: u8,
+                        expected_value: u8,
+                        diffs: &mut Vec<String>| {
+            if actual_value != expected_value {
+                diffs.push(format!(
+                    "  {name}: expected 0x{expected_value:02X}, got 0x{actual_value:02X} (was 0x{initial_value:02X})"
+                ));
+            }
+        };
+        let check_u16 = |name: &str,
+                         initial_value: u16,
+                         actual_value: u16,
+                         expected_value: u16,
+                         diffs: &mut Vec<String>| {
+            if actual_value != expected_value {
+                diffs.push(format!(
+                    "  {name}: expected 0x{expected_value:04X}, got 0x{actual_value:04X} (was 0x{initial_value:04X})"
+                ));
+            }
+        };
+
+        check_u16("pc", initial_state.pc, cpu.pc, expected.pc, &mut diffs);
+        check_u16("s", initial_state.s, cpu.s, expected.s, &mut diffs);
+        check_u16("u", initial_state.u, cpu.u, expected.u, &mut diffs);
+        check_u16("x", initial_state.x, cpu.x, expected.x, &mut diffs);
+        check_u16("y", initial_state.y, cpu.y, expected.y, &mut diffs);
+        check_u8("dp", initial_state.dp, cpu.dp, expected.dp, &mut diffs);
+        check_u8("a", initial_state.a, cpu.a, expected.a, &mut diffs);
+        check_u8("b", initial_state.b, cpu.b, expected.b, &mut diffs);
+        if cpu.flags.compress() != expected.flags.compress() {
+            diffs.push(format!(
+                "{} (was 0x{:02X})",
+                format_flags_diff(expected.flags.compress(), cpu.flags.compress()),
+                initial_state.flags.compress()
+            ));
+        }
+
+        let actual_cycles = cpu.cycles_consumed();
+        let expected_cycles = test.cycles.len() as u64;
+        if actual_cycles != expected_cycles {
+            diffs.push(format!(
+                "  cycles: expected {expected_cycles}, got {actual_cycles}"
+            ));
+        }
+
+        for &(address, expected_value) in &test.final_state.ram {
+            let actual_value = bus.ram[(address & 0xFFFF) as usize];
+            if actual_value != expected_value {
+                let initial_value = test
+                    .initial
+                    .ram
+                    .iter()
+                    .find(|(candidate, _)| *candidate == address)
+                    .map(|(_, value)| *value);
+                match initial_value {
+                    Some(before) => diffs.push(format!(
+                        "  ram[0x{address:04X}]: expected 0x{expected_value:02X}, got 0x{actual_value:02X} (was 0x{before:02X})"
+                    )),
+                    None => diffs.push(format!(
+                        "  ram[0x{address:04X}]: expected 0x{expected_value:02X}, got 0x{actual_value:02X} (not in initial RAM)"
+                    )),
+                }
+            }
+        }
+
+        if !diffs.is_empty() {
+            let bytes_hex: Vec<String> = test
+                .bytes
+                .iter()
+                .map(|byte| format!("{byte:02X}"))
+                .collect();
+            failures.push(format!(
+                "[{} #{index}] {} ({})\n{}",
+                path.file_name().unwrap().to_string_lossy(),
+                test.name,
+                bytes_hex.join(" "),
+                diffs.join("\n")
+            ));
+        }
+    }
+
+    if !failures.is_empty() {
+        let fail_count = failures.len();
+        let test_count = test_cases.len();
+        let mut message = format!("{stem}.moo.gz: {fail_count}/{test_count} tests failed\n");
+        for failure in failures.iter().take(5) {
+            message.push_str(failure);
+            message.push('\n');
+        }
+        if failures.len() > 5 {
+            message.push_str(&format!("  ... and {} more failures\n", failures.len() - 5));
+        }
+        panic!("{message}");
+    }
+}
+
+#[test]
+fn all_6809_vectors() {
+    let revocation_path = test_dir().join("revocation_list.txt");
+    let revoked_hashes = if revocation_path.exists() {
+        load_revocation_list(&revocation_path)
+    } else {
+        std::collections::HashSet::new()
+    };
+
+    for stem in manifest_stems() {
+        run_test_file(&stem, &revoked_hashes);
+    }
+}


### PR DESCRIPTION
Pretty mechanical implementation based on our Z80 core. 

We used MAME to create verification vectors: https://github.com/neetandev/m6809

Once real traces surface, we will use those instead. But MAME's m6809 should produce test vectors, that are pretty close to the real m6809.