### PR TITLE
feature: add 386 SX variants for PC-98 and FM Towns

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Verified per-title compatibility lists.
 
 * [PC-98 game compatibility](doc/games-pc98.md)
 * [PC-88 VA game compatibility](doc/games-88va.md)
+* [FM Towns game compatibility](doc/games-towns.md)
 * [FM-7 game compatibility](doc/games-fm7.md)
 * [X68000 game compatibility](doc/games-x68k.md)
 
@@ -36,16 +37,16 @@ Neetan emulates eight distinct families, selected through the `--machine` option
 each family's guide for the detailed target list, sound options, ROM requirements,
 and platform-specific flags.
 
-| Family                                         | Targets                                                         | Firmware                 |
-|------------------------------------------------|-----------------------------------------------------------------|--------------------------|
-| [NEC PC-9801 / PC-9821](doc/machine-pc98.md)   | PC-9801F, PC-9801VM, PC-9801VX, PC-9801RA, PC-9821AS, PC-9821AP | HLE BIOS (ROMs optional) |
-| [NEC PC-88VA2](doc/machine-pc88va.md)          | PC-88VA2                                                        | Real ROM set required    |
-| [NEC PC-8001 / PC-8801](doc/machine-pc88.md)   | PC-8801MC (plus PC-8001 personalities via `--boot-mode`)        | Real ROM set required    |
-| [NEC PC-6001 / PC-6601](doc/machine-pc6000.md) | PC-6001, PC-6001mkII, PC-6601, PC-6001mkIISR, PC-6601SR         | Real ROM set required    |
-| [Fujitsu FM Towns](doc/machine-towns.md)       | FM Towns II CX, FM Towns II MX                                  | Real ROM set required    |
-| [Sharp X68000](doc/machine-x68k.md)            | X68000, X68000 SUPER, X68000 XVI                                | Real ROM set required    |
-| [Sharp X1](doc/machine-x1.md)                  | X1, X1 turbo                                                    | Real ROM set required    |
-| [Fujitsu FM-7](doc/machine-fm7.md)             | FM-7, FM-77AV                                                   | Real ROM set required    |
+| Family                                         | Targets                                                                    | Firmware                 |
+|------------------------------------------------|----------------------------------------------------------------------------|--------------------------|
+| [NEC PC-9801 / PC-9821](doc/machine-pc98.md)   | PC-9801F, PC-9801VM, PC-9801VX, PC-9801RS, PC-9801RA, PC-9821AS, PC-9821AP | HLE BIOS (ROMs optional) |
+| [NEC PC-88VA2](doc/machine-pc88va.md)          | PC-88VA2                                                                   | Real ROM set required    |
+| [NEC PC-8001 / PC-8801](doc/machine-pc88.md)   | PC-8801MC (plus PC-8001 personalities via `--boot-mode`)                   | Real ROM set required    |
+| [NEC PC-6001 / PC-6601](doc/machine-pc6000.md) | PC-6001, PC-6001mkII, PC-6601, PC-6001mkIISR, PC-6601SR                    | Real ROM set required    |
+| [Fujitsu FM Towns](doc/machine-towns.md)       | FM Towns, FM Towns II CX, FM Towns II MX                                   | Real ROM set required    |
+| [Sharp X68000](doc/machine-x68k.md)            | X68000, X68000 SUPER, X68000 XVI                                           | Real ROM set required    |
+| [Sharp X1](doc/machine-x1.md)                  | X1, X1 turbo                                                               | Real ROM set required    |
+| [Fujitsu FM-7](doc/machine-fm7.md)             | FM-7, FM-77AV                                                              | Real ROM set required    |
 
 The default machine is `PC9801RA`. Games of the PC-98 normally do not require any ROM
 files. The other families need a real ROM set. See [ROMs](doc/roms.md) for details.
@@ -116,9 +117,9 @@ that apply to one family are ignored on the others.
 | `-h, --help`                 | All                       | Print help                                                                                       | -                 |
 | `-V, --version`              | All                       | Print version                                                                                    | -                 |
 
-The `--machine <TYPE>` values are: `PC9801F`, `PC9801VM`, `PC9801VX`, `PC9801RA`,
-`PC9821AS`, `PC9821AP`, `PC8801MC`, `PC88VA2`, `PC6001`, `PC6001MK2`, `PC6601`,
-`PC6001MK2SR`, `PC6601SR`, `FM7`, `FM77AV`, `FMTownsIICX`, `FMTownsIIMX`, `X68000`,
+The `--machine <TYPE>` values are: `PC9801F`, `PC9801VM`, `PC9801VX`, `PC9801RS`,
+`PC9801RA`, `PC9821AS`, `PC9821AP`, `PC8801MC`, `PC88VA2`, `PC6001`, `PC6001MK2`, `PC6601`,
+`PC6001MK2SR`, `PC6601SR`, `FM7`, `FM77AV`, `FMTowns`, `FMTownsIICX`, `FMTownsIIMX`, `X68000`,
 `X68000SUPER`, `X68000XVI`, `X1`, `X1TURBO`. The default is `PC9801RA`.
 
 ### Commands

--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -11,7 +11,8 @@
 ; Machine type: PC9801F  (PC-9801F, 8086 5/8 MHz)
 ;               PC9801VM (PC-9801VM, V30 8/10 MHz)
 ;               PC9801VX (PC-9801VX, 80286 8/10 MHz)
-;               PC9801RA (PC-9801RA, 80386DX 16/20 MHz)
+;               PC9801RS (PC-9801RS, 80386SX 16 MHz)
+;               PC9801RA (PC-9801RA, 80386DX 20 MHz)
 ;               PC9821AS (PC-9821AS, 80486DX)
 ;               PC9821AP (PC-9821AP, 80486DX2)
 ;               PC8801MC (PC-8801MC, Z80 4/8 MHz, requires pc88-roms)
@@ -21,6 +22,7 @@
 ;               PC6601      (PC-6601, Z80 ~4 MHz, requires pc6000-roms)
 ;               PC6001MK2SR (PC-6001mkIISR, Z80 ~3.58 MHz, requires pc6000-roms)
 ;               PC6601SR    (PC-6601SR, Z80 ~3.58 MHz, requires pc6000-roms)
+;               FMTowns     (FM Towns, 80386SX 16 MHz, requires towns-roms)
 ;               FMTownsIICX (FM Towns II CX, 80386DX 16/20 MHz, requires towns-roms)
 ;               FMTownsIIMX (FM Towns II MX, 80486DX2 33/66 MHz, requires towns-roms)
 ;               X68000      (Sharp X68000, MC68000 10 MHz, requires x68k-roms)
@@ -37,12 +39,14 @@
 ;   PC9801F: low = 5 MHz, high = 8 MHz
 ;   PC9801VM: low = 8 MHz, high = 10 MHz
 ;   PC9801VX: low = 8 MHz, high = 10 MHz
-;   PC9801RA: low = 16 MHz, high = 20 MHz
+;   PC9801RS: fixed 16 MHz, ignores cpu-mode
+;   PC9801RA: fixed 20 MHz, ignores cpu-mode
 ;   PC9821AS/PC9821AP: fixed speed, ignores cpu-mode
 ;   X68000XVI: low = 10 MHz, high = 16.67 MHz
 ;   PC-6000 targets: fixed clock, ignores cpu-mode
 ;   X1 targets: fixed clock, ignores cpu-mode
 ;   FM-7 targets: fixed clock, ignores cpu-mode
+;   FMTowns: fixed 16 MHz, ignores cpu-mode
 ;   FMTownsIICX: low = 16 MHz (canonical CX), high = 20 MHz (HG-class speed)
 ;   FMTownsIIMX: low = 33 MHz (MA-class speed), high = 66 MHz (canonical MX)
 ; cpu-mode = high
@@ -70,7 +74,7 @@
 ; fdd2 = path/to/disk2.d88
 
 ; Hard disk images for drive 1 and 2. Each machine family accepts its own formats:
-;   PC-98:    HDI (.hdi), NHD (.nhd), THD (.thd); SASI on PC9801F/VM/VX/RA,
+;   PC-98:    HDI (.hdi), NHD (.nhd), THD (.thd); SASI on PC9801F/VM/VX/RS/RA,
 ;             IDE on PC9821AS/AP
 ;   FM Towns: raw SCSI images (.h0-.h4)
 ;   X68000:   headerless HDF images (.hdf); SASI on X68000,

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -285,7 +285,9 @@ pub enum MachineModel {
     PC9801VM,
     /// PC-9801VX (80286, 8/10 MHz, EGC, 24-bit address space, SASI built-in).
     PC9801VX,
-    /// PC-9801RA (80386, 16/20 MHz, EGC, 32-bit address space, SASI built-in).
+    /// PC-9801RS (80386SX, 16 MHz, EGC, 32-bit address space, SASI built-in).
+    PC9801RS,
+    /// PC-9801RA (80386DX, 20 MHz, EGC, 32-bit address space, SASI built-in).
     PC9801RA,
     /// PC-9821AS (486DX, 33 MHz, PEGC, 32-bit address space, IDE built-in).
     PC9821AS,
@@ -312,7 +314,7 @@ impl MachineModel {
             Self::PC9801F => CpuType::I8086,
             Self::PC9801VM => CpuType::V30,
             Self::PC9801VX => CpuType::I286,
-            Self::PC9801RA => CpuType::I386,
+            Self::PC9801RS | Self::PC9801RA => CpuType::I386,
             Self::PC9821AS | Self::PC9821AP => CpuType::I486DX,
         }
     }
@@ -331,10 +333,8 @@ impl MachineModel {
                 CpuMode::Low => 8_000_000,
                 CpuMode::High => 10_000_000,
             },
-            Self::PC9801RA => match mode {
-                CpuMode::Low => 16_000_000,
-                CpuMode::High => 20_000_000,
-            },
+            Self::PC9801RS => 16_000_000,
+            Self::PC9801RA => 20_000_000,
             Self::PC9821AS => 33_000_000,
             Self::PC9821AP => 66_000_000,
         }
@@ -344,14 +344,18 @@ impl MachineModel {
     pub const fn pit_clock_hz(self) -> u32 {
         match self {
             Self::PC9801VM | Self::PC9801VX => 2_457_600,
-            Self::PC9801F | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => 1_996_800,
+            Self::PC9801F | Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
+                1_996_800
+            }
         }
     }
 
     /// Returns whether this machine uses the 8 MHz PIT clock lineage.
     pub const fn is_8mhz_pit_lineage(self) -> bool {
         match self {
-            Self::PC9801F | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
+            Self::PC9801F | Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
+                true
+            }
             Self::PC9801VM | Self::PC9801VX => false,
         }
     }
@@ -362,9 +366,12 @@ impl MachineModel {
     pub const fn beeper_kind(self) -> BeeperKind {
         match self {
             Self::PC9801F => BeeperKind::Fixed { hz: 2400 },
-            Self::PC9801VM | Self::PC9801VX | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
-                BeeperKind::PitDriven
-            }
+            Self::PC9801VM
+            | Self::PC9801VX
+            | Self::PC9801RS
+            | Self::PC9801RA
+            | Self::PC9821AS
+            | Self::PC9821AP => BeeperKind::PitDriven,
         }
     }
 
@@ -378,7 +385,9 @@ impl MachineModel {
         match self {
             Self::PC9801F | Self::PC9801VM => Self::ADDRESS_MASK_V30,
             Self::PC9801VX => Self::ADDRESS_MASK_I286,
-            Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => Self::ADDRESS_MASK_I386,
+            Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
+                Self::ADDRESS_MASK_I386
+            }
         }
     }
 
@@ -386,7 +395,9 @@ impl MachineModel {
     pub const fn has_egc(self) -> bool {
         match self {
             Self::PC9801F | Self::PC9801VM => false,
-            Self::PC9801VX | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
+            Self::PC9801VX | Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
+                true
+            }
         }
     }
 
@@ -397,9 +408,12 @@ impl MachineModel {
     pub const fn has_grcg(self) -> bool {
         match self {
             Self::PC9801F => false,
-            Self::PC9801VM | Self::PC9801VX | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
-                true
-            }
+            Self::PC9801VM
+            | Self::PC9801VX
+            | Self::PC9801RS
+            | Self::PC9801RA
+            | Self::PC9821AS
+            | Self::PC9821AP => true,
         }
     }
 
@@ -410,7 +424,7 @@ impl MachineModel {
         match self {
             Self::PC9801F => 0,
             Self::PC9801VM => Self::GRCG_CHIP_V1,
-            Self::PC9801VX | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
+            Self::PC9801VX | Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
                 Self::GRCG_CHIP_EGC
             }
         }
@@ -420,14 +434,16 @@ impl MachineModel {
     pub const fn has_cg_ram(self) -> bool {
         match self {
             Self::PC9801F | Self::PC9801VM => false,
-            Self::PC9801VX | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
+            Self::PC9801VX | Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
+                true
+            }
         }
     }
 
     /// Returns whether this machine supports NEC B-bank EMS.
     pub const fn has_b_bank_ems(self) -> bool {
         match self {
-            Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
+            Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
             Self::PC9801F | Self::PC9801VM | Self::PC9801VX => false,
         }
     }
@@ -435,7 +451,7 @@ impl MachineModel {
     /// Returns whether this machine has shadow RAM (E8000-FFFFF).
     pub const fn has_shadow_ram(self) -> bool {
         match self {
-            Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
+            Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
             Self::PC9801F | Self::PC9801VM | Self::PC9801VX => false,
         }
     }
@@ -445,7 +461,7 @@ impl MachineModel {
         match self {
             Self::PC9801F | Self::PC9801VM => 0,
             Self::PC9801VX => 0x400000,
-            Self::PC9801RA => 0xC00000,
+            Self::PC9801RS | Self::PC9801RA => 0xC00000,
             Self::PC9821AS | Self::PC9821AP => 0xE00000,
         }
     }
@@ -453,7 +469,9 @@ impl MachineModel {
     /// Returns whether this machine has a SASI hard disk controller.
     pub const fn has_sasi(self) -> bool {
         match self {
-            Self::PC9801F | Self::PC9801VM | Self::PC9801VX | Self::PC9801RA => true,
+            Self::PC9801F | Self::PC9801VM | Self::PC9801VX | Self::PC9801RS | Self::PC9801RA => {
+                true
+            }
             Self::PC9821AS | Self::PC9821AP => false,
         }
     }
@@ -461,7 +479,9 @@ impl MachineModel {
     /// Returns whether this machine has an IDE hard disk controller.
     pub const fn has_ide(self) -> bool {
         match self {
-            Self::PC9801F | Self::PC9801VM | Self::PC9801VX | Self::PC9801RA => false,
+            Self::PC9801F | Self::PC9801VM | Self::PC9801VX | Self::PC9801RS | Self::PC9801RA => {
+                false
+            }
             Self::PC9821AS | Self::PC9821AP => true,
         }
     }
@@ -470,7 +490,9 @@ impl MachineModel {
     pub const fn is_dual_bank_bios(self) -> bool {
         match self {
             Self::PC9801F | Self::PC9801VM => false,
-            Self::PC9801VX | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
+            Self::PC9801VX | Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
+                true
+            }
         }
     }
 
@@ -480,7 +502,7 @@ impl MachineModel {
             Self::PC9801F | Self::PC9801VM => {
                 size == BIOS_ROM_SIZE_SINGLE_BANK || size == BIOS_ROM_SIZE_DUAL_BANK
             }
-            Self::PC9801VX | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
+            Self::PC9801VX | Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
                 size == BIOS_ROM_SIZE_DUAL_BANK
             }
         }
@@ -490,7 +512,7 @@ impl MachineModel {
     pub const fn has_extended_dma(self) -> bool {
         match self {
             Self::PC9801F | Self::PC9801VM | Self::PC9801VX => false,
-            Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
+            Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
         }
     }
 
@@ -498,7 +520,9 @@ impl MachineModel {
     pub const fn has_protected_memory_register(self) -> bool {
         match self {
             Self::PC9801F | Self::PC9801VM => false,
-            Self::PC9801VX | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
+            Self::PC9801VX | Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
+                true
+            }
         }
     }
 
@@ -506,14 +530,16 @@ impl MachineModel {
     pub const fn has_a20_nmi_port(self) -> bool {
         match self {
             Self::PC9801F | Self::PC9801VM | Self::PC9801VX => false,
-            Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
+            Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
         }
     }
 
     /// Returns whether this machine has the PEGC 256-color packed pixel graphics controller.
     pub const fn has_pegc(self) -> bool {
         match self {
-            Self::PC9801F | Self::PC9801VM | Self::PC9801VX | Self::PC9801RA => false,
+            Self::PC9801F | Self::PC9801VM | Self::PC9801VX | Self::PC9801RS | Self::PC9801RA => {
+                false
+            }
             Self::PC9821AS | Self::PC9821AP => true,
         }
     }
@@ -521,7 +547,9 @@ impl MachineModel {
     /// Returns whether this machine supports the 16 MB system space (F00000-FFFFFF).
     pub const fn has_16mb_system_space(self) -> bool {
         match self {
-            Self::PC9801F | Self::PC9801VM | Self::PC9801VX | Self::PC9801RA => false,
+            Self::PC9801F | Self::PC9801VM | Self::PC9801VX | Self::PC9801RS | Self::PC9801RA => {
+                false
+            }
             Self::PC9821AS | Self::PC9821AP => true,
         }
     }
@@ -533,7 +561,9 @@ impl MachineModel {
     /// I/O ports 0x841E–0x8F1E.
     pub const fn has_sdip(self) -> bool {
         match self {
-            Self::PC9801F | Self::PC9801VM | Self::PC9801VX | Self::PC9801RA => false,
+            Self::PC9801F | Self::PC9801VM | Self::PC9801VX | Self::PC9801RS | Self::PC9801RA => {
+                false
+            }
             Self::PC9821AS | Self::PC9821AP => true,
         }
     }
@@ -542,9 +572,12 @@ impl MachineModel {
     pub const fn has_fdd320_ppi(self) -> bool {
         match self {
             Self::PC9801F => true,
-            Self::PC9801VM | Self::PC9801VX | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
-                false
-            }
+            Self::PC9801VM
+            | Self::PC9801VX
+            | Self::PC9801RS
+            | Self::PC9801RA
+            | Self::PC9821AS
+            | Self::PC9821AP => false,
         }
     }
 
@@ -552,7 +585,9 @@ impl MachineModel {
     pub const fn ems_compatible(self) -> bool {
         match self {
             Self::PC9801F | Self::PC9801VM => false,
-            Self::PC9801VX | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
+            Self::PC9801VX | Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
+                true
+            }
         }
     }
 
@@ -560,7 +595,9 @@ impl MachineModel {
     pub const fn xms_compatible(self) -> bool {
         match self {
             Self::PC9801F | Self::PC9801VM => false,
-            Self::PC9801VX | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
+            Self::PC9801VX | Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => {
+                true
+            }
         }
     }
 
@@ -568,7 +605,7 @@ impl MachineModel {
     pub const fn xms_32_compatible(self) -> bool {
         match self {
             Self::PC9801F | Self::PC9801VM | Self::PC9801VX => false,
-            Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
+            Self::PC9801RS | Self::PC9801RA | Self::PC9821AS | Self::PC9821AP => true,
         }
     }
 }
@@ -579,6 +616,7 @@ impl core::fmt::Display for MachineModel {
             Self::PC9801F => f.write_str("PC9801F"),
             Self::PC9801VM => f.write_str("PC9801VM"),
             Self::PC9801VX => f.write_str("PC9801VX"),
+            Self::PC9801RS => f.write_str("PC9801RS"),
             Self::PC9801RA => f.write_str("PC9801RA"),
             Self::PC9821AS => f.write_str("PC9821AS"),
             Self::PC9821AP => f.write_str("PC9821AP"),
@@ -594,11 +632,12 @@ impl core::str::FromStr for MachineModel {
             "PC9801F" => Ok(Self::PC9801F),
             "PC9801VM" => Ok(Self::PC9801VM),
             "PC9801VX" => Ok(Self::PC9801VX),
+            "PC9801RS" => Ok(Self::PC9801RS),
             "PC9801RA" => Ok(Self::PC9801RA),
             "PC9821AS" => Ok(Self::PC9821AS),
             "PC9821AP" => Ok(Self::PC9821AP),
             _ => Err(format!(
-                "unknown machine model '{s}', expected PC9801F, PC9801VM, PC9801VX, PC9801RA, PC9821AS, or PC9821AP"
+                "unknown machine model '{s}', expected PC9801F, PC9801VM, PC9801VX, PC9801RS, PC9801RA, PC9821AS, or PC9821AP"
             )),
         }
     }
@@ -1991,7 +2030,8 @@ mod tests {
             (MachineModel::PC9801F, 5_000_000, 8_000_000),
             (MachineModel::PC9801VM, 8_000_000, 10_000_000),
             (MachineModel::PC9801VX, 8_000_000, 10_000_000),
-            (MachineModel::PC9801RA, 16_000_000, 20_000_000),
+            (MachineModel::PC9801RS, 16_000_000, 16_000_000),
+            (MachineModel::PC9801RA, 20_000_000, 20_000_000),
             (MachineModel::PC9821AS, 33_000_000, 33_000_000),
             (MachineModel::PC9821AP, 66_000_000, 66_000_000),
         ];

--- a/crates/cpu/src/i386.rs
+++ b/crates/cpu/src/i386.rs
@@ -1,8 +1,9 @@
 //! Implements the Intel 80386+ family emulation.
 //!
 //! The CPU model is selected via the const generic parameter `CPU_MODEL`:
-//! - [`CPU_MODEL_386`] - Intel 80386DX cycle timings.
-//! - [`CPU_MODEL_486`] - Intel 80486DX cycle timings.
+//! - [`CPU_MODEL_386_DX`] - Intel 80386DX cycle timings.
+//! - [`CPU_MODEL_486_DX`] - Intel 80486DX cycle timings.
+//! - [`CPU_MODEL_386_SX`] - Intel 80386SX cycle timings.
 //!
 //! The physical address bus width is selected via the const generic parameter
 //! `ADDRESS_WIDTH`:
@@ -38,9 +39,11 @@ pub use state::I386State;
 use crate::{SegReg32, WordReg};
 
 /// CPU model constant for Intel 80386DX.
-pub const CPU_MODEL_386: u8 = 0;
+pub const CPU_MODEL_386_DX: u8 = 0;
 /// CPU model constant for Intel 80486DX.
-pub const CPU_MODEL_486: u8 = 1;
+pub const CPU_MODEL_486_DX: u8 = 1;
+/// CPU model constant for Intel 80386SX.
+pub const CPU_MODEL_386_SX: u8 = 2;
 
 /// Physical address width constant for a 24-bit address bus (PC-98 wiring).
 pub const ADDRESS_WIDTH_24: u8 = 24;
@@ -56,6 +59,22 @@ const EFLAGS_ALIGNMENT_CHECK_FLAG: u32 = 0x0004_0000;
 const RESET_EDX_386DX: u32 = 0x0000_0308;
 /// EDX after RESET on the 486 (i486 PRM 10.2): 0x0435 identifies an i486DX2-66.
 const RESET_EDX_486DX2: u32 = 0x0000_0435;
+/// EDX after RESET on the 386SX: DH = 0x23 is the 386SX component identifier.
+const RESET_EDX_386SX: u32 = 0x0000_2308;
+
+/// Extra clocks on the 386SX for an aligned dword transfer, which the 16-bit
+/// data bus splits into two bus cycles. Calibration constant.
+const SX_EXTRA_CLOCKS_DWORD_ACCESS: i32 = 2;
+/// Extra clocks on the 386SX for a misaligned word transfer, which splits
+/// into two bus cycles. Calibration constant.
+const SX_EXTRA_CLOCKS_MISALIGNED_WORD: i32 = 2;
+/// Extra clocks on the 386SX for a misaligned dword transfer, which takes
+/// three bus cycles instead of one. Calibration constant.
+const SX_EXTRA_CLOCKS_MISALIGNED_DWORD: i32 = 4;
+/// Extra clocks on the 386SX per 16-bit code word fetched, approximating the
+/// halved code fetch bandwidth without a prefetch queue model. Calibration
+/// constant.
+const SX_EXTRA_CLOCKS_PER_CODE_WORD: i32 = 1;
 
 /// Marker returned from any 386 primitive that may have raised a CPU exception.
 ///
@@ -108,14 +127,16 @@ enum DataSegmentDecision {
 /// Intel 80386+ CPU emulator.
 ///
 /// The const generic `CPU_MODEL` selects the instruction timings and feature set.
-/// Use [`CPU_MODEL_386`] for an 80386DX or [`CPU_MODEL_486`] for an 80486DX.
+/// Use [`CPU_MODEL_386_DX`] for an 80386DX, [`CPU_MODEL_486_DX`] for an 80486DX or
+/// [`CPU_MODEL_386_SX`] for an 80386SX (386DX behavior with 16-bit bus timing
+/// penalties).
 ///
 /// The const generic `ADDRESS_WIDTH` selects the physical address bus width.
 /// Use [`ADDRESS_WIDTH_24`] for the PC-98 wiring (physical addresses are
 /// truncated to 24 bits and reset lands at 000FFFF0) or [`ADDRESS_WIDTH_32`]
 /// for machines with a full 32-bit address bus (reset lands at FFFFFFF0).
 pub struct I386<
-    const CPU_MODEL: u8 = { CPU_MODEL_386 },
+    const CPU_MODEL: u8 = { CPU_MODEL_386_DX },
     const ADDRESS_WIDTH: u8 = { ADDRESS_WIDTH_24 },
 > {
     /// Embedded state for save/restore.
@@ -179,6 +200,8 @@ pub struct I386<
     trap_level: u8,
     prev_exception_class: u8,
     shutdown: bool,
+
+    sx_code_fetch_bytes: u32,
 }
 
 impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> Deref for I386<CPU_MODEL, ADDRESS_WIDTH> {
@@ -255,18 +278,80 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             prev_exception_class: 0,
             shutdown: false,
             prev_ip_upper: 0,
+            sx_code_fetch_bytes: 0,
         };
         cpu.reset();
         cpu
     }
 
-    /// Selects between 386 and 486 cycle counts at compile time.
+    /// Selects between 386 and 486 cycle counts at compile time. The 386SX
+    /// shares the 386DX execution timings; its bus penalties are charged
+    /// separately.
     #[inline(always)]
     const fn timing(t386: i32, t486: i32) -> i32 {
         match CPU_MODEL {
-            CPU_MODEL_386 => t386,
-            CPU_MODEL_486 => t486,
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => t386,
+            CPU_MODEL_486_DX => t486,
             _ => unreachable!(),
+        }
+    }
+
+    /// Like [`timing`], but lets the 386SX use a distinct execute-cycle count
+    /// `tsx`. Non-SX models delegate to `timing(t386, t486)`, so the 386DX and
+    /// 486DX are unaffected by construction. Keep `t386`/`t486` identical to
+    /// the site's original `timing` call so only the SX diverges.
+    #[inline(always)]
+    const fn timing_sx(t386: i32, t486: i32, tsx: i32) -> i32 {
+        match CPU_MODEL {
+            CPU_MODEL_386_SX => tsx,
+            _ => Self::timing(t386, t486),
+        }
+    }
+
+    /// Misaligned-operand penalty charged at decode time: 4 on the 386DX,
+    /// 3 on the 486. Zero on the 386SX, whose alignment cost is charged per
+    /// bus transfer in `clk_sx_bus` instead.
+    #[inline(always)]
+    const fn misaligned_operand_penalty() -> i32 {
+        match CPU_MODEL {
+            CPU_MODEL_386_DX => 4,
+            CPU_MODEL_486_DX => 3,
+            CPU_MODEL_386_SX => 0,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Charges the 386SX penalty for a dword I/O transfer, which the 16-bit
+    /// bus splits into two port accesses. No-op on other models.
+    #[inline(always)]
+    pub(super) fn clk_sx_io_dword(&mut self) {
+        if CPU_MODEL == CPU_MODEL_386_SX {
+            self.clk(SX_EXTRA_CLOCKS_DWORD_ACCESS);
+        }
+    }
+
+    /// Charges the 386SX 16-bit-data-bus penalty for one data transfer of
+    /// `size` bytes at linear address `linear`. No-op on other models.
+    #[inline(always)]
+    fn clk_sx_bus(&mut self, linear: u32, size: u32) {
+        if CPU_MODEL != CPU_MODEL_386_SX {
+            return;
+        }
+        let misaligned = linear & 1 != 0;
+        match size {
+            2 => {
+                if misaligned {
+                    self.clk(SX_EXTRA_CLOCKS_MISALIGNED_WORD);
+                }
+            }
+            4 => {
+                if misaligned {
+                    self.clk(SX_EXTRA_CLOCKS_MISALIGNED_DWORD);
+                } else {
+                    self.clk(SX_EXTRA_CLOCKS_DWORD_ACCESS);
+                }
+            }
+            _ => {}
         }
     }
 
@@ -278,8 +363,8 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
     #[inline(always)]
     const fn eflags_upper_writable() -> u32 {
         match CPU_MODEL {
-            CPU_MODEL_386 => EFLAGS_RESUME_FLAG | EFLAGS_VIRTUAL_8086_FLAG,
-            CPU_MODEL_486 => {
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => EFLAGS_RESUME_FLAG | EFLAGS_VIRTUAL_8086_FLAG,
+            CPU_MODEL_486_DX => {
                 EFLAGS_RESUME_FLAG | EFLAGS_VIRTUAL_8086_FLAG | EFLAGS_ALIGNMENT_CHECK_FLAG
             }
             _ => unreachable!(),
@@ -335,7 +420,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                 }
             };
             let misaligned = self.ea & alignment_mask != 0;
-            let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
+            let penalty = if misaligned {
+                Self::misaligned_operand_penalty()
+            } else {
+                0
+            };
             self.clk(mem_cycles + penalty);
         }
     }
@@ -352,7 +441,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         } else {
             sp & 1 != 0
         };
-        if misaligned { Self::timing(4, 3) } else { 0 }
+        if misaligned {
+            Self::misaligned_operand_penalty()
+        } else {
+            0
+        }
     }
 
     #[inline(always)]
@@ -492,6 +585,9 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         } else {
             bus.read_byte(addr)
         };
+        if CPU_MODEL == CPU_MODEL_386_SX {
+            self.sx_code_fetch_bytes += 1;
+        }
         self.advance_ip_byte();
         // Prefetch next byte to model the 386 prefetch queue.
         // This ensures bytes already fetched before a REP string op
@@ -541,6 +637,9 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                     return 0;
                 };
                 let value = bus.read_word(addr);
+                if CPU_MODEL == CPU_MODEL_386_SX {
+                    self.sx_code_fetch_bytes += 2;
+                }
                 self.advance_ip_by(2);
                 return value;
             }
@@ -560,6 +659,9 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                     return 0;
                 };
                 let value = bus.read_dword(addr);
+                if CPU_MODEL == CPU_MODEL_386_SX {
+                    self.sx_code_fetch_bytes += 4;
+                }
                 self.advance_ip_by(4);
                 return value;
             }
@@ -1112,7 +1214,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         // CR0.AM=1, EFLAGS.AC=1, CPL=3, and the linear address is not
         // aligned to the access size. Instruction fetch and descriptor
         // accesses go through different paths and are exempt.
-        if CPU_MODEL >= CPU_MODEL_486
+        if CPU_MODEL == CPU_MODEL_486_DX
             && (self.cr0 & 0x0004_0000) != 0
             && (self.eflags_upper & 0x0004_0000) != 0
             && self.cpl() == 3
@@ -1318,6 +1420,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         self.check_segment_access(seg, offset, 2, for_update, bus)?;
         let base = self.seg_base(seg);
         let l0 = base.wrapping_add(offset);
+        self.clk_sx_bus(l0, 2);
         if l0 & 0xFFF <= 0xFFE {
             let a0 = self.translate_linear(l0, for_update, bus)?;
             return Ok(bus.read_word(a0));
@@ -1359,6 +1462,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         self.check_segment_access(seg, offset, 4, for_update, bus)?;
         let base = self.seg_base(seg);
         let l0 = base.wrapping_add(offset);
+        self.clk_sx_bus(l0, 4);
         if l0 & 0xFFF <= 0xFFC {
             let a0 = self.translate_linear(l0, for_update, bus)?;
             return Ok(bus.read_dword(a0));
@@ -1407,6 +1511,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         self.check_segment_access(seg, offset, 2, true, bus)?;
         let base = self.seg_base(seg);
         let l0 = base.wrapping_add(offset);
+        self.clk_sx_bus(l0, 2);
         if l0 & 0xFFF <= 0xFFE {
             let a0 = self.translate_linear(l0, true, bus)?;
             bus.write_word(a0, value);
@@ -1431,6 +1536,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         self.check_segment_access(seg, offset, 4, true, bus)?;
         let base = self.seg_base(seg);
         let l0 = base.wrapping_add(offset);
+        self.clk_sx_bus(l0, 4);
         if l0 & 0xFFF <= 0xFFC {
             let a0 = self.translate_linear(l0, true, bus)?;
             bus.write_dword(a0, value);
@@ -1467,6 +1573,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         self.check_segment_access(SegReg32::SS, sp, 2, true, bus)?;
         let base = self.seg_base(SegReg32::SS);
         let l0 = base.wrapping_add(sp);
+        self.clk_sx_bus(l0, 2);
         if l0 & 0xFFF <= 0xFFE {
             let a0 = self.translate_linear(l0, true, bus)?;
             self.commit_sp(sp);
@@ -1491,6 +1598,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         self.check_segment_access(SegReg32::SS, sp, 2, false, bus)?;
         let base = self.seg_base(SegReg32::SS);
         let l0 = base.wrapping_add(sp);
+        self.clk_sx_bus(l0, 2);
         let value = if l0 & 0xFFF <= 0xFFE {
             let a0 = self.translate_linear(l0, false, bus)?;
             bus.read_word(a0)
@@ -1513,6 +1621,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         self.check_segment_access(SegReg32::SS, sp, 4, true, bus)?;
         let base = self.seg_base(SegReg32::SS);
         let l0 = base.wrapping_add(sp);
+        self.clk_sx_bus(l0, 4);
         if l0 & 0xFFF <= 0xFFC {
             let a0 = self.translate_linear(l0, true, bus)?;
             self.commit_sp(sp);
@@ -1552,6 +1661,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         self.check_segment_access(SegReg32::SS, sp, 4, false, bus)?;
         let base = self.seg_base(SegReg32::SS);
         let l0 = base.wrapping_add(sp);
+        self.clk_sx_bus(l0, 4);
         let value = if l0 & 0xFFF <= 0xFFC {
             let a0 = self.translate_linear(l0, false, bus)?;
             bus.read_dword(a0)
@@ -1621,6 +1731,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
     }
 
     pub(super) fn read_word_linear(&mut self, bus: &mut impl common::Bus, addr: u32) -> Step<u16> {
+        self.clk_sx_bus(addr, 2);
         if addr & 0xFFF <= 0xFFE {
             let a0 = self.translate_linear(addr, false, bus)?;
             return Ok(bus.read_word(a0));
@@ -1635,6 +1746,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         bus: &mut impl common::Bus,
         addr: u32,
     ) -> Step<u16> {
+        self.clk_sx_bus(addr, 2);
         if addr & 0xFFF <= 0xFFE {
             let a0 = self.translate_linear(addr, true, bus)?;
             return Ok(bus.read_word(a0));
@@ -1650,6 +1762,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         addr: u32,
         value: u16,
     ) -> Step {
+        self.clk_sx_bus(addr, 2);
         if addr & 0xFFF <= 0xFFE {
             let a0 = self.translate_linear(addr, true, bus)?;
             bus.write_word(a0, value);
@@ -1663,6 +1776,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
     }
 
     fn read_dword_linear(&mut self, bus: &mut impl common::Bus, addr: u32) -> Step<u32> {
+        self.clk_sx_bus(addr, 4);
         if addr & 0xFFF <= 0xFFC {
             let a0 = self.translate_linear(addr, false, bus)?;
             return Ok(bus.read_dword(a0));
@@ -1682,6 +1796,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         bus: &mut impl common::Bus,
         addr: u32,
     ) -> Step<u32> {
+        self.clk_sx_bus(addr, 4);
         if addr & 0xFFF <= 0xFFC {
             let a0 = self.translate_linear(addr, true, bus)?;
             return Ok(bus.read_dword(a0));
@@ -1697,6 +1812,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
     }
 
     fn write_dword_linear(&mut self, bus: &mut impl common::Bus, addr: u32, value: u32) -> Step {
+        self.clk_sx_bus(addr, 4);
         if addr & 0xFFF <= 0xFFC {
             let a0 = self.translate_linear(addr, true, bus)?;
             bus.write_dword(a0, value);
@@ -2796,6 +2912,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
     fn execute_one(&mut self, bus: &mut impl common::Bus) {
         self.prefetch_valid &= self.rep_active | self.rep_completed;
         self.rep_completed = false;
+        self.sx_code_fetch_bytes = 0;
         self.prev_ip = self.ip;
         self.prev_ip_upper = self.ip_upper;
         self.fault_pending = false;
@@ -2825,6 +2942,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             let _ = self.continue_rep(bus);
         } else {
             let _ = self.execute_with_prefixes(bus);
+        }
+
+        if CPU_MODEL == CPU_MODEL_386_SX && self.sx_code_fetch_bytes > 0 {
+            let code_words = self.sx_code_fetch_bytes.div_ceil(2) as i32;
+            self.clk(code_words * SX_EXTRA_CLOCKS_PER_CODE_WORD);
         }
 
         if likely(!self.preserve_resume_flag && !self.rep_active) {
@@ -2893,15 +3015,20 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> common::Cpu for I386<CPU_MODE
             }
         }
         match CPU_MODEL {
-            CPU_MODEL_386 => {
+            CPU_MODEL_386_DX => {
                 // 386DX reset: ET=1 (80387 coprocessor present).
                 self.cr0 = 0x0000_0010;
                 self.regs.set_dword(crate::DwordReg::EDX, RESET_EDX_386DX);
             }
-            CPU_MODEL_486 => {
+            CPU_MODEL_486_DX => {
                 // 486DX reset: ET=1 (on-chip FPU present). ET is hardwired on 486.
                 self.cr0 = 0x0000_0010;
                 self.regs.set_dword(crate::DwordReg::EDX, RESET_EDX_486DX2);
+            }
+            CPU_MODEL_386_SX => {
+                // 386SX reset: ET=1 (80387SX coprocessor present).
+                self.cr0 = 0x0000_0010;
+                self.regs.set_dword(crate::DwordReg::EDX, RESET_EDX_386SX);
             }
             _ => {
                 unreachable!("Unhandled CPU_MODEL")
@@ -3157,5 +3284,23 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> common::Cpu for I386<CPU_MODE
             common::SegmentRegister::DS => SegReg32::DS,
         };
         self.state.seg_bases[seg32 as usize]
+    }
+}
+
+#[cfg(test)]
+mod timing_tests {
+    use super::*;
+
+    /// The 386SX-only execute-cycle override must never change the 386DX or
+    /// 486DX result: for non-SX models `timing_sx(a, b, tsx)` equals
+    /// `timing(a, b)` regardless of `tsx`.
+    #[test]
+    fn timing_sx_leaves_dx_and_486_unchanged() {
+        type Dx = I386<{ CPU_MODEL_386_DX }, { ADDRESS_WIDTH_24 }>;
+        type M486 = I386<{ CPU_MODEL_486_DX }, { ADDRESS_WIDTH_24 }>;
+        for (t386, t486, tsx) in [(2, 1, 99), (7, 3, 0), (14, 13, 41), (5, 2, -7)] {
+            assert_eq!(Dx::timing_sx(t386, t486, tsx), Dx::timing(t386, t486));
+            assert_eq!(M486::timing_sx(t386, t486, tsx), M486::timing(t386, t486));
+        }
     }
 }

--- a/crates/cpu/src/i386/execute.rs
+++ b/crates/cpu/src/i386/execute.rs
@@ -1,6 +1,6 @@
 use super::{
-    CPU_MODEL_386, CPU_MODEL_486, EFLAGS_ALIGNMENT_CHECK_FLAG, EFLAGS_RESUME_FLAG,
-    EFLAGS_VIRTUAL_8086_FLAG, Fault, I386, Step,
+    CPU_MODEL_386_DX, CPU_MODEL_386_SX, CPU_MODEL_486_DX, EFLAGS_ALIGNMENT_CHECK_FLAG,
+    EFLAGS_RESUME_FLAG, EFLAGS_VIRTUAL_8086_FLAG, Fault, I386, Step,
 };
 use crate::{ByteReg, DwordReg, SegReg32, WordReg};
 
@@ -1558,11 +1558,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         if condition {
             self.apply_branch_disp8(disp);
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(7 + m);
                 }
-                CPU_MODEL_486 => self.clk(3),
+                CPU_MODEL_486_DX => self.clk(3),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -1577,11 +1577,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         if condition {
             self.apply_branch_disp8(disp);
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(7 + m);
                 }
-                CPU_MODEL_486 => self.clk(3),
+                CPU_MODEL_486_DX => self.clk(3),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -1847,12 +1847,12 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         } else {
             let ea_pen = if self.operand_size_override {
                 if self.ea & 3 != 0 {
-                    Self::timing(4, 3)
+                    Self::misaligned_operand_penalty()
                 } else {
                     0
                 }
             } else if self.ea & 1 != 0 {
-                Self::timing(4, 3)
+                Self::misaligned_operand_penalty()
             } else {
                 0
             };
@@ -1901,11 +1901,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                 self.ip_upper = offset & 0xFFFF_0000;
             }
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(17 + m + penalty);
                 }
-                CPU_MODEL_486 => self.clk(18 + penalty),
+                CPU_MODEL_486_DX => self.clk(18 + penalty),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -1932,11 +1932,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                 self.ip_upper = 0;
             }
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(17 + m + penalty);
                 }
-                CPU_MODEL_486 => self.clk(18 + penalty),
+                CPU_MODEL_486_DX => self.clk(18 + penalty),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -2025,11 +2025,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             self.ip = target as u16;
             self.ip_upper = target & 0xFFFF_0000;
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(7 + m + penalty);
                 }
-                CPU_MODEL_486 => self.clk(3 + penalty),
+                CPU_MODEL_486_DX => self.clk(3 + penalty),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -2041,11 +2041,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             self.ip = self.ip.wrapping_add(disp as u16);
             self.ip_upper = 0;
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(7 + m + penalty);
                 }
-                CPU_MODEL_486 => self.clk(3 + penalty),
+                CPU_MODEL_486_DX => self.clk(3 + penalty),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -2062,11 +2062,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             self.ip = target as u16;
             self.ip_upper = target & 0xFFFF_0000;
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(7 + m);
                 }
-                CPU_MODEL_486 => self.clk(3),
+                CPU_MODEL_486_DX => self.clk(3),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -2076,11 +2076,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             self.ip = self.ip.wrapping_add(disp as u16);
             self.ip_upper = 0;
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(7 + m);
                 }
-                CPU_MODEL_486 => self.clk(3),
+                CPU_MODEL_486_DX => self.clk(3),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -2100,11 +2100,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                 self.ip_upper = offset & 0xFFFF_0000;
             }
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(12 + m);
                 }
-                CPU_MODEL_486 => self.clk(17),
+                CPU_MODEL_486_DX => self.clk(17),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -2120,11 +2120,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                 self.ip_upper = 0;
             }
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(12 + m);
                 }
-                CPU_MODEL_486 => self.clk(17),
+                CPU_MODEL_486_DX => self.clk(17),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -2137,11 +2137,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         let disp = self.fetch(bus) as i8;
         self.apply_branch_disp8(disp);
         match CPU_MODEL {
-            CPU_MODEL_386 => {
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                 let m = self.next_instruction_length_approx(bus);
                 self.clk(7 + m);
             }
-            CPU_MODEL_486 => self.clk(3),
+            CPU_MODEL_486_DX => self.clk(3),
             _ => {
                 unreachable!("Unhandled CPU_MODEL")
             }
@@ -2160,11 +2160,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             self.ip_upper = 0;
         }
         match CPU_MODEL {
-            CPU_MODEL_386 => {
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                 let m = self.next_instruction_length_approx(bus);
                 self.clk(10 + m + penalty);
             }
-            CPU_MODEL_486 => self.clk(5 + penalty),
+            CPU_MODEL_486_DX => self.clk(5 + penalty),
             _ => {
                 unreachable!("Unhandled CPU_MODEL")
             }
@@ -2192,11 +2192,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             self.regs.set_word(WordReg::SP, stack_pointer);
         }
         match CPU_MODEL {
-            CPU_MODEL_386 => {
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                 let m = self.next_instruction_length_approx(bus);
                 self.clk(10 + m + penalty);
             }
-            CPU_MODEL_486 => self.clk(5 + penalty),
+            CPU_MODEL_486_DX => self.clk(5 + penalty),
             _ => {
                 unreachable!("Unhandled CPU_MODEL")
             }
@@ -2239,11 +2239,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                 self.ip_upper = 0;
             }
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(18 + m + penalty);
                 }
-                CPU_MODEL_486 => self.clk(13 + penalty),
+                CPU_MODEL_486_DX => self.clk(13 + penalty),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -2306,11 +2306,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         }
 
         match CPU_MODEL {
-            CPU_MODEL_386 => {
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                 let m = self.next_instruction_length_approx(bus);
                 self.clk(18 + m + penalty);
             }
-            CPU_MODEL_486 => self.clk(13 + penalty),
+            CPU_MODEL_486_DX => self.clk(13 + penalty),
             _ => {
                 unreachable!("Unhandled CPU_MODEL")
             }
@@ -2354,11 +2354,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                 self.ip_upper = 0;
             }
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(18 + m + penalty);
                 }
-                CPU_MODEL_486 => self.clk(14 + penalty),
+                CPU_MODEL_486_DX => self.clk(14 + penalty),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -2426,11 +2426,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         }
 
         match CPU_MODEL {
-            CPU_MODEL_386 => {
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                 let m = self.next_instruction_length_approx(bus);
                 self.clk(18 + m + penalty);
             }
-            CPU_MODEL_486 => self.clk(14 + penalty),
+            CPU_MODEL_486_DX => self.clk(14 + penalty),
             _ => {
                 unreachable!("Unhandled CPU_MODEL")
             }
@@ -2544,8 +2544,8 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             self.push(bus, flags_val)?;
         }
         let base = match CPU_MODEL {
-            CPU_MODEL_386 => 4,
-            CPU_MODEL_486 => {
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => 4,
+            CPU_MODEL_486_DX => {
                 if self.is_protected_mode() && !self.is_virtual_mode() {
                     3
                 } else {
@@ -2580,8 +2580,8 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             self.flags.load_flags(val, cpl, pm);
         }
         let base = match CPU_MODEL {
-            CPU_MODEL_386 => 5,
-            CPU_MODEL_486 => {
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => 5,
+            CPU_MODEL_486_DX => {
                 if self.is_protected_mode() && !self.is_virtual_mode() {
                     6
                 } else {
@@ -2638,7 +2638,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             let val = self.seg_read_dword(bus)?;
             self.regs.set_dword(DwordReg::EAX, val);
             let penalty = if self.ea & 3 != 0 {
-                Self::timing(4, 3)
+                Self::misaligned_operand_penalty()
             } else {
                 0
             };
@@ -2647,7 +2647,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             let val = self.seg_read_word(bus)?;
             self.regs.set_word(WordReg::AX, val);
             let penalty = if self.ea & 1 != 0 {
-                Self::timing(4, 3)
+                Self::misaligned_operand_penalty()
             } else {
                 0
             };
@@ -2683,7 +2683,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         if self.operand_size_override {
             self.seg_write_dword(bus, self.regs.dword(DwordReg::EAX))?;
             let penalty = if self.ea & 3 != 0 {
-                Self::timing(4, 3)
+                Self::misaligned_operand_penalty()
             } else {
                 0
             };
@@ -2691,7 +2691,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         } else {
             self.seg_write_word(bus, self.regs.word(WordReg::AX))?;
             let penalty = if self.ea & 1 != 0 {
-                Self::timing(4, 3)
+                Self::misaligned_operand_penalty()
             } else {
                 0
             };
@@ -3386,11 +3386,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         if count != 0 && !self.flags.zf() {
             self.apply_branch_disp8(disp);
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(11 + m);
                 }
-                CPU_MODEL_486 => self.clk(9),
+                CPU_MODEL_486_DX => self.clk(9),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -3414,11 +3414,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         if count != 0 && self.flags.zf() {
             self.apply_branch_disp8(disp);
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(11 + m);
                 }
-                CPU_MODEL_486 => self.clk(9),
+                CPU_MODEL_486_DX => self.clk(9),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -3442,11 +3442,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         if count != 0 {
             self.apply_branch_disp8(disp);
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(11 + m);
                 }
-                CPU_MODEL_486 => self.clk(7),
+                CPU_MODEL_486_DX => self.clk(7),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -3466,11 +3466,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         if is_zero {
             self.apply_branch_disp8(disp);
             match CPU_MODEL {
-                CPU_MODEL_386 => {
+                CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                     let m = self.next_instruction_length_approx(bus);
                     self.clk(9 + m);
                 }
-                CPU_MODEL_486 => self.clk(8),
+                CPU_MODEL_486_DX => self.clk(8),
                 _ => {
                     unreachable!("Unhandled CPU_MODEL")
                 }
@@ -3501,6 +3501,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             let low = bus.io_read_word(port) as u32;
             let high = bus.io_read_word(port.wrapping_add(2)) as u32;
             self.regs.set_dword(DwordReg::EAX, low | (high << 16));
+            self.clk_sx_io_dword();
         } else {
             let val = bus.io_read_word(port);
             self.regs.set_word(WordReg::AX, val);
@@ -3530,6 +3531,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             let val = self.regs.dword(DwordReg::EAX);
             bus.io_write_word(port, val as u16);
             bus.io_write_word(port.wrapping_add(2), (val >> 16) as u16);
+            self.clk_sx_io_dword();
         } else {
             let val = self.regs.word(WordReg::AX);
             bus.io_write_word(port, val);
@@ -3559,6 +3561,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             let low = bus.io_read_word(port) as u32;
             let high = bus.io_read_word(port.wrapping_add(2)) as u32;
             self.regs.set_dword(DwordReg::EAX, low | (high << 16));
+            self.clk_sx_io_dword();
         } else {
             let val = bus.io_read_word(port);
             self.regs.set_word(WordReg::AX, val);
@@ -3588,6 +3591,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             let val = self.regs.dword(DwordReg::EAX);
             bus.io_write_word(port, val as u16);
             bus.io_write_word(port.wrapping_add(2), (val >> 16) as u16);
+            self.clk_sx_io_dword();
         } else {
             let val = self.regs.word(WordReg::AX);
             bus.io_write_word(port, val);

--- a/crates/cpu/src/i386/execute_0f.rs
+++ b/crates/cpu/src/i386/execute_0f.rs
@@ -1,4 +1,4 @@
-use super::{CPU_MODEL_386, CPU_MODEL_486, I386, Step};
+use super::{CPU_MODEL_386_DX, CPU_MODEL_386_SX, CPU_MODEL_486_DX, I386, Step};
 use crate::{ByteReg, DwordReg, SegReg32, WordReg};
 
 impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH> {
@@ -23,8 +23,8 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             0x02 => self.lar(bus)?,
             0x03 => self.lsl_instr(bus)?,
             0x06 => self.clts(bus)?,
-            0x08 if CPU_MODEL >= CPU_MODEL_486 => self.invd(bus)?,
-            0x09 if CPU_MODEL >= CPU_MODEL_486 => self.wbinvd(bus)?,
+            0x08 if CPU_MODEL == CPU_MODEL_486_DX => self.invd(bus)?,
+            0x09 if CPU_MODEL == CPU_MODEL_486_DX => self.wbinvd(bus)?,
 
             0x20 => self.mov_r32_cr(bus)?,
             0x21 => self.mov_r32_dr(bus)?,
@@ -56,14 +56,14 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             0xBB => self.btc_reg(bus)?,
             0xBC => self.bsf(bus)?,
             0xBD => self.bsr(bus)?,
-            0xB0 if CPU_MODEL >= CPU_MODEL_486 => self.cmpxchg_byte(bus)?,
-            0xB1 if CPU_MODEL >= CPU_MODEL_486 => self.cmpxchg_word(bus)?,
+            0xB0 if CPU_MODEL == CPU_MODEL_486_DX => self.cmpxchg_byte(bus)?,
+            0xB1 if CPU_MODEL == CPU_MODEL_486_DX => self.cmpxchg_word(bus)?,
             0xBE => self.movsx_rm8(bus)?,
             0xBF => self.movsx_rm16(bus)?,
 
-            0xC0 if CPU_MODEL >= CPU_MODEL_486 => self.xadd_byte(bus)?,
-            0xC1 if CPU_MODEL >= CPU_MODEL_486 => self.xadd_word(bus)?,
-            0xC8..=0xCF if CPU_MODEL >= CPU_MODEL_486 => self.bswap(sub),
+            0xC0 if CPU_MODEL == CPU_MODEL_486_DX => self.xadd_byte(bus)?,
+            0xC1 if CPU_MODEL == CPU_MODEL_486_DX => self.xadd_word(bus)?,
+            0xC8..=0xCF if CPU_MODEL == CPU_MODEL_486_DX => self.bswap(sub),
 
             _ => self.raise_fault(6, bus)?,
         }
@@ -112,11 +112,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                 self.ip = eip as u16;
                 self.ip_upper = eip & 0xFFFF_0000;
                 match CPU_MODEL {
-                    CPU_MODEL_386 => {
+                    CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                         let m = self.next_instruction_length_approx(bus);
                         self.clk(7 + m);
                     }
-                    CPU_MODEL_486 => self.clk(3),
+                    CPU_MODEL_486_DX => self.clk(3),
                     _ => {
                         unreachable!("Unhandled CPU_MODEL")
                     }
@@ -130,11 +130,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                 self.ip = self.ip.wrapping_add(disp as u16);
                 self.ip_upper = 0;
                 match CPU_MODEL {
-                    CPU_MODEL_386 => {
+                    CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                         let m = self.next_instruction_length_approx(bus);
                         self.clk(7 + m);
                     }
-                    CPU_MODEL_486 => self.clk(3),
+                    CPU_MODEL_486_DX => self.clk(3),
                     _ => {
                         unreachable!("Unhandled CPU_MODEL")
                     }
@@ -151,8 +151,8 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         let value = if taken { 1 } else { 0 };
         self.put_rm_byte(modrm, value, bus)?;
         match CPU_MODEL {
-            CPU_MODEL_386 => self.clk_modrm(modrm, 4, 5),
-            CPU_MODEL_486 => {
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => self.clk_modrm(modrm, 4, 5),
+            CPU_MODEL_486_DX => {
                 if taken {
                     self.clk_modrm(modrm, 4, 3);
                 } else {
@@ -978,8 +978,8 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             }
         }
         match CPU_MODEL {
-            CPU_MODEL_386 => self.clk(10 + 3 * n as i32),
-            CPU_MODEL_486 => self.clk_modrm(modrm, 6, 7),
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => self.clk(10 + 3 * n as i32),
+            CPU_MODEL_486_DX => self.clk_modrm(modrm, 6, 7),
             _ => {
                 unreachable!("Unhandled CPU_MODEL")
             }
@@ -1016,8 +1016,8 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             }
         }
         match CPU_MODEL {
-            CPU_MODEL_386 => self.clk(10 + 3 * n as i32),
-            CPU_MODEL_486 => self.clk_modrm(modrm, 6, 7),
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => self.clk(10 + 3 * n as i32),
+            CPU_MODEL_486_DX => self.clk_modrm(modrm, 6, 7),
             _ => {
                 unreachable!("Unhandled CPU_MODEL")
             }
@@ -1258,7 +1258,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                 self.cr0 = (self.cr0 & 0xFFFF_FFF0) | (value as u32 & 0x000F) | (self.cr0 & 1);
                 self.clk_modrm(modrm, Self::timing(10, 13), Self::timing(13, 13));
             }
-            7 if CPU_MODEL >= CPU_MODEL_486 => {
+            7 if CPU_MODEL == CPU_MODEL_486_DX => {
                 // INVLPG - invalidate TLB entry for the given memory address.
                 if modrm >= 0xC0 {
                     self.raise_fault(6, bus)?;
@@ -1486,7 +1486,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         match cr_num {
             0 => {
                 let old_cr0 = self.cr0;
-                let cr0_mask = if CPU_MODEL == super::CPU_MODEL_486 {
+                let cr0_mask = if CPU_MODEL == super::CPU_MODEL_486_DX {
                     0xE005_003F // PG | CD | NW | AM | WP | NE | ET | TS | EM | MP | PE
                 } else {
                     0x8000_001F // PG | ET | TS | EM | MP | PE

--- a/crates/cpu/src/i386/execute_group.rs
+++ b/crates/cpu/src/i386/execute_group.rs
@@ -1,4 +1,4 @@
-use super::{CPU_MODEL_386, CPU_MODEL_486, I386, Step};
+use super::{CPU_MODEL_386_DX, CPU_MODEL_386_SX, CPU_MODEL_486_DX, I386, Step};
 use crate::{ByteReg, DwordReg, SegReg32, WordReg};
 
 impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH> {
@@ -7,11 +7,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
     #[inline(always)]
     fn shift_group_timing(extension: u8, count_source: u8) -> (i32, i32) {
         match CPU_MODEL {
-            CPU_MODEL_386 => match extension & 7 {
+            CPU_MODEL_386_DX | CPU_MODEL_386_SX => match extension & 7 {
                 2 | 3 => (9, 10),
                 _ => (3, 7),
             },
-            CPU_MODEL_486 => match count_source {
+            CPU_MODEL_486_DX => match count_source {
                 0 => match extension & 7 {
                     2 | 3 => (8, 9),
                     _ => (2, 4),
@@ -25,6 +25,21 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             _ => {
                 unreachable!("Unhandled CPU_MODEL")
             }
+        }
+    }
+
+    /// Base clocks for a far indirect JMP (opcode FF /5). Only protected mode
+    /// pays the descriptor-load cost; real and V86 mode load CS directly and are
+    /// much cheaper, consistent with the far CALL (FF /3) timing. The datasheet's
+    /// flat 43 is the protected-mode figure; the 386EX real-mode traces show the
+    /// cheaper cost. Applies to the 386DX and 386SX alike (shared execution
+    /// timing); the SX bus penalty for the pointer fetch is charged separately.
+    #[inline(always)]
+    fn far_jmp_indirect_base(&self) -> i32 {
+        if self.is_protected_mode() && !self.is_virtual_mode() {
+            43
+        } else {
+            18
         }
     }
 
@@ -814,7 +829,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                     self.ip = dst as u16;
                     self.ip_upper = dst & 0xFFFF_0000;
                     match CPU_MODEL {
-                        CPU_MODEL_386 => {
+                        CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                             let m = self.next_instruction_length_approx(bus);
                             if modrm >= 0xC0 {
                                 self.clk(7 + m + sp_pen);
@@ -823,7 +838,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                                 self.clk(10 + m + sp_pen + ea_pen);
                             }
                         }
-                        CPU_MODEL_486 => self.clk(5 + sp_pen),
+                        CPU_MODEL_486_DX => self.clk(5 + sp_pen),
                         _ => {
                             unreachable!("Unhandled CPU_MODEL")
                         }
@@ -836,7 +851,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                     self.ip = dst;
                     self.ip_upper = 0;
                     match CPU_MODEL {
-                        CPU_MODEL_386 => {
+                        CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                             let m = self.next_instruction_length_approx(bus);
                             if modrm >= 0xC0 {
                                 self.clk(7 + m + sp_pen);
@@ -845,7 +860,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                                 self.clk(10 + m + sp_pen + ea_pen);
                             }
                         }
-                        CPU_MODEL_486 => self.clk(5 + sp_pen),
+                        CPU_MODEL_486_DX => self.clk(5 + sp_pen),
                         _ => {
                             unreachable!("Unhandled CPU_MODEL")
                         }
@@ -880,12 +895,12 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                         )?;
                     }
                     match CPU_MODEL {
-                        CPU_MODEL_386 => {
+                        CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                             let m = self.next_instruction_length_approx(bus);
                             let ea_pen = if self.ea & 3 != 0 { 4 } else { 0 };
                             self.clk(22 + m + sp_pen + ea_pen);
                         }
-                        CPU_MODEL_486 => self.clk(17 + sp_pen),
+                        CPU_MODEL_486_DX => self.clk(17 + sp_pen),
                         _ => {
                             unreachable!("Unhandled CPU_MODEL")
                         }
@@ -914,12 +929,12 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                         )?;
                     }
                     match CPU_MODEL {
-                        CPU_MODEL_386 => {
+                        CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                             let m = self.next_instruction_length_approx(bus);
                             let ea_pen = if self.ea & 1 != 0 { 4 } else { 0 };
                             self.clk(22 + m + sp_pen + ea_pen);
                         }
-                        CPU_MODEL_486 => self.clk(17 + sp_pen),
+                        CPU_MODEL_486_DX => self.clk(17 + sp_pen),
                         _ => {
                             unreachable!("Unhandled CPU_MODEL")
                         }
@@ -933,7 +948,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                     self.ip = dst as u16;
                     self.ip_upper = dst & 0xFFFF_0000;
                     match CPU_MODEL {
-                        CPU_MODEL_386 => {
+                        CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                             let m = self.next_instruction_length_approx(bus);
                             if modrm >= 0xC0 {
                                 self.clk(7 + m);
@@ -942,7 +957,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                                 self.clk(10 + m + ea_pen);
                             }
                         }
-                        CPU_MODEL_486 => self.clk(5),
+                        CPU_MODEL_486_DX => self.clk(5),
                         _ => {
                             unreachable!("Unhandled CPU_MODEL")
                         }
@@ -953,7 +968,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                     self.ip = dst;
                     self.ip_upper = 0;
                     match CPU_MODEL {
-                        CPU_MODEL_386 => {
+                        CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                             let m = self.next_instruction_length_approx(bus);
                             if modrm >= 0xC0 {
                                 self.clk(7 + m);
@@ -962,7 +977,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                                 self.clk(10 + m + ea_pen);
                             }
                         }
-                        CPU_MODEL_486 => self.clk(5),
+                        CPU_MODEL_486_DX => self.clk(5),
                         _ => {
                             unreachable!("Unhandled CPU_MODEL")
                         }
@@ -986,12 +1001,12 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                         self.code_descriptor(segment, offset, super::TaskType::Jmp, 0, 0, bus)?;
                     }
                     match CPU_MODEL {
-                        CPU_MODEL_386 => {
+                        CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                             let m = self.next_instruction_length_approx(bus);
                             let penalty = if self.ea & 3 != 0 { 4 } else { 0 };
-                            self.clk(43 + m + penalty);
+                            self.clk(self.far_jmp_indirect_base() + m + penalty);
                         }
-                        CPU_MODEL_486 => self.clk(13),
+                        CPU_MODEL_486_DX => self.clk(13),
                         _ => {
                             unreachable!("Unhandled CPU_MODEL")
                         }
@@ -1016,12 +1031,12 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                         )?;
                     }
                     match CPU_MODEL {
-                        CPU_MODEL_386 => {
+                        CPU_MODEL_386_DX | CPU_MODEL_386_SX => {
                             let m = self.next_instruction_length_approx(bus);
                             let penalty = if self.ea & 1 != 0 { 4 } else { 0 };
-                            self.clk(43 + m + penalty);
+                            self.clk(self.far_jmp_indirect_base() + m + penalty);
                         }
-                        CPU_MODEL_486 => self.clk(13),
+                        CPU_MODEL_486_DX => self.clk(13),
                         _ => {
                             unreachable!("Unhandled CPU_MODEL")
                         }
@@ -1038,7 +1053,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                         self.clk(Self::timing(5, 1) + sp_pen);
                     } else {
                         let ea_pen = if self.ea & 3 != 0 {
-                            Self::timing(4, 3)
+                            Self::misaligned_operand_penalty()
                         } else {
                             0
                         };
@@ -1053,7 +1068,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                         self.clk(Self::timing(5, 1) + sp_pen);
                     } else {
                         let ea_pen = if self.ea & 1 != 0 {
-                            Self::timing(4, 3)
+                            Self::misaligned_operand_penalty()
                         } else {
                             0
                         };

--- a/crates/cpu/src/i386/paging.rs
+++ b/crates/cpu/src/i386/paging.rs
@@ -1,4 +1,4 @@
-use super::{CPU_MODEL_486, Fault, I386, Step};
+use super::{CPU_MODEL_486_DX, Fault, I386, Step};
 
 const TLB_SIZE: usize = 64;
 const TLB_MASK: u32 = (TLB_SIZE as u32) - 1;
@@ -45,7 +45,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             if is_user && !self.tlb_user[slot] {
                 return self.raise_page_fault(linear, write, true, bus);
             }
-            let wp_enforced = CPU_MODEL == CPU_MODEL_486 && self.cr0 & 0x0001_0000 != 0;
+            let wp_enforced = CPU_MODEL == CPU_MODEL_486_DX && self.cr0 & 0x0001_0000 != 0;
             if write && (is_user || wp_enforced) && !self.tlb_writable[slot] {
                 return self.raise_page_fault(linear, write, true, bus);
             }
@@ -97,7 +97,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
                 return self.raise_page_fault(linear, write, true, bus);
             }
         } else if write
-            && CPU_MODEL == CPU_MODEL_486
+            && CPU_MODEL == CPU_MODEL_486_DX
             && self.cr0 & 0x0001_0000 != 0
             && (pde & PTE_WRITABLE == 0 || pte & PTE_WRITABLE == 0)
         {

--- a/crates/cpu/src/i386/string_ops.rs
+++ b/crates/cpu/src/i386/string_ops.rs
@@ -85,6 +85,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         offset: u32,
     ) -> Step<u16> {
         let l0 = self.string_addr_delta(base, offset, 0);
+        self.clk_sx_bus(l0, 2);
         let same_page = if self.address_size_override {
             l0 & 0xFFF <= 0xFFE
         } else {
@@ -134,6 +135,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         offset: u32,
     ) -> Step<(u32, Option<u32>)> {
         let l0 = self.string_addr_delta(base, offset, 0);
+        self.clk_sx_bus(l0, 2);
         let same_page = if self.address_size_override {
             l0 & 0xFFF <= 0xFFE
         } else {
@@ -157,6 +159,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         offset: u32,
     ) -> Step<u32> {
         let l0 = self.string_addr_delta(base, offset, 0);
+        self.clk_sx_bus(l0, 4);
         let same_page = if self.address_size_override {
             l0 & 0xFFF <= 0xFFC
         } else {
@@ -212,6 +215,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         offset: u32,
     ) -> Step<ProbedDwordWrite> {
         let l0 = self.string_addr_delta(base, offset, 0);
+        self.clk_sx_bus(l0, 4);
         let same_page = if self.address_size_override {
             l0 & 0xFFF <= 0xFFC
         } else {
@@ -278,8 +282,16 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         } else {
             si & 1 != 0 || di & 1 != 0
         };
-        let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
-        self.clk(Self::timing(7, 7) + penalty);
+        let penalty = if misaligned {
+            Self::misaligned_operand_penalty()
+        } else {
+            0
+        };
+        // The 386EX real-mode traces show REP MOVSW/MOVSD running a clock per
+        // element slower than the datasheet's flat 7; the 386SX 16-bit bus is
+        // the likely cause, so only it diverges (the 386DX keeps the datasheet
+        // value). The dword form is additionally charged by clk_sx_bus.
+        self.clk(Self::timing_sx(7, 7, 8) + penalty);
         Ok(())
     }
 
@@ -329,7 +341,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         } else {
             si & 1 != 0 || di & 1 != 0
         };
-        let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
+        let penalty = if misaligned {
+            Self::misaligned_operand_penalty()
+        } else {
+            0
+        };
         self.clk(Self::timing(10, 8) + penalty);
         Ok(())
     }
@@ -367,7 +383,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         } else {
             di & 1 != 0
         };
-        let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
+        let penalty = if misaligned {
+            Self::misaligned_operand_penalty()
+        } else {
+            0
+        };
         self.clk(Self::timing(4, 5) + penalty);
         Ok(())
     }
@@ -405,8 +425,14 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         } else {
             si & 1 != 0
         };
-        let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
-        self.clk(Self::timing(5, 5) + penalty);
+        let penalty = if misaligned {
+            Self::misaligned_operand_penalty()
+        } else {
+            0
+        };
+        // REP LODSW runs a clock per element slower than the datasheet flat 5 on
+        // the 386EX; charge the 386SX for it (see movsw). The 386DX is unchanged.
+        self.clk(Self::timing_sx(5, 5, 6) + penalty);
         Ok(())
     }
 
@@ -444,7 +470,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         } else {
             di & 1 != 0
         };
-        let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
+        let penalty = if misaligned {
+            Self::misaligned_operand_penalty()
+        } else {
+            0
+        };
         self.clk(Self::timing(7, 6) + penalty);
         Ok(())
     }
@@ -480,6 +510,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             };
             let low = bus.io_read_word(port) as u32;
             let high = bus.io_read_word(port.wrapping_add(2)) as u32;
+            self.clk_sx_io_dword();
             let val = low | (high << 16);
             match cross {
                 None => bus.write_dword(a0, val),
@@ -510,7 +541,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         } else {
             di & 1 != 0
         };
-        let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
+        let penalty = if misaligned {
+            Self::misaligned_operand_penalty()
+        } else {
+            0
+        };
         self.clk(Self::timing(15, 17) + penalty);
         Ok(())
     }
@@ -546,6 +581,7 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
             let val = self.string_read_dword(bus, base, si)?;
             bus.io_write_word(port, val as u16);
             bus.io_write_word(port.wrapping_add(2), (val >> 16) as u16);
+            self.clk_sx_io_dword();
             self.string_advance_si(4);
         } else {
             let val = self.string_read_word(bus, base, si)?;
@@ -557,7 +593,11 @@ impl<const CPU_MODEL: u8, const ADDRESS_WIDTH: u8> I386<CPU_MODEL, ADDRESS_WIDTH
         } else {
             si & 1 != 0
         };
-        let penalty = if misaligned { Self::timing(4, 3) } else { 0 };
+        let penalty = if misaligned {
+            Self::misaligned_operand_penalty()
+        } else {
+            0
+        };
         self.clk(Self::timing(14, 17) + penalty);
         Ok(())
     }

--- a/crates/cpu/src/lib.rs
+++ b/crates/cpu/src/lib.rs
@@ -31,12 +31,20 @@
 //! cycles and should be indistinguishable from a performance point of view. It's also questionable
 //! that there is any games / software that requires a cycle-count accurate 286 emulation.
 //!
-//! The 386 / 486 are out of scope for cycle-count accuracy, since their real hardware
+//! The 386 / 486 are out of scope for full cycle-count accuracy, since their real hardware
 //! design and behavior is much more complex and the benefit of having a 486 cycle-count accurate
 //! core is very minimal. When the 386 and 486 were dominant, there were a lot of alternative
 //! CPU models on the market, so software really couldn't be optimized for a single CPU anymore.
-//! What could be improved is the emulated performance of the 286 and 486, since right now we are
-//! most likely faster than the original chips (since we use datasheet timings).
+//! The 386DX and 486 run on their datasheet instruction timings. Calibration against the
+//! SingleStepTests suites shows those datasheet numbers already track real throughput closely,
+//! so they are not the systematic "runs too fast" outlier they were once assumed to be.
+//!
+//! The 386SX is a special case within the 386 family. Its narrow 16-bit data bus and weaker
+//! prefetch make it noticeably slower than a 386DX at the same clock, so it gets an extra bus
+//! and prefetch penalty model on top of the shared 386 flat timings. That model is calibrated
+//! on aggregate against captured 386EX traces (the 386EX drives the same 16-bit bus), so the
+//! SX matches the real chip closely on overall throughput. Unlike the 286, it is not tuned per
+//! individual instruction, so it is not in the same accuracy league as the trace-calibrated 286.
 //!
 //! Since Neetan aims to emulate NEC machines roughly between 1979 and 1996, and put a hard line
 //! with the introduction of the Win32 API (and the irrelevance of the PC-98 as a platform),
@@ -45,15 +53,16 @@
 //!
 //! ## Supported CPUs
 //!
-//! | CPU   | Functionality verified | Cycle-count accurate | Trace based timings | Datasheet timings |
-//! |-------|------------------------|----------------------|---------------------|-------------------|
-//! | 8086  | Yes                    | Yes                  | Yes                 | No                |
-//! | V30   | Yes                    | Yes (1)              | Yes                 | No                |
-//! | 80286 | Yes                    | No                   | Yes                 | No                |
-//! | 80386 | Yes                    | No                   | No                  | Yes               |
-//! | 80486 | Yes                    | No                   | No                  | Yes               |
-//! | Z80   | Yes                    | Yes                  | Yes                 | No                |
-//! | 6809  | Yes                    | Yes (2)              | Yes                 | No                |
+//! | CPU     | Functionality verified | Cycle-count accurate | Trace based timings | Datasheet timings |
+//! |---------|------------------------|----------------------|---------------------|-------------------|
+//! | 8086    | Yes                    | Yes                  | Yes                 | No                |
+//! | V30     | Yes                    | Yes (1)              | Yes                 | No                |
+//! | 80286   | Yes                    | No                   | Yes                 | No                |
+//! | 80386DX | Yes                    | No                   | No                  | Yes               |
+//! | 80386SX | Yes                    | No                   | Aggregate (3)       | Yes               |
+//! | 80486   | Yes                    | No                   | No                  | Yes               |
+//! | Z80     | Yes                    | Yes                  | Yes                 | No                |
+//! | 6809    | Yes                    | Yes (2)              | Yes                 | No                |
 //!
 //! Note 1: We validated the timings using the V20 testdata and the V20 bus behavior. We then
 //!         added the V30 bus behavior and verified if the cycles adjust accordingly, how we
@@ -63,6 +72,10 @@
 //! Note 2: We validate the cycle-count against test files generated with MAME's m6809 core, which
 //!         is believed to be the most accurate emulation of the 6809. Once real hardware traces
 //!         become available, we will use those instead.
+//! Note 3: The 386DX and 486 use their datasheet flat timings. The 386SX shares those flat
+//!         timings but adds a 16-bit bus and prefetch penalty model that is calibrated on
+//!         aggregate against the SingleStepTests 386EX traces (same 16-bit bus). It matches the
+//!         real chip on overall throughput but, unlike the 286, is not tuned per instruction.
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(clippy::unnecessary_wraps)]
@@ -81,7 +94,8 @@ pub use i286::{
     I286TimingMilestones, I286TraceBusStatus, I286WarmStartConfig,
 };
 pub use i386::{
-    ADDRESS_WIDTH_24, ADDRESS_WIDTH_32, CPU_MODEL_386, CPU_MODEL_486, I386, I386Flags, I386State,
+    ADDRESS_WIDTH_24, ADDRESS_WIDTH_32, CPU_MODEL_386_DX, CPU_MODEL_386_SX, CPU_MODEL_486_DX, I386,
+    I386Flags, I386State,
 };
 pub use i8086::{I8086, I8086Flags, I8086State, PC9801F_CPU_CLOCK_5MHZ, PC9801F_CPU_CLOCK_8MHZ};
 pub use m6809::{M6809, M6809Flags, M6809State};

--- a/crates/cpu/tests/common/verification_common.rs
+++ b/crates/cpu/tests/common/verification_common.rs
@@ -33,6 +33,19 @@ pub struct MooI286Cycle {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MooI386Cycle {
+    pub pin_bitfield: u8,
+    pub address: u32,
+    pub memory_status: u8,
+    pub io_status: u8,
+    pub bhe_status: u8,
+    pub data_bus: u16,
+    pub bus_status: String,
+    pub raw_bus_status: u8,
+    pub t_state: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MooV20Cycle {
     pub pin_bitfield: u8,
     pub bus_value: u32,
@@ -53,6 +66,7 @@ pub struct MooV20Cycle {
 pub enum MooCycle {
     Legacy(MooLegacyCycle),
     I286(MooI286Cycle),
+    I386(MooI386Cycle),
     V20(MooV20Cycle),
 }
 
@@ -178,6 +192,29 @@ fn decode_i286_t_state(raw_t_state: u8) -> String {
     .to_string()
 }
 
+fn decode_i386_bus_status(raw_bus_status: u8) -> String {
+    match raw_bus_status & 0x07 {
+        0 => "INTA",
+        2 => "IOR",
+        3 => "IOW",
+        4 => "CODE",
+        5 => "HALT",
+        6 => "MEMR",
+        7 => "MEMW",
+        _ => "PASV",
+    }
+    .to_string()
+}
+
+fn decode_i386_t_state(raw_t_state: u8) -> String {
+    match raw_t_state & 0x07 {
+        1 => "T1",
+        2 => "T2",
+        _ => "Ti",
+    }
+    .to_string()
+}
+
 fn decode_v20_bus_status(raw_bus_status: u8) -> String {
     match raw_bus_status & 0x07 {
         0 => "INTA",
@@ -257,6 +294,41 @@ fn parse_cycles(payload: &[u8], cpu_name: &str) -> Vec<MooCycle> {
                 raw_queue_op,
                 queue_op: decode_v20_queue_op(raw_queue_op),
                 queue_byte,
+            }));
+        }
+
+        return cycles;
+    }
+
+    if cpu_name.contains("386") {
+        for _ in 0..count {
+            let pin_bitfield = payload[offset];
+            offset += 1;
+            let address = read_u32(payload, &mut offset);
+            offset += 1;
+            let memory_status = payload[offset];
+            offset += 1;
+            let io_status = payload[offset];
+            offset += 1;
+            let bhe_status = payload[offset];
+            offset += 1;
+            let data_bus = read_u16(payload, &mut offset);
+            let raw_bus_status = payload[offset];
+            offset += 1;
+            let raw_t_state = payload[offset];
+            offset += 1;
+            offset += 2;
+
+            cycles.push(MooCycle::I386(MooI386Cycle {
+                pin_bitfield,
+                address,
+                memory_status,
+                io_status,
+                bhe_status,
+                data_bus,
+                bus_status: decode_i386_bus_status(raw_bus_status),
+                raw_bus_status,
+                t_state: decode_i386_t_state(raw_t_state),
             }));
         }
 

--- a/crates/cpu/tests/extensions_i486.rs
+++ b/crates/cpu/tests/extensions_i486.rs
@@ -1,5 +1,5 @@
 use common::{Bus as _, Cpu as _};
-use cpu::{CPU_MODEL_486, I386, I386State};
+use cpu::{CPU_MODEL_486_DX, I386, I386State};
 
 const RAM_SIZE: usize = 1024 * 1024;
 const ADDRESS_MASK: u32 = 0x000F_FFFF;
@@ -72,8 +72,8 @@ fn setup_ivt_entry(bus: &mut TestBus, vector: u8, handler_cs: u16, handler_ip: u
     bus.ram[addr + 3] = (handler_cs >> 8) as u8;
 }
 
-fn make_486dx() -> I386<{ CPU_MODEL_486 }> {
-    I386::<{ CPU_MODEL_486 }>::new()
+fn make_486dx() -> I386<{ CPU_MODEL_486_DX }> {
+    I386::<{ CPU_MODEL_486_DX }>::new()
 }
 
 fn setup_state(cs: u16, ip: u16) -> I386State {

--- a/crates/cpu/tests/i486_manual/in_out.rs
+++ b/crates/cpu/tests/i486_manual/in_out.rs
@@ -18,7 +18,7 @@
 //! this is what closes off accesses near the end of the bitmap.
 
 use common::Cpu as _;
-use cpu::{CPU_MODEL_386, I386, I386State};
+use cpu::{CPU_MODEL_386_DX, I386, I386State};
 
 use super::setup::{
     ACCESS_DESCRIPTOR_SYSTEM, ACCESS_DPL_RING0, ACCESS_PRESENT, DEFAULT_IO_MAP_BASE_OFFSET,
@@ -63,7 +63,7 @@ fn promote_to_cpl3_iopl(state: &mut I386State, iopl: u8) {
     state.flags.iopl = iopl & 3;
 }
 
-fn assert_general_protection_taken(cpu: &I386<{ CPU_MODEL_386 }>) {
+fn assert_general_protection_taken(cpu: &I386<{ CPU_MODEL_386_DX }>) {
     assert!(cpu.halted(), "expected #GP handler to halt");
     assert_eq!(
         cpu.ip(),
@@ -72,7 +72,7 @@ fn assert_general_protection_taken(cpu: &I386<{ CPU_MODEL_386 }>) {
     );
 }
 
-fn assert_no_fault(cpu: &I386<{ CPU_MODEL_386 }>) {
+fn assert_no_fault(cpu: &I386<{ CPU_MODEL_386_DX }>) {
     assert!(
         !cpu.halted(),
         "expected the I/O instruction to complete without halting"

--- a/crates/cpu/tests/i486_manual/long_tail.rs
+++ b/crates/cpu/tests/i486_manual/long_tail.rs
@@ -1225,7 +1225,7 @@ fn shrink_only_extra_segment_limit(state: &mut cpu::I386State, limit: u16) {
     state.seg_limits[cpu::SegReg32::ES as usize] = limit as u32;
 }
 
-fn run_until_halted(cpu: &mut cpu::I386<{ cpu::CPU_MODEL_486 }>, bus: &mut TestBus) {
+fn run_until_halted(cpu: &mut cpu::I386<{ cpu::CPU_MODEL_486_DX }>, bus: &mut TestBus) {
     for _ in 0..64 {
         cpu.step(bus);
         if cpu.halted() {

--- a/crates/cpu/tests/i486_manual/real_mode_addressing.rs
+++ b/crates/cpu/tests/i486_manual/real_mode_addressing.rs
@@ -30,7 +30,7 @@ fn place_in_test_code(bus: &mut TestBus, offset: u16, code: &[u8]) {
     place_at(bus, TEST_CS_BASE + offset as u32, code);
 }
 
-fn assert_general_protection_dispatched(cpu: &cpu::I386<{ cpu::CPU_MODEL_486 }>) {
+fn assert_general_protection_dispatched(cpu: &cpu::I386<{ cpu::CPU_MODEL_486_DX }>) {
     assert!(cpu.halted(), "expected #GP handler HLT");
     assert_eq!(cpu.cs(), REAL_MODE_HANDLER_SEGMENT);
     assert_eq!(
@@ -39,7 +39,7 @@ fn assert_general_protection_dispatched(cpu: &cpu::I386<{ cpu::CPU_MODEL_486 }>)
     );
 }
 
-fn assert_double_fault_dispatched(cpu: &cpu::I386<{ cpu::CPU_MODEL_486 }>) {
+fn assert_double_fault_dispatched(cpu: &cpu::I386<{ cpu::CPU_MODEL_486_DX }>) {
     assert!(cpu.halted(), "expected #DF handler HLT");
     assert_eq!(cpu.cs(), REAL_MODE_HANDLER_SEGMENT);
     assert_eq!(cpu.ip() as u16, REAL_MODE_HANDLER_DOUBLE_FAULT_OFFSET + 1);

--- a/crates/cpu/tests/i486_manual/real_mode_instruction_semantics.rs
+++ b/crates/cpu/tests/i486_manual/real_mode_instruction_semantics.rs
@@ -56,13 +56,13 @@ fn make_real_mode_state_for_semantics() -> I386State {
     state
 }
 
-fn assert_invalid_opcode_dispatched(cpu: &cpu::I386<{ cpu::CPU_MODEL_486 }>) {
+fn assert_invalid_opcode_dispatched(cpu: &cpu::I386<{ cpu::CPU_MODEL_486_DX }>) {
     assert!(cpu.halted(), "expected #UD handler HLT");
     assert_eq!(cpu.cs(), REAL_MODE_HANDLER_SEGMENT);
     assert_eq!(cpu.ip() as u16, REAL_MODE_HANDLER_INVALID_OPCODE_OFFSET + 1);
 }
 
-fn assert_general_protection_dispatched(cpu: &cpu::I386<{ cpu::CPU_MODEL_486 }>) {
+fn assert_general_protection_dispatched(cpu: &cpu::I386<{ cpu::CPU_MODEL_486_DX }>) {
     assert!(cpu.halted(), "expected #GP handler HLT");
     assert_eq!(cpu.cs(), REAL_MODE_HANDLER_SEGMENT);
     assert_eq!(

--- a/crates/cpu/tests/i486_manual/setup.rs
+++ b/crates/cpu/tests/i486_manual/setup.rs
@@ -3,7 +3,7 @@
 //! Identifiers are spelled out in full and constants are named after the
 //! manual sections they encode so tests do not embed magic hex.
 
-use cpu::{CPU_MODEL_386, CPU_MODEL_486, I386, I386State};
+use cpu::{CPU_MODEL_386_DX, CPU_MODEL_486_DX, I386, I386State};
 
 // Memory layout used by setup_protected_mode and friends. Bases are chosen so
 // that no two regions overlap inside a 1 MiB test bus.
@@ -159,12 +159,12 @@ pub(crate) const TSS_MINIMUM_LIMIT: u32 = 0x67;
 pub(crate) const IO_PERMISSION_BITMAP_SENTINEL: u8 = 0xFF;
 pub(crate) const IO_PERMISSION_BITMAP_DENY_ALL: u16 = 0xFFFF;
 
-pub(crate) fn make_cpu_386() -> I386<{ CPU_MODEL_386 }> {
-    I386::<{ CPU_MODEL_386 }>::new()
+pub(crate) fn make_cpu_386() -> I386<{ CPU_MODEL_386_DX }> {
+    I386::<{ CPU_MODEL_386_DX }>::new()
 }
 
-pub(crate) fn make_cpu_486() -> I386<{ CPU_MODEL_486 }> {
-    I386::<{ CPU_MODEL_486 }>::new()
+pub(crate) fn make_cpu_486() -> I386<{ CPU_MODEL_486_DX }> {
+    I386::<{ CPU_MODEL_486_DX }>::new()
 }
 
 /// Test bus: a flat 1 MiB memory with simple IRQ injection.

--- a/crates/cpu/tests/i486_manual/v86_addressing_and_faults.rs
+++ b/crates/cpu/tests/i486_manual/v86_addressing_and_faults.rs
@@ -79,12 +79,12 @@ fn place_in_v86_code(bus: &mut TestBus, offset: u16, code: &[u8]) {
     place_at(bus, VM86_CS_BASE + offset as u32, code);
 }
 
-fn assert_at_handler(cpu: &cpu::I386<{ cpu::CPU_MODEL_486 }>, handler_ip: u16) {
+fn assert_at_handler(cpu: &cpu::I386<{ cpu::CPU_MODEL_486_DX }>, handler_ip: u16) {
     assert!(cpu.halted(), "expected handler HLT");
     assert_eq!(cpu.ip(), handler_ip as u32 + 1);
 }
 
-fn read_saved_eip_from_pl0_stack(bus: &TestBus, cpu: &cpu::I386<{ cpu::CPU_MODEL_486 }>) -> u32 {
+fn read_saved_eip_from_pl0_stack(bus: &TestBus, cpu: &cpu::I386<{ cpu::CPU_MODEL_486_DX }>) -> u32 {
     let stack_linear =
         cpu.state.seg_bases[cpu::SegReg32::SS as usize] + cpu.state.regs.dword(cpu::DwordReg::ESP);
     read_dword_at(bus, stack_linear)

--- a/crates/cpu/tests/model_identity.rs
+++ b/crates/cpu/tests/model_identity.rs
@@ -3,7 +3,7 @@
 //! from a 486DX.
 
 use common::{Bus as _, Cpu as _};
-use cpu::{CPU_MODEL_386, CPU_MODEL_486, I386, I386State};
+use cpu::{CPU_MODEL_386_DX, CPU_MODEL_486_DX, I386, I386State};
 
 const RAM_SIZE: usize = 1 << 20;
 const ADDRESS_MASK: u32 = 0x000F_FFFF;
@@ -76,7 +76,7 @@ fn setup_real_mode_state(cs: u16, ip: u16) -> I386State {
 
 #[test]
 fn reset_edx_reports_386dx_revision() {
-    let cpu = I386::<{ CPU_MODEL_386 }>::new();
+    let cpu = I386::<{ CPU_MODEL_386_DX }>::new();
     assert_eq!(
         cpu.edx(),
         0x0000_0308,
@@ -86,7 +86,7 @@ fn reset_edx_reports_386dx_revision() {
 
 #[test]
 fn reset_edx_reports_486dx2_revision() {
-    let cpu = I386::<{ CPU_MODEL_486 }>::new();
+    let cpu = I386::<{ CPU_MODEL_486_DX }>::new();
     assert_eq!(
         cpu.edx(),
         0x0000_0435,
@@ -132,7 +132,7 @@ fn run_ac_toggle_detection<const CPU_MODEL: u8>() -> u32 {
 #[test]
 fn pushfd_popfd_ac_detection_reports_386() {
     assert_eq!(
-        run_ac_toggle_detection::<{ CPU_MODEL_386 }>(),
+        run_ac_toggle_detection::<{ CPU_MODEL_386_DX }>(),
         0,
         "the AC toggle must be swallowed on the 386"
     );
@@ -141,7 +141,7 @@ fn pushfd_popfd_ac_detection_reports_386() {
 #[test]
 fn pushfd_popfd_ac_detection_reports_486() {
     assert_eq!(
-        run_ac_toggle_detection::<{ CPU_MODEL_486 }>(),
+        run_ac_toggle_detection::<{ CPU_MODEL_486_DX }>(),
         EFLAGS_ALIGNMENT_CHECK,
         "the AC toggle must stick on the 486"
     );
@@ -187,13 +187,13 @@ fn run_real_mode_iretd_ac<const CPU_MODEL: u8>() -> u32 {
 
 #[test]
 fn real_mode_iretd_ac_stays_clear_on_386() {
-    assert_eq!(run_real_mode_iretd_ac::<{ CPU_MODEL_386 }>(), 0);
+    assert_eq!(run_real_mode_iretd_ac::<{ CPU_MODEL_386_DX }>(), 0);
 }
 
 #[test]
 fn real_mode_iretd_ac_loads_on_486() {
     assert_eq!(
-        run_real_mode_iretd_ac::<{ CPU_MODEL_486 }>(),
+        run_real_mode_iretd_ac::<{ CPU_MODEL_486_DX }>(),
         EFLAGS_ALIGNMENT_CHECK
     );
 }
@@ -311,13 +311,13 @@ fn run_protected_mode_iretd_ac<const CPU_MODEL: u8>() -> u32 {
 
 #[test]
 fn protected_mode_iretd_ac_stays_clear_on_386() {
-    assert_eq!(run_protected_mode_iretd_ac::<{ CPU_MODEL_386 }>(), 0);
+    assert_eq!(run_protected_mode_iretd_ac::<{ CPU_MODEL_386_DX }>(), 0);
 }
 
 #[test]
 fn protected_mode_iretd_ac_loads_on_486() {
     assert_eq!(
-        run_protected_mode_iretd_ac::<{ CPU_MODEL_486 }>(),
+        run_protected_mode_iretd_ac::<{ CPU_MODEL_486_DX }>(),
         EFLAGS_ALIGNMENT_CHECK
     );
 }
@@ -381,13 +381,13 @@ fn run_task_switch_ac<const CPU_MODEL: u8>() -> u32 {
 
 #[test]
 fn task_switch_ac_stays_clear_on_386() {
-    assert_eq!(run_task_switch_ac::<{ CPU_MODEL_386 }>(), 0);
+    assert_eq!(run_task_switch_ac::<{ CPU_MODEL_386_DX }>(), 0);
 }
 
 #[test]
 fn task_switch_ac_loads_on_486() {
     assert_eq!(
-        run_task_switch_ac::<{ CPU_MODEL_486 }>(),
+        run_task_switch_ac::<{ CPU_MODEL_486_DX }>(),
         EFLAGS_ALIGNMENT_CHECK
     );
 }

--- a/crates/cpu/tests/paging_i386.rs
+++ b/crates/cpu/tests/paging_i386.rs
@@ -1,5 +1,5 @@
 use common::Cpu as _;
-use cpu::{CPU_MODEL_486, I386};
+use cpu::{CPU_MODEL_486_DX, I386};
 use softfloat::Fp80;
 
 const RAM_SIZE: usize = 2 * 1024 * 1024;
@@ -960,7 +960,7 @@ fn assert_rmw_user_fault_writes(instruction: &[u8], expected_eip_after_fault: u3
 }
 
 fn assert_rmw_user_fault_writes_486(instruction: &[u8], expected_eip_after_fault: u32) {
-    let mut cpu: I386<{ cpu::CPU_MODEL_486 }> = I386::new();
+    let mut cpu: I386<{ cpu::CPU_MODEL_486_DX }> = I386::new();
     assert_rmw_user_fault_writes_with_cpu(&mut cpu, instruction, expected_eip_after_fault);
 }
 
@@ -2480,7 +2480,7 @@ fn cr0_wp_bit_masked_on_386() {
 
 #[test]
 fn cr0_wp_bit_accepted_on_486() {
-    let mut cpu: I386<{ CPU_MODEL_486 }> = I386::new();
+    let mut cpu: I386<{ CPU_MODEL_486_DX }> = I386::new();
     let mut bus = TestBus::new();
 
     let state = setup_paged_protected_mode(&mut bus);
@@ -2505,7 +2505,7 @@ fn cr0_wp_bit_accepted_on_486() {
 
 #[test]
 fn supervisor_write_to_readonly_page_without_wp() {
-    let mut cpu: I386<{ CPU_MODEL_486 }> = I386::new();
+    let mut cpu: I386<{ CPU_MODEL_486_DX }> = I386::new();
     let mut bus = TestBus::new();
 
     let state = setup_paged_protected_mode(&mut bus);
@@ -2532,7 +2532,7 @@ fn supervisor_write_to_readonly_page_without_wp() {
 
 #[test]
 fn supervisor_write_to_readonly_page_with_wp() {
-    let mut cpu: I386<{ CPU_MODEL_486 }> = I386::new();
+    let mut cpu: I386<{ CPU_MODEL_486_DX }> = I386::new();
     let mut bus = TestBus::new();
 
     let mut state = setup_paged_protected_mode(&mut bus);
@@ -2567,7 +2567,7 @@ fn supervisor_write_to_readonly_page_with_wp() {
 
 #[test]
 fn supervisor_read_from_readonly_page_with_wp() {
-    let mut cpu: I386<{ CPU_MODEL_486 }> = I386::new();
+    let mut cpu: I386<{ CPU_MODEL_486_DX }> = I386::new();
     let mut bus = TestBus::new();
 
     let mut state = setup_paged_protected_mode(&mut bus);
@@ -3198,7 +3198,7 @@ fn paging_call_gate_pf_on_param_copy_does_not_commit_ss_esp() {
 /// surrounding state save / decode reads still succeed.
 #[test]
 fn paging_task_switch_pf_on_new_tss_busy_bit_leaves_old_tss_busy() {
-    let mut cpu: I386<{ CPU_MODEL_486 }> = I386::new();
+    let mut cpu: I386<{ CPU_MODEL_486_DX }> = I386::new();
     let mut bus = TestBus::new();
 
     let mut state = setup_paged_protected_mode(&mut bus);
@@ -3289,7 +3289,7 @@ fn paging_task_switch_pf_on_new_tss_busy_bit_leaves_old_tss_busy() {
 /// migration target) land on a read-only page.
 #[test]
 fn paging_iret_inter_priv_pf_on_cs_a_bit_does_not_commit_cs() {
-    let mut cpu: I386<{ CPU_MODEL_486 }> = I386::new();
+    let mut cpu: I386<{ CPU_MODEL_486_DX }> = I386::new();
     let mut bus = TestBus::new();
 
     let mut state = setup_paged_protected_mode(&mut bus);

--- a/crates/cpu/tests/physical_addressing_i386.rs
+++ b/crates/cpu/tests/physical_addressing_i386.rs
@@ -4,7 +4,7 @@
 //! 24-bit configuration (PC-98 wiring) must keep truncating physical
 //! addresses exactly as before.
 
-use cpu::{ADDRESS_WIDTH_24, ADDRESS_WIDTH_32, CPU_MODEL_386, CPU_MODEL_486, I386, SegReg32};
+use cpu::{ADDRESS_WIDTH_24, ADDRESS_WIDTH_32, CPU_MODEL_386_DX, CPU_MODEL_486_DX, I386, SegReg32};
 
 const LOW_RAM_BASE: u32 = 0x0000_0000;
 const LOW_RAM_SIZE: usize = 0x0020_0000;
@@ -169,12 +169,12 @@ fn reset_vector_lands_at_fffffff0<const CPU_MODEL: u8>() {
 
 #[test]
 fn reset_vector_lands_at_fffffff0_386() {
-    reset_vector_lands_at_fffffff0::<CPU_MODEL_386>();
+    reset_vector_lands_at_fffffff0::<CPU_MODEL_386_DX>();
 }
 
 #[test]
 fn reset_vector_lands_at_fffffff0_486() {
-    reset_vector_lands_at_fffffff0::<CPU_MODEL_486>();
+    reset_vector_lands_at_fffffff0::<CPU_MODEL_486_DX>();
 }
 
 /// Models the real boot flow: the first far jump out of the reset region
@@ -197,12 +197,12 @@ fn reset_far_jump_drops_cs_base<const CPU_MODEL: u8>() {
 
 #[test]
 fn reset_far_jump_drops_cs_base_386() {
-    reset_far_jump_drops_cs_base::<CPU_MODEL_386>();
+    reset_far_jump_drops_cs_base::<CPU_MODEL_386_DX>();
 }
 
 #[test]
 fn reset_far_jump_drops_cs_base_486() {
-    reset_far_jump_drops_cs_base::<CPU_MODEL_486>();
+    reset_far_jump_drops_cs_base::<CPU_MODEL_486_DX>();
 }
 
 fn protected_mode_fetch_above_16mb<const CPU_MODEL: u8>() {
@@ -229,12 +229,12 @@ fn protected_mode_fetch_above_16mb<const CPU_MODEL: u8>() {
 
 #[test]
 fn protected_mode_fetch_above_16mb_386() {
-    protected_mode_fetch_above_16mb::<CPU_MODEL_386>();
+    protected_mode_fetch_above_16mb::<CPU_MODEL_386_DX>();
 }
 
 #[test]
 fn protected_mode_fetch_above_16mb_486() {
-    protected_mode_fetch_above_16mb::<CPU_MODEL_486>();
+    protected_mode_fetch_above_16mb::<CPU_MODEL_486_DX>();
 }
 
 const PAGE_DIRECTORY: u32 = 0x000A_0000;
@@ -297,22 +297,22 @@ fn paged_fetch_above_16mb<const CPU_MODEL: u8>() {
 
 #[test]
 fn paged_fetch_above_16mb_386() {
-    paged_fetch_above_16mb::<CPU_MODEL_386>();
+    paged_fetch_above_16mb::<CPU_MODEL_386_DX>();
 }
 
 #[test]
 fn paged_fetch_above_16mb_486() {
-    paged_fetch_above_16mb::<CPU_MODEL_486>();
+    paged_fetch_above_16mb::<CPU_MODEL_486_DX>();
 }
 
 #[test]
 fn legacy_reset_vector_stays_at_ffff0() {
-    let cpu: I386<CPU_MODEL_386, ADDRESS_WIDTH_24> = I386::new();
+    let cpu: I386<CPU_MODEL_386_DX, ADDRESS_WIDTH_24> = I386::new();
     assert_eq!(cpu.state.cs(), 0xFFFF);
     assert_eq!(cpu.state.seg_bases[SegReg32::CS as usize], 0x000F_FFF0);
     assert_eq!(cpu.state.eip(), 0x0000);
 
-    let cpu: I386<CPU_MODEL_486, ADDRESS_WIDTH_24> = I386::new();
+    let cpu: I386<CPU_MODEL_486_DX, ADDRESS_WIDTH_24> = I386::new();
     assert_eq!(cpu.state.cs(), 0xFFFF);
     assert_eq!(cpu.state.seg_bases[SegReg32::CS as usize], 0x000F_FFF0);
     assert_eq!(cpu.state.eip(), 0x0000);
@@ -347,10 +347,10 @@ fn legacy_width_masks_to_24_bit<const CPU_MODEL: u8>() {
 
 #[test]
 fn legacy_width_masks_to_24_bit_386() {
-    legacy_width_masks_to_24_bit::<CPU_MODEL_386>();
+    legacy_width_masks_to_24_bit::<CPU_MODEL_386_DX>();
 }
 
 #[test]
 fn legacy_width_masks_to_24_bit_486() {
-    legacy_width_masks_to_24_bit::<CPU_MODEL_486>();
+    legacy_width_masks_to_24_bit::<CPU_MODEL_486_DX>();
 }

--- a/crates/cpu/tests/test386.rs
+++ b/crates/cpu/tests/test386.rs
@@ -8,7 +8,7 @@
 //! table.
 
 use common::{Bus, Cpu};
-use cpu::{CPU_MODEL_386, I386};
+use cpu::{CPU_MODEL_386_DX, I386};
 
 const ROM_BYTES: &[u8] = include_bytes!("test386/test386.bin");
 const EE_REFERENCE: &str = include_str!("test386/upstream/test386-EE-reference.txt");
@@ -90,7 +90,7 @@ impl Bus for TestBus {
     fn set_current_cycle(&mut self, _cycle: u64) {}
 }
 
-fn run_until_halt(cpu: &mut I386<CPU_MODEL_386>, bus: &mut TestBus) -> u64 {
+fn run_until_halt(cpu: &mut I386<CPU_MODEL_386_DX>, bus: &mut TestBus) -> u64 {
     let mut steps = 0u64;
     while !cpu.halted() && steps < MAX_STEPS {
         cpu.step(bus);
@@ -109,7 +109,7 @@ fn format_post_history(history: &[u8]) -> String {
 
 #[test]
 fn test386_reaches_post_ff() {
-    let mut cpu: I386<CPU_MODEL_386> = I386::new();
+    let mut cpu: I386<CPU_MODEL_386_DX> = I386::new();
     let mut bus = TestBus::new();
 
     let steps = run_until_halt(&mut cpu, &mut bus);
@@ -135,7 +135,7 @@ fn test386_reaches_post_ff() {
 
 #[test]
 fn test386_ee_output_matches_reference() {
-    let mut cpu: I386<CPU_MODEL_386> = I386::new();
+    let mut cpu: I386<CPU_MODEL_386_DX> = I386::new();
     let mut bus = TestBus::new();
     run_until_halt(&mut cpu, &mut bus);
 

--- a/crates/cpu/tests/verification_i386_sx_timing.rs
+++ b/crates/cpu/tests/verification_i386_sx_timing.rs
@@ -1,0 +1,454 @@
+#![cfg(feature = "verification")]
+
+//! Aggregate timing calibration for the 80386SX CPU model.
+//!
+//! The SingleStepTests 80386 suite was captured from a 386EX, which - like the
+//! 386SX - drives a 16-bit data bus, so its per-cycle traces are a usable proxy
+//! for SX instruction lengths. This test sums the trace clock counts and the
+//! emulated `cycles_consumed()` counts over the whole real-mode suite and
+//! asserts they agree within a small tolerance. It is a calibration aid for the
+//! SX timing constants in `i386.rs`, not a per-instruction cycle check.
+//!
+//! Two hardware artifacts of the capture are compensated for:
+//!  - Each test terminates via an injected `HALT` captured through SMI/SMM,
+//!    adding a fixed capture overhead per test (subtracted as
+//!    [`SMM_CAPTURE_OVERHEAD_CLOCKS`], the free parameter that centers the
+//!    aggregate; re-tune it if the per-opcode model changes).
+//!  - The 386EX's SMM microcode lengthened IN/INS/OUT/OUTS/HLT/MOV CR0 by 1-4
+//!    clocks over a plain SX, so those opcodes are excluded from the aggregate.
+//!
+//! Run with `--nocapture` for two reports: the worst stems by absolute delta,
+//! and an "important opcodes" table (MOV/ALU/MUL/shifts/string/...) that removes
+//! the per-test overhead to expose per-instruction error for tuning. Short
+//! opcodes below a clock floor are overhead-noise-limited and left at their
+//! datasheet timing; only high-clock outliers are flagged.
+
+#[path = "common/verification_common.rs"]
+mod verification_common;
+
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+    sync::LazyLock,
+};
+
+use common::Cpu as _;
+use cpu::{ADDRESS_WIDTH_24, CPU_MODEL_386_SX, I386, I386State};
+use verification_common::{MooCycle, load_moo_tests, load_revocation_list};
+
+const RAM_SIZE: usize = 16 * 1024 * 1024;
+const ADDRESS_MASK: u32 = 0x00FF_FFFF;
+const REG_ORDER_386: [&str; 20] = [
+    "cr0", "cr3", "eax", "ebx", "ecx", "edx", "esi", "edi", "ebp", "esp", "cs", "ds", "es", "fs",
+    "gs", "ss", "eip", "eflags", "dr6", "dr7",
+];
+
+/// Average clocks the 386EX spends per test on the post-jump prefetch queue
+/// fill and the SMM state capture triggered by the terminating `HALT` - the
+/// portion of each trace that a plain 386SX would not spend on the instruction
+/// itself. Subtracted from each trace length. This is an average of a
+/// per-test-varying process (fill length depends on instruction length and
+/// alignment), so a fractional value is expected; the suite README quotes ~14
+/// as a rough figure and notes it "isn't perfect". Calibration constant.
+const SMM_CAPTURE_OVERHEAD_CLOCKS: f64 = 12.32;
+
+/// Aggregate agreement required between emulated and trace clock totals.
+const AGGREGATE_TOLERANCE: f64 = 0.005;
+
+/// Maximum instructions executed per test before giving up (matches the
+/// architectural harness).
+const MAX_STEPS: usize = 4096;
+
+/// Opcode stems (after stripping 66/67 prefixes) whose 386EX timings were
+/// lengthened by the SMM microcode relative to a plain 386SX. Excluded from
+/// the aggregate. Covers IN/INS/OUT/OUTS/HLT and MOV CR0,src.
+const SMM_AFFECTED_OPCODES: &[&str] = &[
+    "6C", "6D", "6E", "6F", "E4", "E5", "E6", "E7", "EC", "ED", "EE", "EF", "F4", "0F22",
+];
+
+/// Bare opcode stems (after stripping 66/67 prefixes) for the high-frequency
+/// instructions whose 386SX per-opcode timing we refine: MOV, the ALU ops,
+/// MUL/IMUL, shifts/rotates, string ops, INC/DEC, PUSH/POP, TEST, and LEA.
+/// Representative encodings are enough because timing-identical encodings share
+/// a single call site. Used to print the per-opcode tuning table below.
+const IMPORTANT_OPCODES: &[&str] = &[
+    // MOV
+    "88", "89", "8A", "8B", "A0", "A1", "A2", "A3", "B0", "B8", "C6",
+    "C7", // ALU r/m,reg and reg,r/m, plus immediate groups
+    "01", "03", "09", "29", "31", "39", "3B", "80", "81", "83", // MUL / IMUL
+    "F6", "F7", "0FAF", "69", "6B", // shifts / rotates (group 2)
+    "C0", "C1", "D0", "D1", "D2", "D3", // INC / DEC
+    "40", "48", "FE", "FF", // PUSH / POP
+    "50", "58", "68", "6A", "8F", // string
+    "A4", "A5", "A6", "A7", "AA", "AB", "AC", "AD", "AE", "AF", // TEST
+    "84", "85", "A8", "A9", // LEA
+    "8D",
+];
+
+/// Per-opcode delta above which the important-opcode table flags a stem for
+/// tuning.
+const IMPORTANT_OPCODE_BOUND_PERCENT: f64 = 10.0;
+
+/// Minimum instruction clocks per test for a stem's delta to be trustworthy.
+/// Below this the fixed ~18-clock capture overhead dwarfs the instruction, so
+/// the overhead-removal variance swamps the signal and the percentage is noise;
+/// such short opcodes keep their datasheet flat timing and are not flagged.
+const MIN_MEANINGFUL_CLOCKS_PER_TEST: f64 = 10.0;
+
+type SxCpu = I386<{ CPU_MODEL_386_SX }, { ADDRESS_WIDTH_24 }>;
+
+struct TestBus {
+    ram: Vec<u8>,
+    dirty: Vec<u32>,
+    dirty_marker: Vec<u8>,
+}
+
+impl TestBus {
+    fn new() -> Self {
+        Self {
+            ram: vec![0u8; RAM_SIZE],
+            dirty: Vec::new(),
+            dirty_marker: vec![0u8; RAM_SIZE],
+        }
+    }
+
+    fn clear(&mut self) {
+        for &address in &self.dirty {
+            let index = (address & ADDRESS_MASK) as usize;
+            self.ram[index] = 0;
+            self.dirty_marker[index] = 0;
+        }
+        self.dirty.clear();
+    }
+
+    fn set_memory(&mut self, address: u32, value: u8) {
+        let index = (address & ADDRESS_MASK) as usize;
+        if self.dirty_marker[index] == 0 {
+            self.dirty_marker[index] = 1;
+            self.dirty.push(address & ADDRESS_MASK);
+        }
+        self.ram[index] = value;
+    }
+}
+
+impl common::Bus for TestBus {
+    fn read_byte(&mut self, address: u32) -> u8 {
+        self.ram[(address & ADDRESS_MASK) as usize]
+    }
+
+    fn write_byte(&mut self, address: u32, value: u8) {
+        self.set_memory(address, value);
+    }
+
+    fn io_read_byte(&mut self, port: u16) -> u8 {
+        match port {
+            0x22 => 0x7F,
+            0x23 => 0x42,
+            _ => 0xFF,
+        }
+    }
+
+    fn io_write_byte(&mut self, _port: u16, _value: u8) {}
+
+    fn has_irq(&self) -> bool {
+        false
+    }
+
+    fn acknowledge_irq(&mut self) -> u8 {
+        0
+    }
+
+    fn has_nmi(&self) -> bool {
+        false
+    }
+
+    fn acknowledge_nmi(&mut self) {}
+
+    fn current_cycle(&self) -> u64 {
+        0
+    }
+
+    fn set_current_cycle(&mut self, _cycle: u64) {}
+}
+
+fn test_dir() -> &'static Path {
+    static DIR: LazyLock<PathBuf> = LazyLock::new(|| {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/SingleStepTests/80386/v1_ex_real_mode")
+    });
+    &DIR
+}
+
+fn revocation_list() -> &'static HashSet<String> {
+    static REVOKED: LazyLock<HashSet<String>> = LazyLock::new(|| {
+        load_revocation_list(
+            &Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/SingleStepTests/80386/revocation_list.txt"),
+        )
+    });
+    &REVOKED
+}
+
+/// Strips 66/67 operand and address size prefixes and any `.ext` ModR/M
+/// suffix, returning the bare opcode stem in uppercase.
+fn bare_opcode(stem: &str) -> String {
+    let mut opcode = stem;
+    loop {
+        if let Some(rest) = opcode.strip_prefix("66") {
+            opcode = rest;
+        } else if let Some(rest) = opcode.strip_prefix("67") {
+            opcode = rest;
+        } else {
+            break;
+        }
+    }
+    let opcode = opcode.split('.').next().unwrap_or(opcode);
+    opcode.to_ascii_uppercase()
+}
+
+fn is_smm_affected(stem: &str) -> bool {
+    let opcode = bare_opcode(stem);
+    SMM_AFFECTED_OPCODES.contains(&opcode.as_str())
+}
+
+fn initial_reg_value(initial_regs: &std::collections::HashMap<String, u32>, name: &str) -> u32 {
+    initial_regs
+        .get(name)
+        .copied()
+        .unwrap_or_else(|| panic!("missing register in initial state: {name}"))
+}
+
+fn build_initial_state(initial_regs: &std::collections::HashMap<String, u32>) -> I386State {
+    let mut s = I386State {
+        cr0: initial_reg_value(initial_regs, "cr0"),
+        cr3: initial_reg_value(initial_regs, "cr3"),
+        dr6: initial_reg_value(initial_regs, "dr6"),
+        dr7: initial_reg_value(initial_regs, "dr7"),
+        ..I386State::default()
+    };
+    s.set_eax(initial_reg_value(initial_regs, "eax"));
+    s.set_ebx(initial_reg_value(initial_regs, "ebx"));
+    s.set_ecx(initial_reg_value(initial_regs, "ecx"));
+    s.set_edx(initial_reg_value(initial_regs, "edx"));
+    s.set_esi(initial_reg_value(initial_regs, "esi"));
+    s.set_edi(initial_reg_value(initial_regs, "edi"));
+    s.set_ebp(initial_reg_value(initial_regs, "ebp"));
+    s.set_esp(initial_reg_value(initial_regs, "esp"));
+    s.set_cs(initial_reg_value(initial_regs, "cs") as u16);
+    s.set_ds(initial_reg_value(initial_regs, "ds") as u16);
+    s.set_es(initial_reg_value(initial_regs, "es") as u16);
+    s.set_fs(initial_reg_value(initial_regs, "fs") as u16);
+    s.set_gs(initial_reg_value(initial_regs, "gs") as u16);
+    s.set_ss(initial_reg_value(initial_regs, "ss") as u16);
+    s.set_eip(initial_reg_value(initial_regs, "eip"));
+    s.set_eflags(initial_reg_value(initial_regs, "eflags"));
+    s
+}
+
+#[derive(Default, Clone)]
+struct StemStats {
+    tests: u64,
+    expected: f64,
+    actual: u64,
+    /// Raw trace clocks (all cycle records), summed. The per-opcode table
+    /// derives instruction clocks from this by subtracting a self-calibrated
+    /// overhead (the capture/prefetch-fill clocks that are not the instruction).
+    trace_total: u64,
+    /// Emulated instruction clocks (every step except the terminating HALT),
+    /// summed. Compared against the overhead-adjusted trace total.
+    instr_actual: u64,
+}
+
+/// Accumulates the expected (trace) and actual (emulated) clock totals for one
+/// opcode stem into `stats`, skipping revoked and exception tests.
+fn accumulate_stem(stem: &str, bus: &mut TestBus, stats: &mut StemStats) {
+    let revoked = revocation_list();
+    let filename = format!("{stem}.MOO.gz");
+    let path = test_dir().join(&filename);
+    let test_cases = load_moo_tests(&path, &[], &REG_ORDER_386);
+
+    for test in &test_cases {
+        if let Some(hash) = &test.hash
+            && revoked.contains(&hash.to_ascii_lowercase())
+        {
+            continue;
+        }
+        if test.exception.is_some() {
+            continue;
+        }
+
+        let trace_clocks = test
+            .cycles
+            .iter()
+            .filter(|cycle| matches!(cycle, MooCycle::I386(_)))
+            .count() as u64;
+        if trace_clocks == 0 {
+            continue;
+        }
+        let expected = (trace_clocks as f64 - SMM_CAPTURE_OVERHEAD_CLOCKS).max(0.0);
+
+        bus.clear();
+        for &(address, value) in &test.initial.ram {
+            bus.set_memory(address, value);
+        }
+
+        let mut cpu: SxCpu = I386::new();
+        cpu.load_state(&build_initial_state(&test.initial.regs));
+
+        let mut actual = 0u64;
+        let mut instr_actual = 0u64;
+        let mut steps = 0usize;
+        while !cpu.halted() && steps < MAX_STEPS {
+            cpu.step(bus);
+            let consumed = cpu.cycles_consumed();
+            actual += consumed;
+            // Exclude the step that halted (the injected HALT): its cost is the
+            // emulator's HALT, not the instruction under test.
+            if !cpu.halted() {
+                instr_actual += consumed;
+            }
+            steps += 1;
+        }
+        if steps >= MAX_STEPS {
+            continue;
+        }
+
+        stats.tests += 1;
+        stats.expected += expected;
+        stats.actual += actual;
+        stats.trace_total += trace_clocks;
+        stats.instr_actual += instr_actual;
+    }
+}
+
+#[test]
+fn sx_aggregate_timing_within_tolerance() {
+    let mut entries: Vec<String> = fs::read_dir(test_dir())
+        .expect("test directory present")
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .filter_map(|name| name.strip_suffix(".MOO.gz").map(str::to_string))
+        .collect();
+    entries.sort();
+    assert!(!entries.is_empty(), "no MOO test files found");
+
+    let mut bus = TestBus::new();
+    let mut per_stem: Vec<(String, StemStats)> = Vec::new();
+
+    for stem in &entries {
+        if is_smm_affected(stem) {
+            continue;
+        }
+        let mut stats = StemStats::default();
+        accumulate_stem(stem, &mut bus, &mut stats);
+        if stats.tests > 0 {
+            per_stem.push((stem.clone(), stats));
+        }
+    }
+
+    let total_expected: f64 = per_stem.iter().map(|(_, stats)| stats.expected).sum();
+    let total_actual: u64 = per_stem.iter().map(|(_, stats)| stats.actual).sum();
+    let total_tests: u64 = per_stem.iter().map(|(_, stats)| stats.tests).sum();
+
+    let mut ranked = per_stem.clone();
+    ranked.sort_by(|a, b| {
+        let delta_a = (a.1.actual as f64 - a.1.expected).abs();
+        let delta_b = (b.1.actual as f64 - b.1.expected).abs();
+        delta_b.total_cmp(&delta_a)
+    });
+
+    println!("SX timing calibration report (worst 40 stems by absolute delta):");
+    println!(
+        "{:<12} {:>7} {:>12} {:>12} {:>12} {:>8} {:>10}",
+        "stem", "tests", "expected", "actual", "delta", "delta%", "avg/test"
+    );
+    for (stem, stats) in ranked.iter().take(40) {
+        let delta = stats.actual as f64 - stats.expected;
+        let delta_pct = if stats.expected > 0.0 {
+            delta / stats.expected * 100.0
+        } else {
+            0.0
+        };
+        let avg = delta / stats.tests as f64;
+        println!(
+            "{:<12} {:>7} {:>12.0} {:>12} {:>12.0} {:>7.2}% {:>10.3}",
+            stem, stats.tests, stats.expected, stats.actual, delta, delta_pct, avg
+        );
+    }
+
+    // Isolate instruction cost from the fixed per-test capture overhead. The
+    // aggregate ties emulated clocks (including the emulator's HALT) to
+    // trace_total - SMM_CAPTURE_OVERHEAD_CLOCKS, so the overhead that maps a
+    // trace total onto pure instruction clocks is that constant plus the mean
+    // emulated HALT-step cost. Self-calibrated from this run so the important
+    // table centers at zero, matching the aggregate.
+    let total_instr_actual: u64 = per_stem.iter().map(|(_, s)| s.instr_actual).sum();
+    let mean_halt = (total_actual - total_instr_actual) as f64 / total_tests as f64;
+    let overhead_instr = SMM_CAPTURE_OVERHEAD_CLOCKS + mean_halt;
+    let expected_instr =
+        |stats: &StemStats| stats.trace_total as f64 - stats.tests as f64 * overhead_instr;
+
+    let mut important: Vec<&(String, StemStats)> = per_stem
+        .iter()
+        .filter(|(stem, _)| IMPORTANT_OPCODES.contains(&bare_opcode(stem).as_str()))
+        .collect();
+    // A stem carries a trustworthy signal only when its instruction cost clears
+    // the overhead-variance floor; sort those to the top by relative error, and
+    // rank the rest (overhead-noise-limited) below by absolute per-test error.
+    let meaningful = |s: &StemStats| {
+        s.trace_total as f64 / s.tests as f64 - overhead_instr >= MIN_MEANINGFUL_CLOCKS_PER_TEST
+    };
+    important.sort_by(|a, b| {
+        let key = |s: &StemStats| {
+            let pct =
+                (s.instr_actual as f64 - expected_instr(s)) / expected_instr(s).max(1.0) * 100.0;
+            (meaningful(s), pct.abs())
+        };
+        key(&b.1).partial_cmp(&key(&a.1)).unwrap()
+    });
+    println!(
+        "\nImportant opcodes (instruction clocks, overhead {overhead_instr:.1}/test removed; \
+         '!' = >{IMPORTANT_OPCODE_BOUND_PERCENT:.0}% and >={MIN_MEANINGFUL_CLOCKS_PER_TEST:.0} clocks/test):"
+    );
+    println!(
+        "{:<12} {:>7} {:>12} {:>12} {:>12} {:>8} {:>10}",
+        "stem", "tests", "expected", "actual", "delta", "delta%", "avg/test"
+    );
+    for (stem, stats) in important {
+        let expected = expected_instr(stats);
+        let delta = stats.instr_actual as f64 - expected;
+        let delta_pct = if expected > 0.0 {
+            delta / expected * 100.0
+        } else {
+            0.0
+        };
+        let avg = delta / stats.tests as f64;
+        // Flag only stems whose instruction cost clears the overhead-variance
+        // floor and whose relative error still exceeds the bound.
+        let flag = if meaningful(stats) && delta_pct.abs() > IMPORTANT_OPCODE_BOUND_PERCENT {
+            " !"
+        } else {
+            ""
+        };
+        println!(
+            "{:<12} {:>7} {:>12.0} {:>12} {:>12.0} {:>7.2}% {:>10.3}{}",
+            stem, stats.tests, expected, stats.instr_actual, delta, delta_pct, avg, flag
+        );
+    }
+
+    let total_delta = total_actual as f64 - total_expected;
+    let total_pct = total_delta / total_expected * 100.0;
+    println!(
+        "TOTAL: {total_tests} tests, expected {total_expected:.0}, actual {total_actual}, \
+         delta {total_delta:.0} ({total_pct:.4}%)"
+    );
+
+    let relative = (total_actual as f64 - total_expected).abs() / total_expected;
+    assert!(
+        relative <= AGGREGATE_TOLERANCE,
+        "SX aggregate timing off by {:.4}% (tolerance {:.4}%): expected {total_expected:.0}, got {total_actual}. \
+         Tune SMM_CAPTURE_OVERHEAD_CLOCKS and the SX_EXTRA_CLOCKS_* constants in i386.rs.",
+        relative * 100.0,
+        AGGREGATE_TOLERANCE * 100.0,
+    );
+}

--- a/crates/cpu/tests/x87_i386.rs
+++ b/crates/cpu/tests/x87_i386.rs
@@ -1,5 +1,5 @@
 use common::Bus as _;
-use cpu::{CPU_MODEL_486, I386, I386State};
+use cpu::{CPU_MODEL_486_DX, I386, I386State};
 use softfloat::{Fp80, FpClass};
 
 const RAM_SIZE: usize = 1024 * 1024;
@@ -160,7 +160,7 @@ fn build_state(stack: &[Fp80], cw: u16) -> I386State {
     state
 }
 
-fn extract_result(cpu: &I386<{ CPU_MODEL_486 }>) -> X87Result {
+fn extract_result(cpu: &I386<{ CPU_MODEL_486_DX }>) -> X87Result {
     let fpu = &cpu.state.fpu;
     X87Result {
         registers: fpu.registers,
@@ -175,7 +175,7 @@ fn run_x87(code: &[u8], stack: &[Fp80]) -> X87Result {
 }
 
 fn run_x87_with_cw(code: &[u8], stack: &[Fp80], cw: u16) -> X87Result {
-    let mut cpu = I386::<{ CPU_MODEL_486 }>::new();
+    let mut cpu = I386::<{ CPU_MODEL_486_DX }>::new();
     let mut bus = TestBus::new();
     place_code(&mut bus, 0x1000, 0x0000, code);
     let state = build_state(stack, cw);
@@ -185,7 +185,7 @@ fn run_x87_with_cw(code: &[u8], stack: &[Fp80], cw: u16) -> X87Result {
 }
 
 fn run_x87_mem(code: &[u8], stack: &[Fp80], cw: u16, mem: &[u8]) -> (X87Result, TestBus) {
-    let mut cpu = I386::<{ CPU_MODEL_486 }>::new();
+    let mut cpu = I386::<{ CPU_MODEL_486_DX }>::new();
     let mut bus = TestBus::new();
     place_code(&mut bus, 0x1000, 0x0000, code);
 

--- a/crates/device/src/i8255_system_ppi.rs
+++ b/crates/device/src/i8255_system_ppi.rs
@@ -166,7 +166,7 @@ pub struct I8255SystemPpiState {
     /// DIP switch 2 register (read-only via port 0x31).
     ///
     /// Bit mapping is `SW2:8..SW2:1` (bit7..bit0), where `1=OFF`, `0=ON`.
-    /// Default `0xF3` (`1111_0011b`) for VM/VX/RA:
+    /// Default `0xF3` (`1111_0011b`) for all models:
     /// - SW2-1 (bit0)=1 OFF: normal boot path
     /// - SW2-2 (bit1)=1 OFF: terminal mode disabled
     /// - SW2-3 (bit2)=0 ON: 80 chars/line

--- a/crates/dos/tests/dos620/harness.rs
+++ b/crates/dos/tests/dos620/harness.rs
@@ -127,7 +127,7 @@ fn create_ra_machine(xms_32_enabled: bool) -> machine::Pc9801Ra {
 
 fn create_hle_machine_ap() -> machine::Pc9821Ap {
     let mut machine = machine::Pc9821Ap::new(
-        cpu::I386::<{ cpu::CPU_MODEL_486 }>::new(),
+        cpu::I386::<{ cpu::CPU_MODEL_486_DX }>::new(),
         machine::Pc9801Bus::new(MachineModel::PC9821AP, CpuMode::High, 48000),
     );
     initialize_hle_bus(&mut machine.bus, false);

--- a/crates/machine/src/bus.rs
+++ b/crates/machine/src/bus.rs
@@ -550,6 +550,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F
             | MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA => {
                 self.sasi.insert_drive(drive, image, path);
             }
@@ -584,6 +585,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F
             | MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA => {
                 self.sasi.flush_drive(drive);
             }
@@ -599,6 +601,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F
             | MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA => {
                 self.sasi.flush_all_drives();
             }

--- a/crates/machine/src/bus/bios/keyboard.rs
+++ b/crates/machine/src/bus/bios/keyboard.rs
@@ -144,6 +144,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F => KEYBOARD_ROM_OFFSET_F as u16,
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => KEYBOARD_ROM_OFFSET_VM as u16,
@@ -249,6 +250,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F => KEYBOARD_ROM_OFFSET_F as u16,
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => KEYBOARD_ROM_OFFSET_VM as u16,

--- a/crates/machine/src/bus/init.rs
+++ b/crates/machine/src/bus/init.rs
@@ -240,7 +240,10 @@ impl<T: Tracing> Pc9801Bus<T> {
                 MachineModel::PC9801F | MachineModel::PC9801VM | MachineModel::PC9801VX => {
                     DMA_ACCESS_CTRL_20BIT
                 }
-                MachineModel::PC9801RA | MachineModel::PC9821AS | MachineModel::PC9821AP => 0x00,
+                MachineModel::PC9801RS
+                | MachineModel::PC9801RA
+                | MachineModel::PC9821AS
+                | MachineModel::PC9821AP => 0x00,
             },
             vram_ems_bank: 0x00,
             ram_window: 0x08,
@@ -281,6 +284,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         match machine_model {
             MachineModel::PC9801F | MachineModel::PC9801VM => {}
             MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => bus.set_cg_ram(true),
@@ -299,6 +303,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F => false,
             MachineModel::PC9801VM => true,
             MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => false,
@@ -361,6 +366,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F => 0x20,
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => 0x03,
@@ -375,9 +381,10 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F => 0xA0 | (msw3 & 0x07),
             MachineModel::PC9801VM => 0x60 | (msw3 & 0x07),
             MachineModel::PC9801VX => 0x20 | (msw3 & 0x07),
-            MachineModel::PC9801RA | MachineModel::PC9821AS | MachineModel::PC9821AP => {
-                0xA0 | (msw3 & 0x07)
-            }
+            MachineModel::PC9801RS
+            | MachineModel::PC9801RA
+            | MachineModel::PC9821AS
+            | MachineModel::PC9821AP => 0xA0 | (msw3 & 0x07),
         };
         self.memory.state.ram[0x0501] = bios_flag1;
 
@@ -405,6 +412,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 MachineModel::PC9801F
                 | MachineModel::PC9801VM
                 | MachineModel::PC9801VX
+                | MachineModel::PC9801RS
                 | MachineModel::PC9801RA => 0x00,
                 MachineModel::PC9821AS | MachineModel::PC9821AP => 0x80,
             };
@@ -442,6 +450,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F => 0x00,
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => 0xFF,
@@ -452,6 +461,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F => 0x00,
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => 0xFF,
@@ -479,7 +489,10 @@ impl<T: Tracing> Pc9801Bus<T> {
                     0xFD,
                 ]);
             }
-            MachineModel::PC9801RA | MachineModel::PC9821AS | MachineModel::PC9821AP => {
+            MachineModel::PC9801RS
+            | MachineModel::PC9801RA
+            | MachineModel::PC9821AS
+            | MachineModel::PC9821AP => {
                 let (f2hd_off, f2dd_off): (u16, u16) = (0x1AAF, 0x1AD7);
                 self.memory.state.ram[0x05CC..0x05D0].copy_from_slice(&[
                     f2dd_off as u8,
@@ -513,6 +526,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         match self.machine_model {
             MachineModel::PC9801F | MachineModel::PC9801VM => {}
             MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => {
@@ -529,6 +543,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F => 0x00,
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => 0x03,
@@ -539,6 +554,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F => KEYBOARD_ROM_OFFSET_F,
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => KEYBOARD_ROM_OFFSET_VM,
@@ -576,6 +592,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F => KEYBOARD_ROM_OFFSET_F,
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => KEYBOARD_ROM_OFFSET_VM,
@@ -599,6 +616,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F => 0xFD,
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => 0xF7,
@@ -610,7 +628,10 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F | MachineModel::PC9801VM => {
                 self.pic.state.chips[1].ocw3 = 0x0B;
             }
-            MachineModel::PC9801RA | MachineModel::PC9821AS | MachineModel::PC9821AP => {
+            MachineModel::PC9801RS
+            | MachineModel::PC9801RA
+            | MachineModel::PC9821AS
+            | MachineModel::PC9821AP => {
                 self.pic.state.chips[0].ocw3 = 0x0B;
             }
             MachineModel::PC9801VX => {}
@@ -641,6 +662,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             }
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => {
@@ -664,6 +686,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         self.system_ppi.state.port_c = match self.machine_model {
             MachineModel::PC9801F | MachineModel::PC9801VM => 0x18,
             MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => 0xB8,
@@ -695,6 +718,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         self.gdc_master.state.draw_on_retrace = true;
         match self.machine_model {
             MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => {
@@ -733,6 +757,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         self.gdc_slave.state.mask = match self.machine_model {
             MachineModel::PC9801F | MachineModel::PC9801VM => 0,
             MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => 1,
@@ -744,6 +769,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             }
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => {}
@@ -753,6 +779,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 self.gdc_slave.state.display_mode = DISPLAY_MODE_GRAPHICS;
             }
             MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => {}
@@ -765,6 +792,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801VX => 23,
             MachineModel::PC9801F
             | MachineModel::PC9801VM
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => 1,
@@ -775,6 +803,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         let (dim, half_bright) = match self.machine_model {
             MachineModel::PC9801F | MachineModel::PC9801VM => (0x0Au8, [7u8, 7, 7]),
             MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => (0x07u8, [4u8, 4, 4]),
@@ -797,6 +826,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         self.palette.state.index = match self.machine_model {
             MachineModel::PC9801F | MachineModel::PC9801VM => 0x08,
             MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => 0x0F,
@@ -810,6 +840,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 self.grcg.state.mode = 0x0F;
             }
             MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => {
@@ -823,6 +854,7 @@ impl<T: Tracing> Pc9801Bus<T> {
             MachineModel::PC9801F => 0x5F56,
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => 0x7F57,
@@ -839,6 +871,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 self.printer.state.port_c = 0x80;
             }
             MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => {}
@@ -877,6 +910,7 @@ impl<T: Tracing> Pc9801Bus<T> {
         self.mouse_ppi.state.port_c = match self.machine_model {
             MachineModel::PC9801F | MachineModel::PC9801VM => 0xF0,
             MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => 0x00,
@@ -933,10 +967,13 @@ impl<T: Tracing> Pc9801Bus<T> {
         self.apply_gdc_dot_clock();
         self.reschedule_gdc_events();
 
-        // RA-specific registers.
+        // Registers of the 386/486 machines (RS and later).
         match self.machine_model {
             MachineModel::PC9801F | MachineModel::PC9801VM | MachineModel::PC9801VX => {}
-            MachineModel::PC9801RA | MachineModel::PC9821AS | MachineModel::PC9821AP => {
+            MachineModel::PC9801RS
+            | MachineModel::PC9801RA
+            | MachineModel::PC9821AS
+            | MachineModel::PC9821AP => {
                 self.vram_ems_bank = 0x20;
                 self.protected_memory_max = 0xE0;
                 self.memory.copy_rom_to_shadow_ram();

--- a/crates/machine/src/bus/io_read.rs
+++ b/crates/machine/src/bus/io_read.rs
@@ -522,7 +522,7 @@ impl<T: Tracing> Pc9801Bus<T> {
                 0xFF
             }
 
-            // Protected memory registration readback (VX/RA only).
+            // Protected memory registration readback (VX and later only).
             0x0567 => {
                 if self.machine_model.has_protected_memory_register() {
                     self.protected_memory_max

--- a/crates/machine/src/lib.rs
+++ b/crates/machine/src/lib.rs
@@ -25,7 +25,7 @@ use device::{
     soundboard_26k::Soundboard26kState, soundboard_86::Soundboard86State,
     upd765a_fdc::Upd765aFdcState, upd7220_gdc::GdcState, upd52611_crtc::Upd52611CrtcState,
 };
-pub use machine::{Machine, Pc9801F, Pc9801Ra, Pc9801Vm, Pc9801Vx, Pc9821Ap, Pc9821As};
+pub use machine::{Machine, Pc9801F, Pc9801Ra, Pc9801Rs, Pc9801Vm, Pc9801Vx, Pc9821Ap, Pc9821As};
 
 pub use crate::{
     bus::{BootDevice, Pc9801Bus},

--- a/crates/machine/src/machine.rs
+++ b/crates/machine/src/machine.rs
@@ -138,14 +138,17 @@ pub type Pc9801Vm = Machine<cpu::VX0>;
 /// PC-9801VX machine type (80286 CPU at 8 / 10 MHz).
 pub type Pc9801Vx = Machine<cpu::I286>;
 
-/// PC-9801RA machine type (80386 SX CPU at 16 / 20 MHz).
+/// PC-9801RS machine type (80386SX CPU at 16 MHz).
+pub type Pc9801Rs = Machine<cpu::I386<{ cpu::CPU_MODEL_386_SX }>>;
+
+/// PC-9801RA machine type (80386DX CPU at 20 MHz).
 pub type Pc9801Ra = Machine<cpu::I386>;
 
 /// PC-9821AS machine type (486DX CPU at 33 MHz, IDE, PEGC).
-pub type Pc9821As = Machine<cpu::I386<{ cpu::CPU_MODEL_486 }>>;
+pub type Pc9821As = Machine<cpu::I386<{ cpu::CPU_MODEL_486_DX }>>;
 
 /// PC-9821AP machine type (486DX2 CPU at 66 MHz, IDE, PEGC).
-pub type Pc9821Ap = Machine<cpu::I386<{ cpu::CPU_MODEL_486 }>>;
+pub type Pc9821Ap = Machine<cpu::I386<{ cpu::CPU_MODEL_486_DX }>>;
 
 impl<T: Tracing> Machine<cpu::I8086, T> {
     /// Captures the full machine state.
@@ -242,6 +245,7 @@ fn validate_hdd_for_model(
         common::MachineModel::PC9801F
         | common::MachineModel::PC9801VM
         | common::MachineModel::PC9801VX
+        | common::MachineModel::PC9801RS
         | common::MachineModel::PC9801RA => {
             if geometry.sasi_media_type().is_none() {
                 return Err(format!(

--- a/crates/machine/src/memory.rs
+++ b/crates/machine/src/memory.rs
@@ -374,6 +374,7 @@ impl Pc9801Memory {
             MachineModel::PC9801F => NEC_COPYRIGHT_OFFSET_F,
             MachineModel::PC9801VM
             | MachineModel::PC9801VX
+            | MachineModel::PC9801RS
             | MachineModel::PC9801RA
             | MachineModel::PC9821AS
             | MachineModel::PC9821AP => NEC_COPYRIGHT_OFFSET_VM,
@@ -484,9 +485,10 @@ impl Pc9801Memory {
 
         let (f2hd_ind, f2hd_data, f2dd_ind, f2dd_data): (usize, usize, usize, usize) =
             match machine_model {
-                MachineModel::PC9801RA | MachineModel::PC9821AS | MachineModel::PC9821AP => {
-                    (0x1AAF, 0x1AB7, 0x1AD7, 0x1ADF)
-                }
+                MachineModel::PC9801RS
+                | MachineModel::PC9801RA
+                | MachineModel::PC9821AS
+                | MachineModel::PC9821AP => (0x1AAF, 0x1AB7, 0x1AD7, 0x1ADF),
                 MachineModel::PC9801VM | MachineModel::PC9801VX => (0x1AB4, 0x1ABC, 0x1ADC, 0x1AE4),
                 MachineModel::PC9801F => unreachable!(),
             };

--- a/crates/machine/src/rom.rs
+++ b/crates/machine/src/rom.rs
@@ -108,8 +108,8 @@ const VX_YLL04: Chip = Chip {
     size: KIB_32,
 };
 
-// PC-9801RS IPL images (MAME set `pc9801rs`; used for the PC-9801RA, which has
-// no dedicated MAME dump). These are already merged bank images.
+// PC-9801RS IPL images (MAME set `pc9801rs`). This set serves both the
+// PC-9801RS and the PC-9801RA. These are already merged bank images.
 const RS_ITF: Chip = Chip {
     digest: "c1881b44dc07a7f20ceff00a24fe4467a933fd2c94e64213c9a8526d60e4d3d1",
     size: KIB_32,
@@ -189,7 +189,7 @@ pub fn required_mame_set(model: MachineModel) -> Option<&'static str> {
         MachineModel::PC9801F => Some("pc9801f"),
         MachineModel::PC9801VM => Some("pc9801vm"),
         MachineModel::PC9801VX => Some("pc9801vx"),
-        MachineModel::PC9801RA => Some("pc9801rs"),
+        MachineModel::PC9801RS | MachineModel::PC9801RA => Some("pc9801rs"),
         MachineModel::PC9821AS | MachineModel::PC9821AP => None,
     }
 }
@@ -210,7 +210,9 @@ fn bios_chips(model: MachineModel) -> Option<(&'static [&'static Chip], &'static
             &[&VX_YLL01, &VX_YLL02, &VX_YLL03, &VX_YLL04],
             ASSEMBLED_BIOS_VX,
         )),
-        MachineModel::PC9801RA => Some((&[&RS_ITF, &RS_BIOS], ASSEMBLED_BIOS_RA)),
+        MachineModel::PC9801RS | MachineModel::PC9801RA => {
+            Some((&[&RS_ITF, &RS_BIOS], ASSEMBLED_BIOS_RA))
+        }
         MachineModel::PC9821AS | MachineModel::PC9821AP => None,
     }
 }
@@ -223,6 +225,7 @@ fn font_digests(model: MachineModel) -> &'static [&'static str] {
         MachineModel::PC9801F
         | MachineModel::PC9801VM
         | MachineModel::PC9801VX
+        | MachineModel::PC9801RS
         | MachineModel::PC9801RA => FONT_STANDARD,
         MachineModel::PC9821AS => FONT_9821AS,
         MachineModel::PC9821AP => FONT_9821AP,
@@ -332,7 +335,7 @@ fn assemble_bios(model: MachineModel, by_digest: &HashMap<String, Vec<u8>>) -> O
             image[0x28000..0x30000].copy_from_slice(&biosrom[0x10000..0x18000]);
             Some(image)
         }
-        MachineModel::PC9801RA => {
+        MachineModel::PC9801RS | MachineModel::PC9801RA => {
             let itf = chip(by_digest, &RS_ITF)?;
             let bios = chip(by_digest, &RS_BIOS)?;
             let mut image = vec![0xFFu8; BIOS_ROM_SIZE];
@@ -394,6 +397,7 @@ mod tests {
         assert_eq!(required_mame_set(MachineModel::PC9801F), Some("pc9801f"));
         assert_eq!(required_mame_set(MachineModel::PC9801VM), Some("pc9801vm"));
         assert_eq!(required_mame_set(MachineModel::PC9801VX), Some("pc9801vx"));
+        assert_eq!(required_mame_set(MachineModel::PC9801RS), Some("pc9801rs"));
         assert_eq!(required_mame_set(MachineModel::PC9801RA), Some("pc9801rs"));
         assert_eq!(required_mame_set(MachineModel::PC9821AS), None);
         assert_eq!(required_mame_set(MachineModel::PC9821AP), None);
@@ -404,6 +408,7 @@ mod tests {
         assert_eq!(accepted_bios_digests(MachineModel::PC9801F).len(), 6);
         assert_eq!(accepted_bios_digests(MachineModel::PC9801VM).len(), 4);
         assert_eq!(accepted_bios_digests(MachineModel::PC9801VX).len(), 4);
+        assert_eq!(accepted_bios_digests(MachineModel::PC9801RS).len(), 2);
         assert_eq!(accepted_bios_digests(MachineModel::PC9801RA).len(), 2);
         assert!(accepted_bios_digests(MachineModel::PC9821AS).is_empty());
     }

--- a/crates/machine/tests/bios.rs
+++ b/crates/machine/tests/bios.rs
@@ -338,7 +338,7 @@ fn create_machine_ra() -> Pc9801Ra {
 
 fn create_machine_pc9821as() -> Pc9821As {
     let mut machine = Pc9821As::new(
-        cpu::I386::<{ cpu::CPU_MODEL_486 }>::new(),
+        cpu::I386::<{ cpu::CPU_MODEL_486_DX }>::new(),
         machine::Pc9801Bus::new(MachineModel::PC9821AS, CpuMode::High, 48000),
     );
     // TODO: We haven't verified our implementation yet against a real 9821 BIOS.

--- a/crates/machine/tests/bios/int18h.rs
+++ b/crates/machine/tests/bios/int18h.rs
@@ -4270,7 +4270,7 @@ fn display_area_set_resets_scroll_ra() {
 
 /// AH=42h must NOT load new GDC slave sync parameters unless PRXDUPD has the
 /// right bit pattern ((prxdupd & 0x24) == 0x24 for 200-line, or 0x20 for 400-line).
-/// After a fresh boot PRXDUPD is 0x00 (VM) / 0x50 (VX/RA), so neither condition
+/// After a fresh boot PRXDUPD is 0x00 (VM) / 0x50 (VX and later), so neither condition
 /// is met and the slave GDC pitch, AW, AL, and timing must remain unchanged.
 #[test]
 fn display_area_set_preserves_slave_sync_f() {
@@ -4293,7 +4293,7 @@ fn display_area_set_preserves_slave_sync_f() {
 
 /// AH=42h must NOT load new GDC slave sync parameters unless PRXDUPD has the
 /// right bit pattern ((prxdupd & 0x24) == 0x24 for 200-line, or 0x20 for 400-line).
-/// After a fresh boot PRXDUPD is 0x00 (VM) / 0x50 (VX/RA), so neither condition
+/// After a fresh boot PRXDUPD is 0x00 (VM) / 0x50 (VX and later), so neither condition
 /// is met and the slave GDC pitch, AW, AL, and timing must remain unchanged.
 #[test]
 fn display_area_set_preserves_slave_sync_vm() {

--- a/crates/machine/tests/bios/int1bh.rs
+++ b/crates/machine/tests/bios/int1bh.rs
@@ -2675,7 +2675,7 @@ fn int1bh_sasi_format_ra() {
 // §12.4 INT 1Bh - 2DD Device Type Dispatch
 // ============================================================================
 
-// 2DD (DA=0x70) is not supported on VM/VX/RA - returns error 0x40.
+// 2DD (DA=0x70) is not supported on VM/VX/RS/RA - returns error 0x40.
 
 const DA_FDD_640KB_DRIVE0: u8 = 0x70;
 

--- a/crates/machine/tests/bios/int1fh.rs
+++ b/crates/machine/tests/bios/int1fh.rs
@@ -368,7 +368,7 @@ fn int1fh_memcpy_with_offsets_ra() {
     }
 }
 
-/// §14.1 AH=0x90 - BIOS Ignores Descriptor Limits (VX/RA only)
+/// §14.1 AH=0x90 - BIOS Ignores Descriptor Limits (VX and later only)
 ///
 /// The real BIOS does NOT validate SI/DI against the descriptor limit fields.
 /// NP21W adds this validation, but the original ROM performs the copy regardless.

--- a/crates/machine/tests/bus.rs
+++ b/crates/machine/tests/bus.rs
@@ -78,7 +78,8 @@ fn bus_clock_config_uses_cpu_mode_without_changing_pit_lineage() {
         (MachineModel::PC9801F, 5_000_000, 8_000_000, 1_996_800),
         (MachineModel::PC9801VM, 8_000_000, 10_000_000, 2_457_600),
         (MachineModel::PC9801VX, 8_000_000, 10_000_000, 2_457_600),
-        (MachineModel::PC9801RA, 16_000_000, 20_000_000, 1_996_800),
+        (MachineModel::PC9801RS, 16_000_000, 16_000_000, 1_996_800),
+        (MachineModel::PC9801RA, 20_000_000, 20_000_000, 1_996_800),
         (MachineModel::PC9821AS, 33_000_000, 33_000_000, 1_996_800),
         (MachineModel::PC9821AP, 66_000_000, 66_000_000, 1_996_800),
     ];

--- a/crates/machinetowns/src/bus.rs
+++ b/crates/machinetowns/src/bus.rs
@@ -108,6 +108,11 @@ const SLOW_MODE_MEMORY_WAITS: u8 = 6;
 /// The FASTMODE lamp reads lit while the VRAM wait stays below this value.
 const FAST_MODE_LAMP_VRAM_WAIT_LIMIT: u8 = 3;
 
+/// Baseline wait-state cycles charged on every video-memory access on top of the
+/// programmed VRAM wait latch, modeling VRAM being inherently slower than RAM.
+/// Experimental tuning knob.
+const VRAM_BASELINE_WAIT_CYCLES: i64 = 2;
+
 /// Vertical-sync pulse duration in microseconds (measured ~60 us on a real MX).
 const VSYNC_DURATION_MICROS: u64 = 60;
 
@@ -166,11 +171,15 @@ pub struct TownsBus<T: Tracing = NoTracing> {
     /// Electronic-volume attenuators (I/O 0x04E0-0x04E3); the second chip's
     /// channels 0/1 set the CD-DA left/right level.
     pub(crate) elevol: [ElectronicVolume; 2],
-    /// Main-RAM wait latch (I/O 0x05E0 first-generation alias / 0x05E2); stored
-    /// and read back only, the slow-mode clock change is not modeled.
+    /// Main-RAM wait latch (I/O 0x05E0 first-generation alias / 0x05E2). Charged
+    /// as wait-state cycles on every non-video memory access (RAM, ROM, CMOS).
     pub(crate) main_ram_wait: u8,
-    /// VRAM wait latch (I/O 0x05E6); stored and read back only.
+    /// VRAM wait latch (I/O 0x05E6). Charged as wait-state cycles on every video
+    /// memory access (native VRAM, sprite RAM, and the mapped FMR VRAM window).
     pub(crate) vram_wait: u8,
+    /// Memory wait-state cycles accumulated since the last drain. The CPU pulls
+    /// these through [`Bus::drain_wait_cycles`] after each instruction.
+    pub(crate) pending_wait_cycles: i64,
     pub(crate) gameport: TownsGamePort,
     pub(crate) video: TownsVideo,
     pub(crate) sprite: TownsSprite,
@@ -261,6 +270,7 @@ impl<T: Tracing + Default> TownsBus<T> {
             elevol: [ElectronicVolume::new(), ElectronicVolume::new()],
             main_ram_wait: 0,
             vram_wait: 0,
+            pending_wait_cycles: 0,
             gameport: TownsGamePort::new(clocks.cpu_clock_hz),
             video: TownsVideo::new(model.high_res_available()),
             sprite: TownsSprite::new(clocks.cpu_clock_hz),
@@ -1095,10 +1105,23 @@ impl<T: Tracing> TownsBus<T> {
     fn vsync_duration_cycles(&self) -> u64 {
         (u64::from(self.clocks.cpu_clock_hz) * VSYNC_DURATION_MICROS / MICROS_PER_SECOND).max(1)
     }
-}
 
-impl<T: Tracing> Bus for TownsBus<T> {
-    fn read_byte(&mut self, address: u32) -> u8 {
+    /// Charges one memory access at `address` its programmed wait-state cycles:
+    /// the VRAM wait latch for video memory, the main-RAM wait latch otherwise.
+    /// Called once per access regardless of width, matching a single bus cycle
+    /// on the 32-bit data bus; the 386SX 16-bit split penalty is charged by the
+    /// CPU core.
+    fn charge_memory_wait(&mut self, address: u32) {
+        if self.memory.is_video_memory(address) {
+            self.pending_wait_cycles += VRAM_BASELINE_WAIT_CYCLES + i64::from(self.vram_wait);
+        } else {
+            self.pending_wait_cycles += i64::from(self.main_ram_wait);
+        }
+    }
+
+    /// Reads a byte through the memory-mapped windows (RF5C68 wave RAM, FMR
+    /// buzzer control) and the physical memory map, without charging waits.
+    fn read_byte_data(&mut self, address: u32) -> u8 {
         if (RF5C68_WAVE_WINDOW_BASE..RF5C68_WAVE_WINDOW_END).contains(&address) {
             return self
                 .pcm
@@ -1111,7 +1134,9 @@ impl<T: Tracing> Bus for TownsBus<T> {
         self.memory.read_byte(address)
     }
 
-    fn write_byte(&mut self, address: u32, value: u8) {
+    /// Writes a byte through the memory-mapped windows and the physical memory
+    /// map, without charging waits.
+    fn write_byte_data(&mut self, address: u32, value: u8) {
         if (RF5C68_WAVE_WINDOW_BASE..RF5C68_WAVE_WINDOW_END).contains(&address) {
             self.pcm
                 .write_wave_ram((address - RF5C68_WAVE_WINDOW_BASE) as u16, value);
@@ -1122,6 +1147,50 @@ impl<T: Tracing> Bus for TownsBus<T> {
             self.refresh_beeper_gate();
         }
         self.memory.write_byte(address, value);
+    }
+}
+
+impl<T: Tracing> Bus for TownsBus<T> {
+    fn read_byte(&mut self, address: u32) -> u8 {
+        self.charge_memory_wait(address);
+        self.read_byte_data(address)
+    }
+
+    fn write_byte(&mut self, address: u32, value: u8) {
+        self.charge_memory_wait(address);
+        self.write_byte_data(address, value);
+    }
+
+    fn read_word(&mut self, address: u32) -> u16 {
+        self.charge_memory_wait(address);
+        u16::from(self.read_byte_data(address))
+            | (u16::from(self.read_byte_data(address.wrapping_add(1))) << 8)
+    }
+
+    fn write_word(&mut self, address: u32, value: u16) {
+        self.charge_memory_wait(address);
+        self.write_byte_data(address, value as u8);
+        self.write_byte_data(address.wrapping_add(1), (value >> 8) as u8);
+    }
+
+    fn read_dword(&mut self, address: u32) -> u32 {
+        self.charge_memory_wait(address);
+        u32::from(self.read_byte_data(address))
+            | (u32::from(self.read_byte_data(address.wrapping_add(1))) << 8)
+            | (u32::from(self.read_byte_data(address.wrapping_add(2))) << 16)
+            | (u32::from(self.read_byte_data(address.wrapping_add(3))) << 24)
+    }
+
+    fn write_dword(&mut self, address: u32, value: u32) {
+        self.charge_memory_wait(address);
+        self.write_byte_data(address, value as u8);
+        self.write_byte_data(address.wrapping_add(1), (value >> 8) as u8);
+        self.write_byte_data(address.wrapping_add(2), (value >> 16) as u8);
+        self.write_byte_data(address.wrapping_add(3), (value >> 24) as u8);
+    }
+
+    fn drain_wait_cycles(&mut self) -> i64 {
+        core::mem::take(&mut self.pending_wait_cycles)
     }
 
     fn io_read_byte(&mut self, port: u16) -> u8 {

--- a/crates/machinetowns/src/bus/io_read.rs
+++ b/crates/machinetowns/src/bus/io_read.rs
@@ -33,9 +33,9 @@ impl<T: Tracing> TownsBus<T> {
             }
             0x0022 => 0x00,
             // CPU misc register: the 2_UG and later models report 0x07 here; the
-            // CX and MX predate it and read back 0xFF.
+            // base, CX and MX models predate it and read back 0xFF.
             0x0024 => match self.model {
-                TownsModel::FmTownsIICx | TownsModel::FmTownsIIMx => 0xFF,
+                TownsModel::FmTowns | TownsModel::FmTownsIICx | TownsModel::FmTownsIIMx => 0xFF,
             },
             // Free-running microsecond counter.
             0x0026 => self.free_run_counter() as u8,

--- a/crates/machinetowns/src/config.rs
+++ b/crates/machinetowns/src/config.rs
@@ -3,6 +3,10 @@
 /// FM Towns machine model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TownsModel {
+    /// Base FM Towns (model 1/2 class): 16 MHz, 1x CD-ROM. Wired to the 386SX
+    /// CPU model so titles tuned for the base Towns / Marty run at their
+    /// intended speed.
+    FmTowns,
     /// FM Towns II CX: i386DX at 16 MHz (20 MHz in high mode), 1x CD-ROM.
     FmTownsIICx,
     /// FM Towns II MX: i486DX2 at 66 MHz (33 MHz in low mode), 2x CD-ROM.
@@ -27,11 +31,17 @@ pub enum TownsBootDevice {
 }
 
 impl TownsModel {
-    /// Main CPU clock in Hz for the selected CPU mode. The CX pair matches the
-    /// real 386DX lineup (CX at 16 MHz, HG at 20 MHz); the MX pair matches the
-    /// 486 lineup (MA-class 33 MHz, MX 66 MHz).
+    /// Main CPU clock in Hz for the selected CPU mode. The base model runs at
+    /// a fixed 16 MHz in both modes. The CX pair matches the real 386DX lineup
+    /// (CX at 16 MHz, HG at 20 MHz); the MX pair matches the 486 lineup
+    /// (MA-class 33 MHz, MX 66 MHz).
     pub const fn cpu_clock_hz(self, mode: common::CpuMode) -> u32 {
         match self {
+            // The base machines have no clock switch; both modes run at 16 MHz.
+            TownsModel::FmTowns => match mode {
+                common::CpuMode::Low => 16_000_000,
+                common::CpuMode::High => 16_000_000,
+            },
             TownsModel::FmTownsIICx => match mode {
                 common::CpuMode::Low => 16_000_000,
                 common::CpuMode::High => 20_000_000,
@@ -45,8 +55,9 @@ impl TownsModel {
 
     /// Extended RAM size in bytes (main RAM below 1 MiB is separate).
     pub const fn extended_ram_size(self) -> usize {
-        // Defaults the MX to 8 MiB total; 1 MiB is the low map, the
-        // rest is the extended region from 0x00100000.
+        // Defaults every model to 8 MiB total; 1 MiB is the low map, the
+        // rest is the extended region from 0x00100000. The real base model
+        // 1/2 shipped 1-2 MiB, but the larger map is compatibility-safe.
         0x0070_0000
     }
 
@@ -54,6 +65,8 @@ impl TownsModel {
     /// (high). The low byte encodes the CPU class, the high byte the model.
     pub const fn machine_id(self) -> (u8, u8) {
         match self {
+            // i386 class (0x01), base model 1/2 (0x01).
+            TownsModel::FmTowns => (0x01, 0x01),
             // i386DX class (0x01), model CX (0x05).
             TownsModel::FmTownsIICx => (0x01, 0x05),
             // i486DX class (0x02), model MX (0x0C).
@@ -65,6 +78,7 @@ impl TownsModel {
     /// mode (1 for the CX's 1x drive, 2 for the MX's 2x drive).
     pub const fn cd_drive_speed(self) -> u32 {
         match self {
+            TownsModel::FmTowns => 1,
             TownsModel::FmTownsIICx => 1,
             TownsModel::FmTownsIIMx => 2,
         }
@@ -75,6 +89,7 @@ impl TownsModel {
     /// present. Only the MX-class machines carry it.
     pub const fn high_res_available(self) -> bool {
         match self {
+            TownsModel::FmTowns => false,
             TownsModel::FmTownsIICx => false,
             TownsModel::FmTownsIIMx => true,
         }
@@ -84,6 +99,7 @@ impl TownsModel {
 impl std::fmt::Display for TownsModel {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            TownsModel::FmTowns => formatter.write_str("fmtowns"),
             TownsModel::FmTownsIICx => formatter.write_str("fmtownsiicx"),
             TownsModel::FmTownsIIMx => formatter.write_str("fmtownsiimx"),
         }
@@ -95,10 +111,11 @@ impl std::str::FromStr for TownsModel {
 
     fn from_str(text: &str) -> Result<Self, Self::Err> {
         match text.to_ascii_lowercase().as_str() {
+            "fmtowns" | "towns" | "townsbase" | "base" => Ok(TownsModel::FmTowns),
             "fmtownsiicx" | "townscx" | "townsiicx" | "cx" => Ok(TownsModel::FmTownsIICx),
             "fmtownsiimx" | "townsmx" | "townsiimx" | "mx" => Ok(TownsModel::FmTownsIIMx),
             _ => Err(format!(
-                "unknown FM Towns model '{text}', expected fmtownsiicx or fmtownsiimx"
+                "unknown FM Towns model '{text}', expected fmtowns, fmtownsiicx or fmtownsiimx"
             )),
         }
     }
@@ -165,6 +182,31 @@ mod tests {
         );
         assert_eq!("CX".parse::<TownsModel>(), Ok(TownsModel::FmTownsIICx));
         assert_eq!(TownsModel::FmTownsIICx.to_string(), "fmtownsiicx");
+    }
+
+    #[test]
+    fn base_model_string_round_trips() {
+        assert_eq!("fmtowns".parse::<TownsModel>(), Ok(TownsModel::FmTowns));
+        assert_eq!("towns".parse::<TownsModel>(), Ok(TownsModel::FmTowns));
+        assert_eq!("base".parse::<TownsModel>(), Ok(TownsModel::FmTowns));
+        assert_eq!(TownsModel::FmTowns.to_string(), "fmtowns");
+    }
+
+    #[test]
+    fn base_machine_id_matches_hardware() {
+        assert_eq!(TownsModel::FmTowns.machine_id(), (0x01, 0x01));
+    }
+
+    #[test]
+    fn base_cpu_clock_is_16mhz_in_both_modes() {
+        assert_eq!(
+            TownsModel::FmTowns.cpu_clock_hz(common::CpuMode::Low),
+            16_000_000
+        );
+        assert_eq!(
+            TownsModel::FmTowns.cpu_clock_hz(common::CpuMode::High),
+            16_000_000
+        );
     }
 
     #[test]

--- a/crates/machinetowns/src/memory.rs
+++ b/crates/machinetowns/src/memory.rs
@@ -192,6 +192,7 @@ const MX_DEFAULT_CMOS: &[u8; CMOS_SIZE] = include_bytes!("cmos_default_mx.bin");
 /// Default CMOS image for `model`.
 const fn default_cmos(model: TownsModel) -> &'static [u8; CMOS_SIZE] {
     match model {
+        TownsModel::FmTowns => MX_DEFAULT_CMOS,
         TownsModel::FmTownsIICx => MX_DEFAULT_CMOS,
         TownsModel::FmTownsIIMx => MX_DEFAULT_CMOS,
     }
@@ -322,6 +323,20 @@ impl TownsMemory {
     /// 0xCFF98) respond instead of plain RAM.
     pub(crate) fn fmr_window_mapped(&self) -> bool {
         self.fmr_vram
+    }
+
+    /// Whether `address` targets video memory for the memory wait-state
+    /// accounting: the native linear/interleaved/high-res VRAM windows, sprite
+    /// RAM, or the FMR VRAM window while it is mapped. Everything else (main and
+    /// extended RAM, ROM, CMOS) takes the main-RAM wait instead.
+    pub(crate) fn is_video_memory(&self, address: u32) -> bool {
+        (VRAM_LINEAR_BASE..VRAM_LINEAR_END).contains(&address)
+            || (VRAM_INTERLEAVED_BASE..VRAM_INTERLEAVED_END).contains(&address)
+            || (VRAM_HIGH_RES_PAGE0_BASE..VRAM_HIGH_RES_PAGE0_END).contains(&address)
+            || (VRAM_HIGH_RES_PAGE1_BASE..VRAM_HIGH_RES_PAGE1_END).contains(&address)
+            || (VRAM_HIGH_RES_SINGLE_BASE..VRAM_HIGH_RES_SINGLE_END).contains(&address)
+            || (SPRITE_RAM_BASE..SPRITE_RAM_END).contains(&address)
+            || (self.fmr_vram && (FMR_WINDOW_BASE..FMR_WINDOW_END).contains(&address))
     }
 
     /// Reads and clears the TVRAM dirty flag (I/O 0x05C8): returns 0x80 when the

--- a/crates/machinetowns/src/rom.rs
+++ b/crates/machinetowns/src/rom.rs
@@ -88,8 +88,9 @@ const MX_TABLES: RomTables = RomTables {
 
 const fn tables_for(model: TownsModel) -> &'static RomTables {
     match model {
-        // No CX dump is available yet; the MX set is compatible (the SYSROM
-        // layout is identical across the full 32-bit models).
+        // No base-model or CX dump is available yet; the MX set is compatible
+        // (the SYSROM layout is identical across the full 32-bit models).
+        TownsModel::FmTowns => &MX_TABLES,
         TownsModel::FmTownsIICx => &MX_TABLES,
         TownsModel::FmTownsIIMx => &MX_TABLES,
     }

--- a/crates/machinetowns/tests/common/harness.rs
+++ b/crates/machinetowns/tests/common/harness.rs
@@ -5,7 +5,7 @@
 use std::{cell::RefCell, collections::BTreeSet, rc::Rc};
 
 use common::{Bus, Cpu, CpuMode, HostDateTime, Tracing};
-use cpu::{CPU_MODEL_386, CPU_MODEL_486, I386State, SegReg32};
+use cpu::{CPU_MODEL_386_DX, CPU_MODEL_386_SX, CPU_MODEL_486_DX, I386State, SegReg32};
 use machinetowns::{LoadedRoms, TownsBus, TownsMachine, TownsModel};
 
 /// SYSROM / FONT slot size (256 KiB).
@@ -61,22 +61,30 @@ pub fn font_serial_roms(font: Vec<u8>, serial: Vec<u8>) -> LoadedRoms {
 }
 
 /// An MX machine (i486, High mode) over synthetic ROMs.
-pub fn machine_mx() -> TownsMachine<{ CPU_MODEL_486 }> {
+pub fn machine_mx() -> TownsMachine<{ CPU_MODEL_486_DX }> {
     build_machine(TownsModel::FmTownsIIMx, CpuMode::High, synthetic_roms())
 }
 
 /// A CX machine (i386, Low mode) over synthetic ROMs.
-pub fn machine_cx() -> TownsMachine<{ CPU_MODEL_386 }> {
+pub fn machine_cx() -> TownsMachine<{ CPU_MODEL_386_DX }> {
     build_machine(TownsModel::FmTownsIICx, CpuMode::Low, synthetic_roms())
 }
 
+/// A base FM Towns machine (i386SX, Low mode) over synthetic ROMs.
+pub fn machine_base() -> TownsMachine<{ CPU_MODEL_386_SX }> {
+    build_machine(TownsModel::FmTowns, CpuMode::Low, synthetic_roms())
+}
+
 /// An MX machine over synthetic ROMs whose bus activity is recorded.
-pub fn machine_mx_traced() -> TownsMachine<{ CPU_MODEL_486 }, RecordingTracer> {
+pub fn machine_mx_traced() -> TownsMachine<{ CPU_MODEL_486_DX }, RecordingTracer> {
     build_machine(TownsModel::FmTownsIIMx, CpuMode::High, synthetic_roms())
 }
 
 /// An MX machine with custom FONT and serial-ID ROM images.
-pub fn machine_with_font_serial(font: Vec<u8>, serial: Vec<u8>) -> TownsMachine<{ CPU_MODEL_486 }> {
+pub fn machine_with_font_serial(
+    font: Vec<u8>,
+    serial: Vec<u8>,
+) -> TownsMachine<{ CPU_MODEL_486_DX }> {
     build_machine(
         TownsModel::FmTownsIIMx,
         CpuMode::High,

--- a/crates/machinetowns/tests/midi_rs.rs
+++ b/crates/machinetowns/tests/midi_rs.rs
@@ -17,7 +17,7 @@ const RS232C_STATUS_PORT: u16 = 0x0A02;
 const STATUS_TXRDY: u8 = 1 << 0;
 const STATUS_TXEMPTY: u8 = 1 << 2;
 
-fn towns() -> TownsMachine<{ cpu::CPU_MODEL_486 }> {
+fn towns() -> TownsMachine<{ cpu::CPU_MODEL_486_DX }> {
     machine_mx()
 }
 

--- a/crates/machinetowns/tests/scsi_dma.rs
+++ b/crates/machinetowns/tests/scsi_dma.rs
@@ -19,7 +19,7 @@ const INITIATOR_MASK: u8 = 1 << 7;
 
 /// Selects target 0, sends a CDB, and advances the clock past the SCSI task so
 /// its scheduled data transfer runs.
-fn run_command(machine: &mut machinetowns::TownsMachine<{ cpu::CPU_MODEL_486 }>, cdb: &[u8]) {
+fn run_command(machine: &mut machinetowns::TownsMachine<{ cpu::CPU_MODEL_486_DX }>, cdb: &[u8]) {
     machine
         .bus
         .io_write_byte(SCSI_DATA, (1 << 0) | INITIATOR_MASK);
@@ -33,7 +33,7 @@ fn run_command(machine: &mut machinetowns::TownsMachine<{ cpu::CPU_MODEL_486 }>,
 }
 
 /// Reads back STATUS and MESSAGE IN so the bus returns to BUS FREE.
-fn drain_status(machine: &mut machinetowns::TownsMachine<{ cpu::CPU_MODEL_486 }>) {
+fn drain_status(machine: &mut machinetowns::TownsMachine<{ cpu::CPU_MODEL_486_DX }>) {
     machine.bus.io_read_byte(SCSI_DATA);
     machine.bus.io_read_byte(SCSI_DATA);
 }

--- a/crates/machinetowns/tests/serial_rtc.rs
+++ b/crates/machinetowns/tests/serial_rtc.rs
@@ -104,7 +104,7 @@ const RTC_DIGIT_MASK: u8 = 0x0F;
 /// Selects and reads back one RTC register through the data/command ports,
 /// returning the raw data byte (ready flag in bit 7, digit in the low nibble).
 fn read_rtc_register(
-    machine: &mut machinetowns::TownsMachine<{ cpu::CPU_MODEL_486 }>,
+    machine: &mut machinetowns::TownsMachine<{ cpu::CPU_MODEL_486_DX }>,
     reg: u8,
 ) -> u8 {
     machine.bus.io_write_byte(RTC_COMMAND_PORT, RTC_ENABLE);

--- a/crates/machinetowns/tests/sound.rs
+++ b/crates/machinetowns/tests/sound.rs
@@ -25,7 +25,7 @@ fn fm_tone_mixes_into_output() {
     machine.bus.io_write_byte(0x04D5, 0x03);
 
     let fm_write =
-        |machine: &mut machinetowns::TownsMachine<{ cpu::CPU_MODEL_486 }>, reg: u8, data: u8| {
+        |machine: &mut machinetowns::TownsMachine<{ cpu::CPU_MODEL_486_DX }>, reg: u8, data: u8| {
             machine.bus.io_write_byte(0x04D8, reg);
             machine.bus.io_write_byte(0x04DA, data);
         };

--- a/crates/machinetowns/tests/system_ports.rs
+++ b/crates/machinetowns/tests/system_ports.rs
@@ -5,7 +5,15 @@
 mod harness;
 
 use common::{Bus, Machine};
-use harness::machine_mx;
+use harness::{machine_base, machine_mx};
+
+#[test]
+fn base_model_reports_machine_id() {
+    let mut machine = machine_base();
+    // I/O 0x0030 is the CPU-class byte, 0x0031 the model byte.
+    assert_eq!(machine.bus.io_read_byte(0x0030), 0x01);
+    assert_eq!(machine.bus.io_read_byte(0x0031), 0x01);
+}
 
 #[test]
 fn memory_wait_latches_read_back() {
@@ -50,6 +58,67 @@ fn fastmode_write_drives_waits_and_lamp() {
     assert_eq!(machine.bus.io_read_byte(0x05EC), 1);
     machine.bus.io_write_byte(0x05E0, 1);
     assert_eq!(machine.bus.io_read_byte(0x05EC), 0);
+}
+
+/// The programmed wait latches are charged as real wait-state cycles: video
+/// memory takes the VRAM wait, everything else the main-RAM wait. A wide access
+/// costs one wait, not one per byte, and the counter drains to zero.
+#[test]
+fn memory_wait_latches_charge_access_cycles() {
+    let mut machine = machine_mx();
+    const MAIN_RAM: u32 = 0x0000_1000;
+    const VRAM_LINEAR: u32 = 0x8000_0000;
+
+    // Distinct RAM and VRAM waits so a mis-classified access is visible.
+    machine.bus.io_write_byte(0x05E0, 2);
+    machine.bus.io_write_byte(0x05E6, 5);
+
+    let _ = machine.bus.read_byte(MAIN_RAM);
+    assert_eq!(machine.bus.drain_wait_cycles(), 2);
+
+    machine.bus.write_byte(MAIN_RAM, 0);
+    assert_eq!(machine.bus.drain_wait_cycles(), 2);
+
+    // Video memory also carries the always-on baseline (2) on top of the latch.
+    let _ = machine.bus.read_byte(VRAM_LINEAR);
+    assert_eq!(machine.bus.drain_wait_cycles(), 2 + 5);
+
+    // A dword access is a single bus cycle: one wait, not four.
+    let _ = machine.bus.read_dword(MAIN_RAM);
+    assert_eq!(machine.bus.drain_wait_cycles(), 2);
+    machine.bus.write_dword(VRAM_LINEAR, 0);
+    assert_eq!(machine.bus.drain_wait_cycles(), 2 + 5);
+
+    // Draining leaves the counter empty.
+    assert_eq!(machine.bus.drain_wait_cycles(), 0);
+}
+
+/// Fast mode (both wait latches zero) charges no wait-state cycles for RAM, but
+/// video memory still carries the always-on VRAM baseline penalty.
+#[test]
+fn fast_mode_charges_only_vram_baseline() {
+    let mut machine = machine_mx();
+    machine.bus.io_write_byte(0x05EC, 0x01);
+
+    let _ = machine.bus.read_byte(0x0000_1000);
+    machine.bus.write_word(0x0000_1000, 0);
+    assert_eq!(machine.bus.drain_wait_cycles(), 0);
+
+    let _ = machine.bus.read_dword(0x8000_0000);
+    assert_eq!(machine.bus.drain_wait_cycles(), 2);
+}
+
+/// FMR-compatible slow mode (FASTMODE bit 0 clear) programs both latches to the
+/// slow value, so subsequent accesses are penalized.
+#[test]
+fn slow_mode_penalizes_accesses() {
+    let mut machine = machine_mx();
+    machine.bus.io_write_byte(0x05EC, 0x00);
+
+    let _ = machine.bus.read_byte(0x0000_1000);
+    let _ = machine.bus.read_byte(0x8000_0000);
+    // RAM charges the slow latch (6); VRAM charges the baseline (2) plus it (6).
+    assert_eq!(machine.bus.drain_wait_cycles(), 6 + (2 + 6));
 }
 
 /// The reset-reason port (0x0020) latches a software reset, reads it back, and

--- a/crates/software_renderer/tests/e2e_pegc.rs
+++ b/crates/software_renderer/tests/e2e_pegc.rs
@@ -18,7 +18,7 @@ fn run_mode(mode: u8) -> (Vec<u8>, u32) {
     let mut bus = Pc9801Bus::new(MachineModel::PC9821AP, CpuMode::High, 48000);
     bus.set_gdc_clock_5mhz();
 
-    let mut machine = Pc9821Ap::new(cpu::I386::<{ cpu::CPU_MODEL_486 }>::new(), bus);
+    let mut machine = Pc9821Ap::new(cpu::I386::<{ cpu::CPU_MODEL_486_DX }>::new(), bus);
     machine.bus.load_font_rom(BUILTIN_FONT_ROM);
     machine.bus.load_bios_rom(DEBUG_PEGC_ROM);
     machine.bus.write_byte(MODE_BYTE_ADDR, mode);

--- a/doc/games-towns.md
+++ b/doc/games-towns.md
@@ -1,0 +1,20 @@
+# FM Towns game compatibility
+
+This list contains only the verified compatibility, not the actual one.
+Even if a title is not listed here, there is a good chance it runs.
+
+✅ = Fully working
+⚠️ = Has Issues
+❌️ = Broken
+ⁿ̸ₐ = Not applicable
+
+| Title                                  | Japanese Title                 | Machine  | Status | Description                             |
+|----------------------------------------|--------------------------------|:--------:|:------:|-----------------------------------------|
+| After Burner                           | アフターバーナー                       | FM Towns |   ✅    |                                         |
+| After Burner III                       | アフターバーナーIII                    | FM Towns |   ✅    | Needs 386SX 16 MHz to run correctly     |
+| Genocide Square                        | ジェノサイド スクウェア                   | FM Towns |   ✅    | Supports SC-55 MIDI                     |
+| Power Dolls                            | パワードール                         | FM Towns |   ✅    |                                         |
+| Power Dolls 2                          | パワードール2                        | FM Towns |   ✅    |                                         |
+| Princess Maker 2                       | プリンセスメーカー2                     | FM Towns |   ✅    |                                         |
+| Psychic Detective Series Vol. 4: Orgel | サイキック・ディテクティブ・シリーズ Vol.4 オルゴール | FM Towns |   ❌️   | Input is broken                         |
+| Super D.P.S.                           | スーパーD.P.S.                     | FM Towns |   ⚠️   | FM sounds too low. Not sure if intended |

--- a/doc/machine-pc98.md
+++ b/doc/machine-pc98.md
@@ -1,7 +1,7 @@
 # PC-9801 / PC-9821
 
 Select a PC-98 machine with `--machine`; the default is `PC9801RA`. neetan aims to
-support all 16-bit era DOS games and emulates them accurately for 6 idealized
+support all 16-bit era DOS games and emulates them accurately for 7 idealized
 machine targets:
 
 | Machine   | `--machine` | CPU      | CPU Speed   | FPU (x87) | Extended RAM | Graphics | Interface | CD-ROM |
@@ -9,17 +9,19 @@ machine targets:
 | PC-9801F  | `PC9801F`   | 8086     | 5 / 8 MHz   | No        | None         | GDC      | SASI      | No     |
 | PC-9801VM | `PC9801VM`  | V30      | 8 / 10 MHz  | No        | None         | GRCG     | SASI      | No     |
 | PC-9801VX | `PC9801VX`  | 80286    | 8 / 10 MHz  | No        | 4 MiB        | EGC      | SASI      | No     |
-| PC-9801RA | `PC9801RA`  | 80386DX  | 16 / 20 MHz | Yes       | 12 MiB       | EGC      | SASI      | No     |
+| PC-9801RS | `PC9801RS`  | 80386SX  | 16 MHz      | Yes       | 12 MiB       | EGC      | SASI      | No     |
+| PC-9801RA | `PC9801RA`  | 80386DX  | 20 MHz      | Yes       | 12 MiB       | EGC      | SASI      | No     |
 | PC-9821AS | `PC9821AS`  | 80486DX  | 33 MHz      | Yes       | 14 MiB       | PEGC     | IDE       | Yes    |
 | PC-9821AP | `PC9821AP`  | 80486DX2 | 66 MHz      | Yes       | 14 MiB       | PEGC     | IDE       | Yes    |
 
 All targets have the full 640 KiB conventional RAM. The 8086 and V30 are cycle-count
 accurately emulated. The emulated 286 is calibrated to run at the same speed as the
-original 286 using trace data. The 386 and the 486 are optimized for emulation speed
-and most likely run a bit fast compared to their real counterparts.
+original 286 using trace data. The 386SX shares the 386 timings but adds a 16-bit bus
+and prefetch penalty model calibrated on aggregate against real traces, so it matches
+the real chip on overall throughput. The 386DX and 486 use their datasheet instruction
+timings, which calibration against test suites shows already track real throughput closely.
 
-The default for the CLI is the PC-9801RA machine with the PC-9801-86 + PC-9801-26k
-combo soundboards.
+The default for the CLI is the PC-9801RA machine with the PC-9801-86 + PC-9801-26k combo soundboards.
 
 Games of the PC-98 normally do not require any ROM files, with the rare exception of
 games that used the PC-98's N88 (86) BASIC ROM.

--- a/doc/machine-towns.md
+++ b/doc/machine-towns.md
@@ -1,21 +1,24 @@
 # FM Towns
 
-Select the FM Towns family with `--machine FMTownsIICX` or `--machine FMTownsIIMX`.
-Both are 32-bit machines sharing the Towns chipset; they differ mainly in CPU and
-clock:
+Select the FM Towns family with `--machine FMTowns`, `--machine FMTownsIICX` or
+`--machine FMTownsIIMX`. These are 32-bit machines sharing the Towns chipset; they
+differ mainly in CPU and clock:
 
 | Machine        | `--machine`   | CPU      | CPU Speed   | Sound              | CD-ROM |
 |----------------|---------------|----------|-------------|--------------------|--------|
+| FM Towns       | `FMTowns`     | 80386SX  | 16 MHz      | YMF276 OPN2 + PCM  | Yes    |
 | FM Towns II CX | `FMTownsIICX` | 80386DX  | 16 / 20 MHz | YMF276 OPN2 + PCM  | Yes    |
 | FM Towns II MX | `FMTownsIIMX` | 80486DX2 | 33 / 66 MHz | YMF276 OPN2 + PCM  | Yes    |
 
-For both targets `--cpu-mode low` selects the lower clock and `--cpu-mode high` (the
-default) the higher one: 16 / 20 MHz on the CX and 33 / 66 MHz on the MX. The 386 and
-486 cores are optimized for emulation speed and most likely run a bit fast compared
-to their real counterparts.
+The base FM Towns runs at a fixed 16 MHz and ignores `--cpu-mode`. On the CX and MX
+`--cpu-mode low` selects the lower clock and `--cpu-mode high` (the default) the higher
+one: 16 / 20 MHz on the CX and 33 / 66 MHz on the MX. The 386DX and 486 cores run on
+their datasheet instruction timings, which calibration against test suites shows
+already track real throughput closely. The base FM Towns is a 386SX, so it also carries
+the aggregate-calibrated 16-bit bus and prefetch penalty model.
 
 Sound is provided by the built-in YMF276 (OPN2) FM synthesizer and the RF5C68 PCM
-sound source. Both targets have a built-in CD-ROM drive, a SCSI interface, a floppy
+sound source. All three targets have a built-in CD-ROM drive, a SCSI interface, a floppy
 drive, and support the 2-button and 6-button Towns game pads. MIDI sound modules can
 be used as well; see [MIDI sound modules](#midi-sound-modules).
 
@@ -35,8 +38,8 @@ floppy images with `--fdd1` / `--fdd2`.
 
 ## ROM set
 
-The FM Towns targets need a real ROM set, pointed to by `--towns-roms`. Both targets
-use the FM Towns II MX ROM dump. Two layouts are accepted: a merged set (the packed
+The FM Towns targets need a real ROM set, pointed to by `--towns-roms`. All three
+targets use the FM Towns II MX ROM dump. Two layouts are accepted: a merged set (the packed
 2 MiB MAME BIOS image plus the 32-byte serial ROM) or a split set (the five
 individual images plus the serial ROM).
 

--- a/doc/roms.md
+++ b/doc/roms.md
@@ -56,7 +56,7 @@ for that machine.
 | PC-9801F              | `pc9801f`                                 | BIOS assembled from `urm01-02`..`urm06-02`                                   |
 | PC-9801VM             | `pc9801vm`                                | BIOS assembled from the `cpu_board_*` chips                                  |
 | PC-9801VX             | `pc9801vx`                                | BIOS assembled from the four `..._yll0x` chips; ships the font ROM           |
-| PC-9801RA             | `pc9801rs`                                | No RA dump exists - the RS set is used instead; ships the font ROM           |
+| PC-9801RS / PC-9801RA | `pc9801rs`                                | The `pc9801rs` set supplies the BIOS for both models; ships the font ROM     |
 | PC-9821AS / PC-9821AP | -                                         | HLE BIOS only; their fonts are not part of any MAME set (built-in font used) |
 | PC-8801MC             | `pc8801mc` (+ `pc8001mk2`, `pc8001mk2sr`) | The two `pc8001*` sets only add the optional N80 boot-mode ROMs              |
 | PC-88VA2              | `pc88va2`                                 | The sub-CPU ROM is NO_DUMP in MAME and must be sourced separately            |
@@ -65,7 +65,7 @@ for that machine.
 | PC-6601               | `pc6601`                                  |                                                                              |
 | PC-6001mkIISR         | `pc6001mk2sr`                             |                                                                              |
 | PC-6601SR             | `pc6601sr`                                |                                                                              |
-| FM Towns II CX & MX   | `fmtownsmx`                               | The CX target boots the shared MX ROM set until a CX dump exists             |
+| FM Towns / II CX / MX | `fmtownsmx`                               | The base FM Towns and CX targets boot the shared MX ROM set until CX dumps exist |
 | Sharp X68000          | `x68000`                                  | Original CZ-600C split IPL                                                   |
 | Sharp X68000 SUPER    | `x68ksupr`                                | IPL V1.0 and internal SCSI ROM                                               |
 | Sharp X68000 XVI      | `x68kxvi`                                 | IPL V1.1 with the compatible Compact-XVI SCSI ROM                            |
@@ -92,7 +92,7 @@ roms/
 |   |-- urm01-02.bin ... urm06-02.bin              (PC-9801F BIOS chips)
 |   |-- cpu_board_1a_23128e.bin ...                (PC-9801VM BIOS chips)
 |   |-- nec_d27c256d-15_cpu_extboard_yll01.bin ... (PC-9801VX BIOS chips)
-|   |-- itf_rs.rom, bios_rs.rom                    (PC-9801RA BIOS, from the RS set)
+|   |-- itf_rs.rom, bios_rs.rom                    (PC-9801RS / PC-9801RA BIOS, from the RS set)
 |   |-- font_ux.rom, font_rs.rom                   (shared V98 fonts)
 |   `-- sound.rom                                  (PC-9801-26K sound BIOS)
 |-- pc88/          --pc88-roms                     pc8801mc [+ pc8001mk2, pc8001mk2sr]
@@ -352,8 +352,7 @@ PC-9801VX (MAME set `pc9801vx`):
 | `nec_d27c256d-15_cpu_extboard_yll03.bin`   | 32 KiB | `05e3220b53a61c9325ceb694629bddc20c593dbf2218ee78a9e5635e8a7bf5f6` |
 | `nec_d27c256d-15_cpu_extboard_yll04.bin`   | 32 KiB | `a0f6e1e87afa336c21648f972c96e20ea88dda792a1fc3d0acf26d8c50546158` |
 
-PC-9801RA (MAME set `pc9801rs` - there is no dedicated RA dump, so the RS set is
-used):
+PC-9801RS / PC-9801RA (MAME set `pc9801rs`, shared by both models):
 
 | File          | Size   | BLAKE3                                                             |
 |---------------|--------|--------------------------------------------------------------------|
@@ -369,13 +368,13 @@ font (`font_ux.rom` / `font_rs.rom`); the `pc9801f` and `pc9801vm` sets do not, 
 those models fall back to the built-in font unless one of the other fonts is in the
 same directory.
 
-| Dump         | Source           | BLAKE3                                                             |
-|--------------|------------------|--------------------------------------------------------------------|
-| `font_rs.rom`| `pc9801rs`       | `4b6f751f34e633e072ded2a109c25ddb90ac70350792dc55914a4cefa4dbe005` |
-| `font_ux.rom`| `pc9801vx`       | `3c1efa858b80fc11bb7482bdc5e15004dd9a015d7d22d48159cd43ed63f540dc` |
-| PC-9821As    | -                | `a567134a3d5c2a215b9573ee07b5204fff243631052e7a40be340e863aff8eef` |
-| PC-9821Ap2   | -                | `7fb96af345c33f9bd7be5c22f75c650ac41da9b543ca5f9ca7b3d3906f2abb40` |
-| PC-9821Ce2   | -                | `b38096265c76cf9f54cb47df905cfb6c8b4d4f27019a04835bbc3dc8782d33e1` |
+| Dump          | Source     | BLAKE3                                                             |
+|---------------|------------|--------------------------------------------------------------------|
+| `font_rs.rom` | `pc9801rs` | `4b6f751f34e633e072ded2a109c25ddb90ac70350792dc55914a4cefa4dbe005` |
+| `font_ux.rom` | `pc9801vx` | `3c1efa858b80fc11bb7482bdc5e15004dd9a015d7d22d48159cd43ed63f540dc` |
+| PC-9821As     | -          | `a567134a3d5c2a215b9573ee07b5204fff243631052e7a40be340e863aff8eef` |
+| PC-9821Ap2    | -          | `7fb96af345c33f9bd7be5c22f75c650ac41da9b543ca5f9ca7b3d3906f2abb40` |
+| PC-9821Ce2    | -          | `b38096265c76cf9f54cb47df905cfb6c8b4d4f27019a04835bbc3dc8782d33e1` |
 
 Sound ROM (loaded when a PC-9801-26K board is selected; present in every PC-98 set):
 
@@ -460,9 +459,9 @@ dumps are bit-identical across models, so a single file can satisfy more than on
 
 ## FM Towns
 
-The FM Towns targets need a real ROM set, pointed to by `--towns-roms`. Both the
-FM Towns II CX and MX use the FM Towns II MX ROM dump (MAME set `fmtownsmx`). Two
-layouts are accepted.
+The FM Towns targets need a real ROM set, pointed to by `--towns-roms`. The base
+FM Towns, the FM Towns II CX, and the MX all use the FM Towns II MX ROM dump (MAME
+set `fmtownsmx`). Two layouts are accepted.
 
 The merged set is the packed 2 MiB MAME BIOS image plus the 32-byte serial ROM (this
 is what the `fmtownsmx` set contains):

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,8 +52,8 @@ Commands:
 
 Options:
   -c, --config <PATH>           Load configuration from file
-      --machine <TYPE>          Machine type: PC9801F, PC9801VM, PC9801VX, PC9801RA, PC9821AS, PC9821AP, PC8801MC, PC88VA2, PC6001, PC6001MK2, PC6601, PC6001MK2SR, PC6601SR, FMTownsIICX, FMTownsIIMX, X68000, X68000SUPER, X68000XVI, X1, X1TURBO, FM7, FM77AV
-      --cpu-mode <MODE>         CPU speed mode: low or high (PC-88 derives from boot mode; X68000 XVI 10/16.67 MHz; FM Towns CX 16/20 MHz, MX 33/66 MHz)
+      --machine <TYPE>          Machine type: PC9801F, PC9801VM, PC9801VX, PC9801RS, PC9801RA, PC9821AS, PC9821AP, PC8801MC, PC88VA2, PC6001, PC6001MK2, PC6601, PC6001MK2SR, PC6601SR, FMTowns, FMTownsIICX, FMTownsIIMX, X68000, X68000SUPER, X68000XVI, X1, X1TURBO, FM7, FM77AV
+      --cpu-mode <MODE>         CPU speed mode: low or high (PC-88 derives from boot mode; X68000 XVI 10/16.67 MHz; FM Towns base fixed 16 MHz, CX 16/20 MHz, MX 33/66 MHz)
       --boot-mode <MODE>        Boot mode; each machine accepts only its own values: PC-8801 v1s, v1h, v2 (default), n, n80, n80sr; FM-7 basic (default), dos
       --monitor <MODE>          Monitor timing: auto, 15k, 24k (default: auto; PC-8801 and X1 turbo)
       --pc88-memory-wait <MODE> PC-8801 memory wait: fast or compatible (default derives from boot mode)
@@ -1285,10 +1285,10 @@ fn apply_machine_selection(config: &mut EmulatorConfig, value: &str) -> Result<(
     }
     let Ok(model) = value.parse::<MachineModel>() else {
         return Err(format!(
-            "unknown machine type '{value}', expected PC9801F, PC9801VM, PC9801VX, PC9801RA, \
-             PC9821AS, PC9821AP, PC8801MC, PC88VA2, PC6001, PC6001MK2, PC6601, PC6001MK2SR, \
-             PC6601SR, FMTownsIICX, FMTownsIIMX, X68000, X68000SUPER, X68000XVI, X1, X1TURBO, \
-             FM7 or FM77AV"
+            "unknown machine type '{value}', expected PC9801F, PC9801VM, PC9801VX, PC9801RS, \
+             PC9801RA, PC9821AS, PC9821AP, PC8801MC, PC88VA2, PC6001, PC6001MK2, PC6601, PC6001MK2SR, \
+             PC6601SR, FMTowns, FMTownsIICX, FMTownsIIMX, X68000, X68000SUPER, X68000XVI, X1, \
+             X1TURBO, FM7 or FM77AV"
         ));
     };
     if config.target != Target::Pc98 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1373,7 +1373,7 @@ fn initialize_pc98_machine(config: &EmulatorConfig, sample_rate: u32) -> Result<
         (true, _, Some(ForceGdcClock::Force2_5)) => {
             info!("GDC clock forced to 2.5 MHz (200-line compatibility mode)");
         }
-        // EGC-only machines (PC-9801VX/RA): default to 2.5 MHz
+        // EGC-only machines (PC-9801VX/RS/RA): default to 2.5 MHz
         (false, true, Some(ForceGdcClock::Force5)) => {
             bus.set_gdc_clock_5mhz();
             info!("GDC clock forced to 5 MHz (400-line graphics mode)");
@@ -1523,12 +1523,23 @@ fn initialize_pc98_machine(config: &EmulatorConfig, sample_rate: u32) -> Result<
         common::CpuType::I8086 => Box::new(machine::Machine::new(cpu::I8086::new(), bus)),
         common::CpuType::V30 => Box::new(machine::Machine::new(cpu::V30::new(), bus)),
         common::CpuType::I286 => Box::new(machine::Machine::new(cpu::I286::new(), bus)),
-        common::CpuType::I386 => Box::new(machine::Machine::new(
-            cpu::I386::<{ cpu::CPU_MODEL_386 }>::new(),
-            bus,
-        )),
+        common::CpuType::I386 => match model {
+            MachineModel::PC9801RS => Box::new(machine::Machine::new(
+                cpu::I386::<{ cpu::CPU_MODEL_386_SX }>::new(),
+                bus,
+            )),
+            MachineModel::PC9801F
+            | MachineModel::PC9801VM
+            | MachineModel::PC9801VX
+            | MachineModel::PC9801RA
+            | MachineModel::PC9821AS
+            | MachineModel::PC9821AP => Box::new(machine::Machine::new(
+                cpu::I386::<{ cpu::CPU_MODEL_386_DX }>::new(),
+                bus,
+            )),
+        },
         common::CpuType::I486DX => Box::new(machine::Machine::new(
-            cpu::I386::<{ cpu::CPU_MODEL_486 }>::new(),
+            cpu::I386::<{ cpu::CPU_MODEL_486_DX }>::new(),
             bus,
         )),
     };
@@ -1568,8 +1579,8 @@ fn initialize_pc88_machine(config: &EmulatorConfig, sample_rate: u32) -> Result<
     })?;
 
     let clock_select = match config.cpu_mode {
-        common::CpuMode::Low => machine88::ClockSelect::FourMhz,
-        common::CpuMode::High => machine88::ClockSelect::EightMhz,
+        CpuMode::Low => machine88::ClockSelect::FourMhz,
+        CpuMode::High => machine88::ClockSelect::EightMhz,
     };
 
     let mut bus: machine88::Pc8801Bus = machine88::Pc8801Bus::new(model, clock_select, sample_rate);
@@ -1701,11 +1712,14 @@ fn initialize_towns_machine(
     };
 
     match model {
+        machinetowns::TownsModel::FmTowns => {
+            build_towns_machine::<{ cpu::CPU_MODEL_386_SX }>(config, model, roms, boot_device)
+        }
         machinetowns::TownsModel::FmTownsIICx => {
-            build_towns_machine::<{ cpu::CPU_MODEL_386 }>(config, model, roms, boot_device)
+            build_towns_machine::<{ cpu::CPU_MODEL_386_DX }>(config, model, roms, boot_device)
         }
         machinetowns::TownsModel::FmTownsIIMx => {
-            build_towns_machine::<{ cpu::CPU_MODEL_486 }>(config, model, roms, boot_device)
+            build_towns_machine::<{ cpu::CPU_MODEL_486_DX }>(config, model, roms, boot_device)
         }
     }
 }
@@ -1716,10 +1730,11 @@ fn build_towns_machine<const CPU_MODEL: u8>(
     roms: machinetowns::LoadedRoms,
     boot_device: machinetowns::TownsBootDevice,
 ) -> Result<Box<dyn Machine>> {
-    let cpu_name = if CPU_MODEL == cpu::CPU_MODEL_386 {
-        "i386DX"
-    } else {
-        "i486DX2"
+    let cpu_name = match CPU_MODEL {
+        cpu::CPU_MODEL_386_DX => "i386DX",
+        cpu::CPU_MODEL_386_SX => "i386SX",
+        cpu::CPU_MODEL_486_DX => "i486DX2",
+        _ => "unknown",
     };
     info!(
         "FM Towns configured: {} MHz {cpu_name}",


### PR DESCRIPTION
The game After Burner III needs a 386 SX target to correctly run. This is not cycle accurate, but it's calibrated like we did for the 386. This is still not perfect, but better than nothing.

This shows that there is value of a cycle accurate 286 and 386. A microcode based one like the 68000 from MAME would be ideal.

We now have a RS and RA model for the PC-98. This doesn't change much, since the PC-98 software by that time should not rely on a specific CPU by that time. But is is nice to have for completeness.

Fixes #213 