### PR TITLE
feature: automation check-* function contain failed condition in error message

### DIFF
--- a/crates/automation/scheme/neetan-test.scm
+++ b/crates/automation/scheme/neetan-test.scm
@@ -4,7 +4,7 @@
     test-suite test-case
     check-true check-false check-equal check-near check-screen
     fail note artifact!)
-  (import (scheme base) (neetan automation 1) (neetan internal 1)
+  (import (scheme base) (scheme write) (neetan automation 1) (neetan internal 1)
           (neetan handles internal 1))
   (begin
     (define-record-type <test-suite-state>
@@ -30,6 +30,15 @@
     (define (%assert-fail message)
       (%require-test-case "assertion")
       (error message 'neetan/assertion))
+
+    (define (%written value)
+      (let ((port (open-output-string)))
+        (write value port)
+        (get-output-string port)))
+
+    (define (%check-fail message check-form)
+      (%assert-fail
+        (string-append message "; check: " (%written check-form))))
 
     ;; Returns whether a condition is a neetan/assertion failure.
     (define (%assertion? condition)
@@ -174,25 +183,25 @@
              (if #f #f)
              body ...)))))
 
-    (define (check-true value)
+    (define (%check-true check-form value)
       (%require-test-case "check-true")
       (if value
           value
-          (%assert-fail "check-true failed: value was false")))
+          (%check-fail "check-true failed: value was false" check-form)))
 
-    (define (check-false value)
+    (define (%check-false check-form value)
       (%require-test-case "check-false")
       (if value
-          (%assert-fail "check-false failed: value was true")
+          (%check-fail "check-false failed: value was true" check-form)
           value))
 
-    (define (check-equal expected actual)
+    (define (%check-equal check-form expected actual)
       (%require-test-case "check-equal")
       (if (equal? expected actual)
           actual
-          (%assert-fail "check-equal failed: values are not equal")))
+          (%check-fail "check-equal failed: values are not equal" check-form)))
 
-    (define (check-near expected actual tolerance)
+    (define (%check-near check-form expected actual tolerance)
       (%require-test-case "check-near")
       (if (not (and (real? expected) (real? actual)
                     (real? tolerance) (>= tolerance 0)))
@@ -200,11 +209,12 @@
                  'neetan/argument)
           (if (<= (abs (- expected actual)) tolerance)
               actual
-              (%assert-fail
+              (%check-fail
                 (string-append "check-near failed: |"
                                (number->string expected) " - "
                                (number->string actual) "| > "
-                               (number->string tolerance))))))
+                               (number->string tolerance))
+                check-form))))
 
     ;; Best-effort extraction of a written comparison-image path for a message.
     (define (%comparison-path result)
@@ -212,7 +222,7 @@
           "(comparison image unavailable)"
           (alist-ref result 'path)))
 
-    (define (check-screen machine expected-path . optional-options)
+    (define (%check-screen check-form machine expected-path . optional-options)
       (%require-test-case "check-screen")
       (if (not (string? expected-path))
           (error "check-screen path must be a string" 'neetan/argument)
@@ -232,9 +242,35 @@
                         (%screen-comparison-image
                           (%require-machine-token "check-screen" machine)
                           expected-path)))
-                  (%assert-fail
+                  (%check-fail
                     (string-append "check-screen failed: " expected-path
                                    " did not match; comparison image at "
-                                   (%comparison-path artifact))))))))
+                                   (%comparison-path artifact))
+                    check-form))))))
+
+    (define-syntax check-true
+      (syntax-rules ()
+        ((_ arguments ...)
+         (%check-true '(check-true arguments ...) arguments ...))))
+
+    (define-syntax check-false
+      (syntax-rules ()
+        ((_ arguments ...)
+         (%check-false '(check-false arguments ...) arguments ...))))
+
+    (define-syntax check-equal
+      (syntax-rules ()
+        ((_ arguments ...)
+         (%check-equal '(check-equal arguments ...) arguments ...))))
+
+    (define-syntax check-near
+      (syntax-rules ()
+        ((_ arguments ...)
+         (%check-near '(check-near arguments ...) arguments ...))))
+
+    (define-syntax check-screen
+      (syntax-rules ()
+        ((_ arguments ...)
+         (%check-screen '(check-screen arguments ...) arguments ...))))
 
     ))

--- a/crates/automation/tests/run.rs
+++ b/crates/automation/tests/run.rs
@@ -110,6 +110,50 @@ fn failed_case_is_named_and_later_cases_continue() {
 }
 
 #[test]
+fn failed_checks_report_their_source_forms() {
+    let run = run_committed_script("test-suite-check-details.scm", 30);
+    let expected_messages = [
+        (
+            "check-true detail",
+            "check-true failed: value was false; check: (check-true (begin (set! evaluations (+ evaluations 1)) #f))",
+        ),
+        (
+            "check-false detail",
+            "check-false failed: value was true; check: (check-false (> 2 1))",
+        ),
+        (
+            "check-equal detail",
+            "check-equal failed: values are not equal; check: (check-equal (+ 1 1) 3)",
+        ),
+        (
+            "check-near detail",
+            "check-near failed: |1.0 - 2.0| > 0.1; check: (check-near 1.0 2.0 0.1)",
+        ),
+    ];
+
+    for (test_case, expected_message) in expected_messages {
+        assert!(run.messages.iter().any(|message| matches!(
+            message,
+            MessageProtocol::TestCaseFinished {
+                test_case: actual_test_case,
+                outcome: TestCaseOutcome::Failure { message, .. },
+                ..
+            } if actual_test_case == test_case && message == expected_message
+        )));
+    }
+
+    match &run.termination {
+        RunTermination::Completed(ExecutionResult::Error { message }) => {
+            assert!(message.contains("check detail suite: 4 of 5 test case(s) failed"));
+            for (test_case, expected_message) in expected_messages {
+                assert!(message.contains(&format!("{test_case}: {expected_message}")));
+            }
+        }
+        other => panic!("expected Completed(Error), got {other:?}"),
+    }
+}
+
+#[test]
 fn catchable_case_error_is_recorded_and_later_cases_continue() {
     let run = run_committed_script("test-suite-error.scm", 30);
     let output = output_text(&run);

--- a/crates/automation/tests/screen.rs
+++ b/crates/automation/tests/screen.rs
@@ -311,6 +311,10 @@ fn pc98_check_screen_failure_writes_comparison_image() {
                 message.contains("PC-98 mismatch: 1 of 1 test case(s) failed"),
                 "summary should report a failure, got {message:?}"
             );
+            assert!(
+                message.contains("check: (check-screen machine \"expected/pc98-wrong.png\")"),
+                "summary should identify the failed check, got {message:?}"
+            );
         }
         other => panic!("expected Completed(Error), got {other:?}"),
     }

--- a/crates/automation/tests/scripts/test-suite-check-details.scm
+++ b/crates/automation/tests/scripts/test-suite-check-details.scm
@@ -1,0 +1,23 @@
+(import
+  (scheme base)
+  (scheme write)
+  (neetan test 1))
+
+(define evaluations 0)
+
+(write
+  (test-suite "check detail suite"
+    (test-case "check-true detail"
+      (check-true
+        (begin
+          (set! evaluations (+ evaluations 1))
+          #f)))
+    (test-case "check-false detail"
+      (check-false (> 2 1)))
+    (test-case "check-equal detail"
+      (check-equal (+ 1 1) 3))
+    (test-case "check-near detail"
+      (check-near 1.0 2.0 0.1))
+    (test-case "arguments are evaluated once"
+      (check-equal 1 evaluations))))
+(newline)

--- a/doc/scheme/test.md
+++ b/doc/scheme/test.md
@@ -28,8 +28,10 @@ A misuse of these forms (nesting, no active case, a second root) raises
 
 ## Checks
 
-Each check returns the checked value on success and aborts the case with a
-`neetan/assertion` error on failure.
+Each check is a syntax form that returns the checked value on success and aborts
+the case with a `neetan/assertion` error on failure. Failure messages include a
+normalized written representation of the complete check form so multiple checks
+in one case can be distinguished.
 
 - `(check-true value)` -> value. Fails if `value` is `#f`.
 - `(check-false value)` -> value. Fails if `value` is not `#f`.


### PR DESCRIPTION
Looks like this:

`MSX Megadoom - first opening frame renders: assertion: check-true failed: value was false; check: (check-true (wait-for-screen machine "megadoom-opening.png" (quote ((frames . 480)))))`