### PR TITLE
fix: PC-98 HLE DOS console rendering

### DIFF
--- a/crates/dos/src/console.rs
+++ b/crates/dos/src/console.rs
@@ -106,7 +106,8 @@ impl Console {
     pub(crate) fn put_fullwidth_jis_char(&self, memory: &mut dyn MemoryAccess, jis: JisChar) {
         let mut row = self.cursor_row(memory);
         let mut col = self.cursor_col(memory);
-        if col == COLUMNS - 1 {
+        let width = jis.display_width();
+        if width == 2 && col == COLUMNS - 1 {
             if !self.wrap_to_next_line(memory) {
                 return;
             }
@@ -116,8 +117,10 @@ impl Console {
 
         let attr = self.display_attr(memory);
         self.write_cell(memory, row, col, jis, attr);
-        self.write_cell(memory, row, col + 1, JisChar::from_u16(0x0000), attr);
-        self.advance_cursor(memory);
+        if width == 2 {
+            self.write_cell(memory, row, col + 1, JisChar::from_u16(0x0000), attr);
+            self.advance_cursor(memory);
+        }
         self.advance_cursor(memory);
     }
 
@@ -722,21 +725,25 @@ mod tests {
     }
 
     #[test]
-    fn process_byte_graphic_mode_does_not_pair_shift_jis_leads() {
+    fn process_byte_graphic_mode_pairs_halfwidth_jis_graphics() {
         let mut console = make_console();
         let mut memory = make_memory();
 
         feed_str(&mut console, &mut memory, "\x1b)3");
         console.process_byte(&mut memory, 0x86);
-        console.process_byte(&mut memory, 0x86);
+        console.process_byte(&mut memory, 0x5F);
 
         assert_eq!(
             memory.read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_KANJI_HI_FLAG),
             0x00
         );
-        assert_vram_char(&memory, 0, 0, 0x86, 0x00);
-        assert_vram_char(&memory, 0, 1, 0x86, 0x00);
-        assert_cursor(&console, &memory, 0, 2);
+        assert_vram_jis(
+            &memory,
+            0,
+            0,
+            common::shift_jis_pair_to_jis(0x86, 0x5F).unwrap(),
+        );
+        assert_cursor(&console, &memory, 0, 1);
     }
 
     #[test]
@@ -1440,6 +1447,38 @@ mod tests {
 
         assert_eq!(read_vram_attr(&memory, 0, 0), 0x0041);
         assert_eq!(read_vram_attr(&memory, 0, 1), 0x00E1);
+    }
+
+    #[test]
+    fn csi_m_sets_pc98_text_effects() {
+        let mut console = make_console();
+        let mut memory = make_memory();
+        feed_str(&mut console, &mut memory, "\x1B[4;5;7mX");
+
+        assert_eq!(read_vram_attr(&memory, 0, 0), 0x00EF);
+    }
+
+    #[test]
+    fn csi_m_clears_pc98_text_effects() {
+        let mut console = make_console();
+        let mut memory = make_memory();
+        feed_str(
+            &mut console,
+            &mut memory,
+            "\x1B[4;5;7;8mX\x1B[24;25;27;28mY",
+        );
+
+        assert_eq!(read_vram_attr(&memory, 0, 0), 0x00EE);
+        assert_eq!(read_vram_attr(&memory, 0, 1), 0x00E1);
+    }
+
+    #[test]
+    fn csi_m_maps_background_color_to_pc98_reverse_video() {
+        let mut console = make_console();
+        let mut memory = make_memory();
+        feed_str(&mut console, &mut memory, "\x1B[46mX");
+
+        assert_eq!(read_vram_attr(&memory, 0, 0), 0x00A5);
     }
 
     #[test]

--- a/crates/dos/src/console_esc.rs
+++ b/crates/dos/src/console_esc.rs
@@ -100,9 +100,10 @@ impl Console {
             return;
         }
 
+        let shift_jis_mode = self.shift_jis_mode_enabled(memory);
         if self.esc_parser.state == EscState::Normal
-            && self.shift_jis_mode_enabled(memory)
             && is_shift_jis_lead_byte(byte)
+            && (shift_jis_mode || byte == 0x86)
         {
             self.set_pending_shift_jis_lead(memory, byte);
             return;
@@ -340,6 +341,14 @@ impl Console {
             let parameter = self.esc_parser.params[index];
             match parameter {
                 0 | 39 => self.set_attribute(memory, 0xE1),
+                4 => self.update_attribute(memory, 0x08, 0x00),
+                5 => self.update_attribute(memory, 0x02, 0x00),
+                7 => self.update_attribute(memory, 0x04, 0x00),
+                8 => self.update_attribute(memory, 0x00, 0x01),
+                24 => self.update_attribute(memory, 0x00, 0x08),
+                25 => self.update_attribute(memory, 0x00, 0x02),
+                27 => self.update_attribute(memory, 0x00, 0x04),
+                28 => self.update_attribute(memory, 0x01, 0x00),
                 30..=37 => {
                     let color = ansi_foreground_to_pc98_color(parameter as u8);
                     let lower_bits = memory
@@ -347,9 +356,21 @@ impl Console {
                         & 0x1F;
                     self.set_attribute(memory, (color << 5) | lower_bits);
                 }
+                40..=47 => {
+                    let color = ansi_foreground_to_pc98_color(parameter as u8 - 10);
+                    let lower_bits = memory
+                        .read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_DISPLAY_ATTR)
+                        & 0x1F;
+                    self.set_attribute(memory, (color << 5) | lower_bits | 0x04);
+                }
                 _ => {}
             }
         }
+    }
+
+    fn update_attribute(&self, memory: &mut dyn MemoryAccess, set: u8, clear: u8) {
+        let attribute = memory.read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_DISPLAY_ATTR);
+        self.set_attribute(memory, (attribute | set) & !clear);
     }
 
     fn esc_dispatch_csi_question(&self, memory: &mut dyn MemoryAccess, final_byte: u8) {

--- a/crates/dos/src/dos.rs
+++ b/crates/dos/src/dos.rs
@@ -167,8 +167,9 @@ impl NeetanDos {
         dev_info & tables::SFT_DEVINFO_NUL != 0
     }
 
-    fn write_stdout_byte(&mut self, memory: &mut dyn MemoryAccess, byte: u8) {
-        if !self.stdout_is_nul(memory) {
+    /// Writes one byte through the active console output path.
+    pub(crate) fn write_stdout_byte(&mut self, memory: &mut dyn MemoryAccess, byte: u8) {
+        if !self.stdout_is_nul(memory) && !int29_handler_is_iret(memory) {
             self.console.process_byte(memory, byte);
         }
     }
@@ -1503,6 +1504,13 @@ impl NeetanDos {
     }
 }
 
+fn int29_handler_is_iret(memory: &dyn MemoryAccess) -> bool {
+    const INT29_VECTOR: u32 = 0x29 * 4;
+    let offset = u32::from(memory.read_word(INT29_VECTOR));
+    let segment = u32::from(memory.read_word(INT29_VECTOR + 2));
+    memory.read_byte((segment << 4).wrapping_add(offset)) == 0xCF
+}
+
 /// Normalizes a DOS path by resolving `.` and `..` components.
 /// Input/output is a byte vector like `A:\FOO\BAR\..\BAZ`.
 pub(crate) fn normalize_path(path: &[u8]) -> Vec<u8> {
@@ -1551,6 +1559,7 @@ fn read_dword(memory: &dyn MemoryAccess, address: u32) -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use super::int29_handler_is_iret;
     use crate::{
         CpuAccess, MemoryAccess, NeetanDos,
         memory::{self, memory_manager::MemoryManager},
@@ -1584,6 +1593,26 @@ mod tests {
 
     fn mcb_addr(segment: u16) -> u32 {
         (segment as u32) << 4
+    }
+
+    #[test]
+    fn int29_iret_hook_suppresses_fast_console_output() {
+        let mut memory = MockMemory::with_extended_memory(0x200000, 0);
+        memory.write_word(0x29 * 4, 0x0123);
+        memory.write_word(0x29 * 4 + 2, 0x2000);
+        memory.write_byte(0x20123, 0xCF);
+
+        assert!(int29_handler_is_iret(&memory));
+    }
+
+    #[test]
+    fn int29_non_iret_hook_keeps_fast_console_output() {
+        let mut memory = MockMemory::with_extended_memory(0x200000, 0);
+        memory.write_word(0x29 * 4, 0x0123);
+        memory.write_word(0x29 * 4 + 2, 0x2000);
+        memory.write_byte(0x20123, 0x90);
+
+        assert!(!int29_handler_is_iret(&memory));
     }
 
     #[test]

--- a/crates/dos/src/file_io.rs
+++ b/crates/dos/src/file_io.rs
@@ -710,7 +710,7 @@ impl NeetanDos {
                 // Device write: send to console
                 for i in 0..count {
                     let byte = memory.read_byte(buf_addr + i);
-                    self.console.process_byte(memory, byte);
+                    self.write_stdout_byte(memory, byte);
                 }
                 return Ok(count as u16);
             }


### PR DESCRIPTION
Handle ANSI text effects and reverse video, correctly decode half-width JIS graphics, and honor INT 29h output suppression for redirected console writes.

This fixes the text rendering in the installer of PC-98's "Only You".