### PR TITLE
feature: improve tracing automation

### DIFF
--- a/crates/automation/scheme/neetan-inspect.scm
+++ b/crates/automation/scheme/neetan-inspect.scm
@@ -4,7 +4,10 @@
     processors processor-info registers register-ref
     protected-mode-state
     address-spaces address-space-info
-    memory-read-bytevector memory-peek-unsigned)
+    memory-read-bytevector memory-peek-unsigned
+    save-memory!
+    text-surfaces text-surface-info text-cell text-screen
+    wait-for-text save-text-screen!)
   (import (scheme base) (neetan automation 1) (neetan internal 1)
           (neetan handles internal 1))
   (begin
@@ -92,4 +95,101 @@
       (%raise-if-error
         (%memory-peek-unsigned
           (%require-machine-token "memory-peek-unsigned" machine)
-          space address width byte-order)))))
+          space address width byte-order)))
+
+    (define (%require-string who value)
+      (if (string? value)
+          value
+          (error (string-append who ": expected a string") 'neetan/argument)))
+
+    (define default-maximum-ticks-per-frame 50000000)
+    (define default-wait-for-text-frames 120)
+
+    (define (save-memory! machine space address length path)
+      (%require-symbol "save-memory!" space)
+      (%require-count "save-memory!" address)
+      (%require-count "save-memory!" length)
+      (%require-string "save-memory!" path)
+      (%raise-if-error
+        (%save-memory (%require-machine-token "save-memory!" machine)
+                      space address length path)))
+
+    (define (text-surfaces machine)
+      (%raise-if-error
+        (%text-surfaces (%require-machine-token "text-surfaces" machine))))
+
+    (define (text-surface-info machine surface)
+      (%require-symbol "text-surface-info" surface)
+      (%raise-if-error
+        (%text-surface-info
+          (%require-machine-token "text-surface-info" machine) surface)))
+
+    (define (text-cell machine surface row column)
+      (%require-symbol "text-cell" surface)
+      (%require-count "text-cell" row)
+      (%require-count "text-cell" column)
+      (%raise-if-error
+        (%text-cell (%require-machine-token "text-cell" machine)
+                    surface row column)))
+
+    (define (text-screen machine surface)
+      (%require-symbol "text-screen" surface)
+      (%raise-if-error
+        (%text-screen (%require-machine-token "text-screen" machine) surface)))
+
+    (define (save-text-screen! machine surface path)
+      (%require-symbol "save-text-screen!" surface)
+      (%require-string "save-text-screen!" path)
+      (%raise-if-error
+        (%save-text-screen
+          (%require-machine-token "save-text-screen!" machine) surface path)))
+
+    ;; Drives the machine until surface text matches the predicate, returning the
+    ;; matched text or #f when the frame or tick bound is exhausted first.
+    ;;
+    ;; The predicate is a bare string, shorthand for ((contains . string)), or an
+    ;; alist with a required 'contains string and an optional 'row index; options
+    ;; is an optional alist with 'frames and 'ticks bounds.
+    ;;
+    ;; The text surface is the live text plane, sampled once before running and
+    ;; then at each frame boundary. Text written and overwritten within a single
+    ;; frame is not observed.
+    (define (wait-for-text machine surface raw-predicate . optional-options)
+      (%require-symbol "wait-for-text" surface)
+      (define predicate
+        (if (string? raw-predicate)
+            (list (cons 'contains raw-predicate))
+            raw-predicate))
+      (if (not (list? predicate))
+          (error "wait-for-text: predicate must be a string or an association list"
+                 'neetan/argument))
+      (let* ((missing (cons #f #f))
+             (contains (alist-ref predicate 'contains missing))
+             (row (alist-ref predicate 'row #f))
+             (options
+               (cond
+                 ((null? optional-options) '())
+                 ((null? (cdr optional-options)) (car optional-options))
+                 (else
+                   (error "wait-for-text: expected three or four arguments"
+                          'neetan/argument))))
+             (frames-value (alist-ref options 'frames missing))
+             (ticks-value (alist-ref options 'ticks missing))
+             (maximum-frames
+               (if (eq? frames-value missing)
+                   default-wait-for-text-frames
+                   (%require-count "wait-for-text" frames-value)))
+             (maximum-ticks
+               (if (eq? ticks-value missing)
+                   (* maximum-frames default-maximum-ticks-per-frame)
+                   (%require-count "wait-for-text" ticks-value))))
+        (if (eq? contains missing)
+            (error "wait-for-text: predicate requires a 'contains string"
+                   'neetan/argument))
+        (%require-string "wait-for-text" contains)
+        (if (and row (not (and (integer? row) (exact? row) (>= row 0))))
+            (error "wait-for-text: row must be a non-negative exact integer or #f"
+                   'neetan/argument))
+        (%raise-if-error
+          (%wait-for-text (%require-machine-token "wait-for-text" machine)
+                          surface contains row maximum-frames maximum-ticks))))))

--- a/crates/automation/scheme/neetan-trace.scm
+++ b/crates/automation/scheme/neetan-trace.scm
@@ -2,7 +2,7 @@
 (define-library (neetan trace 1)
   (export
     trace-schema trace-start! trace-active? trace-stop! trace-drain!
-    trace-failure wait-for-event)
+    trace-failure wait-for-event save-trace! trace-arm!)
   (import (scheme base) (neetan automation 1) (neetan internal 1)
           (neetan handles internal 1))
   (begin
@@ -69,8 +69,79 @@
       (%raise-if-error
         (%trace-failure (%require-machine-token "trace-failure" machine))))
 
+    (define (%require-string who value)
+      (if (string? value)
+          value
+          (error (string-append who ": expected a string") 'neetan/argument)))
+
+    ;; Writes the buffered trace events to an artifact as Scheme data, one event
+    ;; datum per line. The text reads back with `read`, and the events are the
+    ;; same alists trace-drain! returns. This is non-consuming, so the buffer
+    ;; stays available for a later trace-drain!.
+    (define (save-trace! machine path)
+      (%require-string "save-trace!" path)
+      (%raise-if-error
+        (%save-trace (%require-machine-token "save-trace!" machine) path)))
+
     (define default-maximum-ticks-per-frame 50000000)
     (define default-wait-for-event-frames 120)
+
+    (define (%every predicate items)
+      (or (null? items)
+          (and (predicate (car items)) (%every predicate (cdr items)))))
+
+    ;; Validates the snapshot option value is a list holding one processor
+    ;; symbol.
+    ;;
+    ;; A snapshot is captured at HLE dispatch entry, so only main-CPU HLE events
+    ;; carry register state. Other event classes marshal the snapshot as #f.
+    (define (%require-snapshot who value)
+      (if (and (list? value) (%every symbol? value))
+          value
+          (error (string-append who ": snapshot must be a list of processor symbols")
+                 'neetan/argument)))
+
+    ;; Runs a triggered bounded ring capture.
+    ;;
+    ;; The spec is an alist with required keys capture, trigger, before, after,
+    ;; and artifact, plus optional frames and ticks run bounds. Events matching
+    ;; the capture filter are kept in a window of at most `before` events ahead
+    ;; of the first trigger match and `after` events following it. The machine
+    ;; stops as soon as the post-trigger context is complete. Once the trigger
+    ;; has fired the retained events are written to the artifact in the same
+    ;; format save-trace! uses. Returns an alist with triggered, complete,
+    ;; events, trigger-index, and bytes entries.
+    (define (trace-arm! machine spec)
+      (let* ((options (%validate-options "trace-arm!" spec
+                        '(capture trigger before after artifact frames ticks)))
+             (missing (cons #f #f))
+             (%required
+               (lambda (key)
+                 (let ((value (alist-ref options key missing)))
+                   (if (eq? value missing)
+                       (error (string-append "trace-arm!: missing required option: "
+                                             (symbol->string key))
+                              'neetan/argument)
+                       value))))
+             (capture (%require-filter "trace-arm!" (%required 'capture)))
+             (trigger (%require-filter "trace-arm!" (%required 'trigger)))
+             (before (%require-count "trace-arm!" (%required 'before)))
+             (after (%require-count "trace-arm!" (%required 'after)))
+             (artifact (%require-string "trace-arm!" (%required 'artifact)))
+             (frames-value (alist-ref options 'frames missing))
+             (ticks-value (alist-ref options 'ticks missing))
+             (maximum-frames
+               (if (eq? frames-value missing)
+                   default-wait-for-event-frames
+                   (%require-count "trace-arm!" frames-value)))
+             (maximum-ticks
+               (if (eq? ticks-value missing)
+                   (* maximum-frames default-maximum-ticks-per-frame)
+                   (%require-count "trace-arm!" ticks-value))))
+        (%raise-if-error
+          (%trace-arm (%require-machine-token "trace-arm!" machine)
+                      capture trigger before after artifact
+                      maximum-frames maximum-ticks))))
 
     (define (wait-for-event machine filter . optional-options)
       (%require-filter "wait-for-event" filter)
@@ -79,13 +150,14 @@
                  ((null? optional-options) '())
                  ((null? (cdr optional-options))
                   (%validate-options
-                    "wait-for-event" (car optional-options) '(frames ticks)))
+                    "wait-for-event" (car optional-options) '(frames ticks snapshot)))
                  (else
                    (error "wait-for-event: expected two or three arguments"
                           'neetan/argument))))
              (missing (cons #f #f))
              (frames-value (alist-ref options 'frames missing))
              (ticks-value (alist-ref options 'ticks missing))
+             (snapshot-value (alist-ref options 'snapshot missing))
              (maximum-frames
                (if (eq? frames-value missing)
                    default-wait-for-event-frames
@@ -93,7 +165,11 @@
              (maximum-ticks
                (if (eq? ticks-value missing)
                    (* maximum-frames default-maximum-ticks-per-frame)
-                   (%require-count "wait-for-event" ticks-value))))
+                   (%require-count "wait-for-event" ticks-value)))
+             (snapshot
+               (if (eq? snapshot-value missing)
+                   '()
+                   (%require-snapshot "wait-for-event" snapshot-value))))
         (%raise-if-error
           (%wait-for-event (%require-machine-token "wait-for-event" machine)
-                           filter maximum-frames maximum-ticks))))))
+                           filter maximum-frames maximum-ticks snapshot))))))

--- a/crates/automation/src/scheme.rs
+++ b/crates/automation/src/scheme.rs
@@ -20,6 +20,7 @@ mod query;
 mod run;
 mod screen;
 mod support;
+mod text;
 mod trace;
 
 use std::{cell::RefCell, rc::Rc};
@@ -115,6 +116,7 @@ pub fn register_libraries(
     screen::register_screen_natives(engine, session, &internal)?;
     inspect::register_inspect_natives(engine, session, &internal)?;
     inspect::register_mutate_natives(engine, session, &internal)?;
+    text::register_text_natives(engine, session, &internal)?;
     trace::register_trace_natives(engine, session, &internal)?;
 
     engine.register_library_source(

--- a/crates/automation/src/scheme/inspect.rs
+++ b/crates/automation/src/scheme/inspect.rs
@@ -9,8 +9,8 @@ use common::{
 use r7rs::{Engine, Error, LibraryName, NativeContext, Value};
 
 use super::support::{
-    error_value, inspected_integer, machine_id, make_alist, make_list, op_error_value, to_count,
-    to_u32, to_u128,
+    artifact_alist, error_value, inspected_integer, machine_id, make_alist, make_list,
+    op_error_value, to_count, to_u32, to_u128, written_len,
 };
 use crate::session::AutomationSession;
 
@@ -352,6 +352,30 @@ pub(super) fn register_inspect_natives(
             }
         },
     )?;
+
+    let save_memory = Rc::clone(session);
+    engine.register_library_fn(internal, "%save-memory", 5..=5, move |context, args| {
+        if let Err(value) = machine_id(context, &save_memory, args[0])? {
+            return Ok(value);
+        }
+        let space = context.to_symbol_name(args[1])?.to_owned();
+        let address = match to_count(context, args[2])? {
+            Ok(address) => address,
+            Err(value) => return Ok(value),
+        };
+        let length = match to_count(context, args[3])? {
+            Ok(length) => length,
+            Err(value) => return Ok(value),
+        };
+        let path = context.to_str(args[4])?.to_owned();
+        match save_memory
+            .borrow_mut()
+            .save_memory(&space, address, length, &path)
+        {
+            Ok(written) => artifact_alist(context, &path, Some(written_len(&written))),
+            Err(error) => op_error_value(context, &error),
+        }
+    })?;
 
     Ok(())
 }

--- a/crates/automation/src/scheme/screen.rs
+++ b/crates/automation/src/scheme/screen.rs
@@ -2,25 +2,12 @@
 
 use std::{cell::RefCell, rc::Rc};
 
-use r7rs::{Engine, Error, LibraryName, NativeContext, Value};
+use r7rs::{Engine, Error, LibraryName, Value};
 
-use super::support::{machine_id, make_alist, make_list, op_error_value, to_count, to_u32};
+use super::support::{
+    artifact_alist, machine_id, make_list, op_error_value, to_count, to_u32, written_len,
+};
 use crate::session::AutomationSession;
-
-/// Builds the artifact alist describing a written or recorded artifact path.
-fn artifact_alist(
-    context: &mut NativeContext,
-    path: &str,
-    bytes: Option<usize>,
-) -> Result<Value, Error> {
-    let path_value = context.string_utf8(path.to_owned())?;
-    let mut entries = vec![("path", path_value)];
-    if let Some(bytes) = bytes {
-        let bytes_value = context.integer(i128::try_from(bytes).unwrap_or(i128::MAX))?;
-        entries.push(("bytes", bytes_value));
-    }
-    make_alist(context, entries)
-}
 
 /// Derives the artifact-relative comparison image name from an expected path.
 ///
@@ -32,13 +19,6 @@ fn comparison_output_name(expected_path: &str) -> String {
         .and_then(|stem| stem.to_str())
         .unwrap_or("screen");
     format!("{stem}-compare.png")
-}
-
-/// Returns the on-disk byte length of a written artifact, or 0 when unknown.
-fn written_len(path: &std::path::Path) -> usize {
-    std::fs::metadata(path)
-        .map(|metadata| usize::try_from(metadata.len()).unwrap_or(usize::MAX))
-        .unwrap_or(0)
 }
 
 /// Registers the screen read, hash, screenshot, and comparison natives.

--- a/crates/automation/src/scheme/support.rs
+++ b/crates/automation/src/scheme/support.rs
@@ -24,6 +24,28 @@ pub(super) fn make_alist(
     Ok(list)
 }
 
+/// Builds the artifact alist `((path . "...") (bytes . n))` for a written file.
+pub(super) fn artifact_alist(
+    context: &mut NativeContext,
+    path: &str,
+    bytes: Option<usize>,
+) -> Result<Value, Error> {
+    let path_value = context.string_utf8(path.to_owned())?;
+    let mut entries = vec![("path", path_value)];
+    if let Some(bytes) = bytes {
+        let bytes_value = context.integer(i128::try_from(bytes).unwrap_or(i128::MAX))?;
+        entries.push(("bytes", bytes_value));
+    }
+    make_alist(context, entries)
+}
+
+/// Returns the on-disk byte length of a written artifact, or 0 when unknown.
+pub(super) fn written_len(path: &std::path::Path) -> usize {
+    std::fs::metadata(path)
+        .map(|metadata| usize::try_from(metadata.len()).unwrap_or(usize::MAX))
+        .unwrap_or(0)
+}
+
 /// Builds a proper list from values, preserving the given order.
 pub(super) fn make_list(context: &mut NativeContext, values: Vec<Value>) -> Result<Value, Error> {
     let mut list = Value::nil();

--- a/crates/automation/src/scheme/text.rs
+++ b/crates/automation/src/scheme/text.rs
@@ -1,0 +1,196 @@
+//! Decoded text-surface inspection, waiting, and dump natives.
+
+use std::{cell::RefCell, rc::Rc};
+
+use common::TextCell;
+use r7rs::{Engine, Error, LibraryName, NativeContext, Value, ValueKind};
+
+use super::support::{
+    artifact_alist, machine_id, make_alist, make_list, op_error_value, to_count, written_len,
+};
+use crate::session::{AutomationSession, text::TextMatch};
+
+/// Marshals one decoded text cell into a normalized alist.
+fn cell_value(context: &mut NativeContext, cell: &TextCell) -> Result<Value, Error> {
+    let row = context.integer(i128::from(cell.row))?;
+    let column = context.integer(i128::from(cell.column))?;
+    let raw_jis = context.integer(i128::from(cell.raw_jis))?;
+    let unicode = match cell.unicode {
+        Some(character) => Value::character(character),
+        None => Value::boolean(false),
+    };
+    let attribute = context.integer(i128::from(cell.attribute))?;
+    let display_width = context.integer(i128::from(cell.display_width))?;
+    make_alist(
+        context,
+        vec![
+            ("row", row),
+            ("column", column),
+            ("raw-jis", raw_jis),
+            ("unicode", unicode),
+            ("attribute", attribute),
+            ("display-width", display_width),
+        ],
+    )
+}
+
+/// Marshals a text-surface descriptor into a normalized alist.
+fn surface_info_value(
+    context: &mut NativeContext,
+    info: &common::TextSurfaceInfo,
+) -> Result<Value, Error> {
+    let id = context.intern_symbol(info.id)?;
+    let rows = context.integer(i128::from(info.rows))?;
+    let columns = context.integer(i128::from(info.columns))?;
+    make_alist(
+        context,
+        vec![("id", id), ("rows", rows), ("columns", columns)],
+    )
+}
+
+/// Parses a bounded row argument, accepting a non-negative integer or `#f`.
+fn parse_optional_row(
+    context: &mut NativeContext,
+    value: Value,
+) -> Result<Result<Option<u16>, Value>, Error> {
+    if context.kind(value) == ValueKind::Boolean && value == Value::boolean(false) {
+        return Ok(Ok(None));
+    }
+    match to_count(context, value)? {
+        Ok(row) => Ok(Ok(Some(u16::try_from(row).unwrap_or(u16::MAX)))),
+        Err(value) => Ok(Err(value)),
+    }
+}
+
+/// Registers the decoded text-surface natives.
+pub(super) fn register_text_natives(
+    engine: &mut Engine,
+    session: &Rc<RefCell<AutomationSession>>,
+    internal: &LibraryName,
+) -> Result<(), Error> {
+    let surfaces = Rc::clone(session);
+    engine.register_library_fn(internal, "%text-surfaces", 1..=1, move |context, args| {
+        if let Err(value) = machine_id(context, &surfaces, args[0])? {
+            return Ok(value);
+        }
+        match surfaces.borrow().text_surfaces() {
+            Ok(ids) => {
+                let mut values = Vec::with_capacity(ids.len());
+                for id in ids {
+                    values.push(context.intern_symbol(id)?);
+                }
+                make_list(context, values)
+            }
+            Err(error) => op_error_value(context, &error),
+        }
+    })?;
+
+    let surface_info = Rc::clone(session);
+    engine.register_library_fn(
+        internal,
+        "%text-surface-info",
+        2..=2,
+        move |context, args| {
+            if let Err(value) = machine_id(context, &surface_info, args[0])? {
+                return Ok(value);
+            }
+            let surface = context.to_symbol_name(args[1])?.to_owned();
+            match surface_info.borrow().text_surface_info(&surface) {
+                Ok(info) => surface_info_value(context, &info),
+                Err(error) => op_error_value(context, &error),
+            }
+        },
+    )?;
+
+    let text_cell = Rc::clone(session);
+    engine.register_library_fn(internal, "%text-cell", 4..=4, move |context, args| {
+        if let Err(value) = machine_id(context, &text_cell, args[0])? {
+            return Ok(value);
+        }
+        let surface = context.to_symbol_name(args[1])?.to_owned();
+        let row = match to_count(context, args[2])? {
+            Ok(row) => u16::try_from(row).unwrap_or(u16::MAX),
+            Err(value) => return Ok(value),
+        };
+        let column = match to_count(context, args[3])? {
+            Ok(column) => u16::try_from(column).unwrap_or(u16::MAX),
+            Err(value) => return Ok(value),
+        };
+        match text_cell.borrow().text_cell(&surface, row, column) {
+            Ok(cell) => cell_value(context, &cell),
+            Err(error) => op_error_value(context, &error),
+        }
+    })?;
+
+    let text_screen = Rc::clone(session);
+    engine.register_library_fn(internal, "%text-screen", 2..=2, move |context, args| {
+        if let Err(value) = machine_id(context, &text_screen, args[0])? {
+            return Ok(value);
+        }
+        let surface = context.to_symbol_name(args[1])?.to_owned();
+        match text_screen.borrow().text_screen_lines(&surface) {
+            Ok(lines) => {
+                let mut values = Vec::with_capacity(lines.len());
+                for line in lines {
+                    values.push(context.string_utf8(line)?);
+                }
+                make_list(context, values)
+            }
+            Err(error) => op_error_value(context, &error),
+        }
+    })?;
+
+    let save_text = Rc::clone(session);
+    engine.register_library_fn(
+        internal,
+        "%save-text-screen",
+        3..=3,
+        move |context, args| {
+            if let Err(value) = machine_id(context, &save_text, args[0])? {
+                return Ok(value);
+            }
+            let surface = context.to_symbol_name(args[1])?.to_owned();
+            let path = context.to_str(args[2])?.to_owned();
+            match save_text.borrow_mut().save_text_screen(&surface, &path) {
+                Ok(written) => artifact_alist(context, &path, Some(written_len(&written))),
+                Err(error) => op_error_value(context, &error),
+            }
+        },
+    )?;
+
+    let wait_for_text = Rc::clone(session);
+    engine.register_library_fn(internal, "%wait-for-text", 6..=6, move |context, args| {
+        if let Err(value) = machine_id(context, &wait_for_text, args[0])? {
+            return Ok(value);
+        }
+        let surface = context.to_symbol_name(args[1])?.to_owned();
+        let contains = context.to_str(args[2])?.to_owned();
+        let row = match parse_optional_row(context, args[3])? {
+            Ok(row) => row,
+            Err(value) => return Ok(value),
+        };
+        let max_frames = match to_count(context, args[4])? {
+            Ok(value) => value,
+            Err(value) => return Ok(value),
+        };
+        let max_ticks = match to_count(context, args[5])? {
+            Ok(value) => value,
+            Err(value) => return Ok(value),
+        };
+        let predicate = TextMatch {
+            surface,
+            row,
+            contains,
+        };
+        match wait_for_text
+            .borrow_mut()
+            .wait_for_text(predicate, max_frames, max_ticks)
+        {
+            Ok(Some(text)) => context.string_utf8(text),
+            Ok(None) => Ok(Value::boolean(false)),
+            Err(error) => op_error_value(context, &error),
+        }
+    })?;
+
+    Ok(())
+}

--- a/crates/automation/src/scheme/trace.rs
+++ b/crates/automation/src/scheme/trace.rs
@@ -4,16 +4,19 @@ use std::{cell::RefCell, rc::Rc};
 
 use common::{
     OwnedTraceCall, OwnedTraceDeviceEvent, OwnedTraceEvent, OwnedTraceField, OwnedTraceValue,
-    TraceCallInterface, TraceContext, TraceEventClass,
+    ProcessorSnapshot, TraceCallInterface, TraceContext, TraceEventClass, TraceFieldDescriptor,
     tracing::{ApplicationTraceEnvelope, TraceFailure},
 };
 use r7rs::{Engine, Error, LibraryName, NativeContext, Value, ValueKind};
 
-use super::support::{error_value, machine_id, make_alist, make_list, op_error_value, to_count};
+use super::support::{
+    artifact_alist, error_value, inspected_integer, machine_id, make_alist, make_list,
+    op_error_value, to_count, written_len,
+};
 use crate::session::{
-    AutomationSession,
+    AutomationSession, OpError,
     trace::{
-        CLASS_SCHEMAS, ENVELOPE_FIELDS, FilterScalar, FilterSpec, access_operation,
+        CLASS_SCHEMAS, ENVELOPE_FIELDS, FilterScalar, FilterSpec, SchemaType, access_operation,
         access_width_bits, call_phase_name, interrupt_action_name, interrupt_kind_name,
         space_class_name,
     },
@@ -35,10 +38,14 @@ fn parse_scalar(
             Ok(Ok(FilterScalar::Integer(integer)))
         }
         ValueKind::Pair => parse_range(context, value),
+        ValueKind::Bytevector => {
+            let bytes = context.to_bytes(value)?.to_vec();
+            Ok(Ok(FilterScalar::Bytes(bytes)))
+        }
         _ => Ok(Err(error_value(
             context,
             "neetan/argument",
-            "trace filter value must be a symbol, integer, boolean, or range",
+            "trace filter value must be a symbol, integer, boolean, bytevector, or range",
         )?)),
     }
 }
@@ -119,6 +126,73 @@ fn parse_alist(
     }
 }
 
+/// The two sections of a parsed `data` block: the direct data constraints and an
+/// optional nested `fields` sub-alist of provider-specific field constraints.
+type DataSections = (
+    Vec<(String, FilterScalar)>,
+    Option<Vec<(String, FilterScalar)>>,
+);
+
+/// Parses the nested `data` alist, splitting out an optional `fields` sub-alist.
+fn parse_data(
+    context: &mut NativeContext,
+    value: Value,
+) -> Result<Result<DataSections, Value>, Error> {
+    let items = match context.kind(value) {
+        ValueKind::Nil => Vec::new(),
+        ValueKind::Pair => {
+            let Ok(items) = context.to_list(value) else {
+                return Ok(Err(error_value(
+                    context,
+                    "neetan/argument",
+                    "trace filter data must be a proper association list",
+                )?));
+            };
+            items
+        }
+        _ => {
+            return Ok(Err(error_value(
+                context,
+                "neetan/argument",
+                "trace filter data must be an association list",
+            )?));
+        }
+    };
+    let mut data = Vec::new();
+    let mut fields = None;
+    for item in items {
+        if context.kind(item) != ValueKind::Pair {
+            return Ok(Err(error_value(
+                context,
+                "neetan/argument",
+                "trace filter data entry must be a (key . value) pair",
+            )?));
+        }
+        let (key, tail) = context.to_pair(item)?;
+        if context.kind(key) != ValueKind::Symbol {
+            return Ok(Err(error_value(
+                context,
+                "neetan/argument",
+                "trace filter data key must be a symbol",
+            )?));
+        }
+        let name = context.to_symbol_name(key)?.to_owned();
+        if name == "fields" {
+            match parse_alist(context, tail)? {
+                Ok(sub) => fields = Some(sub),
+                Err(error) => return Ok(Err(error)),
+            }
+        } else {
+            let scalar = match parse_scalar(context, tail)? {
+                Ok(scalar) => scalar,
+                Err(error) => return Ok(Err(error)),
+            };
+            data.push((name, scalar));
+        }
+    }
+    Ok(Ok((data, fields)))
+}
+
 /// Parses a full declarative filter value into a filter specification.
 fn parse_filter(
     context: &mut NativeContext,
@@ -126,6 +200,7 @@ fn parse_filter(
 ) -> Result<Result<FilterSpec, Value>, Error> {
     let mut top = Vec::new();
     let mut data = None;
+    let mut fields = None;
     let items = match context.kind(value) {
         ValueKind::Nil => Vec::new(),
         ValueKind::Pair => match context.to_list(value) {
@@ -164,8 +239,11 @@ fn parse_filter(
         }
         let name = context.to_symbol_name(key)?.to_owned();
         if name == "data" {
-            match parse_alist(context, tail)? {
-                Ok(sub) => data = Some(sub),
+            match parse_data(context, tail)? {
+                Ok((sub_data, sub_fields)) => {
+                    data = Some(sub_data);
+                    fields = sub_fields;
+                }
                 Err(error) => return Ok(Err(error)),
             }
         } else {
@@ -176,7 +254,7 @@ fn parse_filter(
             top.push((name, scalar));
         }
     }
-    Ok(Ok(FilterSpec { top, data }))
+    Ok(Ok(FilterSpec { top, data, fields }))
 }
 
 /// Interns a stable identifier symbol.
@@ -205,6 +283,14 @@ fn field_value(context: &mut NativeContext, value: &OwnedTraceValue) -> Result<V
         OwnedTraceValue::Bool(flag) => Ok(Value::boolean(*flag)),
         OwnedTraceValue::Bytes(bytes) => context.bytevector(bytes.clone()),
         OwnedTraceValue::Text(text) => context.string_utf8(text.clone()),
+        OwnedTraceValue::Symbol(name) => symbol(context, name),
+        OwnedTraceValue::U16List(elements) => {
+            let mut values = Vec::with_capacity(elements.len());
+            for element in elements {
+                values.push(context.integer(i128::from(*element))?);
+            }
+            make_list(context, values)
+        }
         _ => Ok(Value::boolean(false)),
     }
 }
@@ -369,6 +455,26 @@ fn clock_rate_value(
     }
 }
 
+/// Marshals an entry snapshot into `#f` or a `((processor . registers))` alist.
+///
+/// The registers use the same names and values as `register-ref`, captured at
+/// HLE dispatch entry. Events without an armed snapshot marshal to `#f`.
+fn snapshot_value(
+    context: &mut NativeContext,
+    snapshot: &Option<ProcessorSnapshot>,
+) -> Result<Value, Error> {
+    let Some(snapshot) = snapshot else {
+        return Ok(Value::boolean(false));
+    };
+    let mut register_entries: Vec<(&str, Value)> = Vec::with_capacity(snapshot.registers.len());
+    for register in &snapshot.registers {
+        let value = inspected_integer(context, register.value)?;
+        register_entries.push((register.name, value));
+    }
+    let registers = make_alist(context, register_entries)?;
+    make_alist(context, vec![(snapshot.processor, registers)])
+}
+
 /// Marshals one owned trace envelope into a normalized event alist.
 fn envelope_value(
     context: &mut NativeContext,
@@ -384,6 +490,7 @@ fn envelope_value(
     let clock_rate = clock_rate_value(context, &envelope.context)?;
     let class = symbol(context, owned_class_name(&envelope.event))?;
     let data = data_value(context, &envelope.event)?;
+    let snapshot = snapshot_value(context, &envelope.snapshot)?;
     make_alist(
         context,
         vec![
@@ -397,6 +504,7 @@ fn envelope_value(
             ("clock-rate", clock_rate),
             ("class", class),
             ("data", data),
+            ("snapshot", snapshot),
         ],
     )
 }
@@ -439,6 +547,32 @@ fn failure_value(
             make_alist(context, vec![("reason", reason)])
         }
     }
+}
+
+/// Marshals a list of provider-specific field descriptors into a list of
+/// `((name . sym) (type . sym) (range . bool))` alists.
+fn descriptor_list(
+    context: &mut NativeContext,
+    descriptors: &[TraceFieldDescriptor],
+) -> Result<Value, Error> {
+    let mut entries = Vec::with_capacity(descriptors.len());
+    for descriptor in descriptors {
+        let name = symbol(context, descriptor.name)?;
+        let type_symbol = symbol(
+            context,
+            SchemaType::from_field_type(descriptor.value_type).name(),
+        )?;
+        let entry = make_alist(
+            context,
+            vec![
+                ("name", name),
+                ("type", type_symbol),
+                ("range", Value::boolean(descriptor.range)),
+            ],
+        )?;
+        entries.push(entry);
+    }
+    make_list(context, entries)
 }
 
 /// Builds the `trace-schema` descriptor alist.
@@ -533,11 +667,14 @@ fn schema_value(
     let mut device_entries = Vec::with_capacity(parts.catalog.devices.len());
     for device in parts.catalog.devices {
         let device_symbol = symbol(context, device.device)?;
-        let mut action_symbols = Vec::with_capacity(device.actions.len());
+        let mut action_entries = Vec::with_capacity(device.actions.len());
         for action in device.actions {
-            action_symbols.push(symbol(context, action)?);
+            let action_symbol = symbol(context, action.action)?;
+            let fields = descriptor_list(context, action.fields)?;
+            let entry = make_alist(context, vec![("action", action_symbol), ("fields", fields)])?;
+            action_entries.push(entry);
         }
-        let actions = make_list(context, action_symbols)?;
+        let actions = make_list(context, action_entries)?;
         let entry = make_alist(
             context,
             vec![("device", device_symbol), ("actions", actions)],
@@ -554,11 +691,13 @@ fn schema_value(
             interface_symbols.push(symbol(context, interface)?);
         }
         let interfaces = make_list(context, interface_symbols)?;
+        let call_fields = descriptor_list(context, provider.call_fields)?;
         let entry = make_alist(
             context,
             vec![
                 ("provider", provider_symbol),
                 ("named-interfaces", interfaces),
+                ("call-fields", call_fields),
             ],
         )?;
         provider_entries.push(entry);
@@ -580,6 +719,45 @@ fn schema_value(
             ("providers", providers),
         ],
     )
+}
+
+/// Parses a snapshot-processor argument into a list of processor identifiers.
+///
+/// The argument is a list of symbols, or `#f` for no snapshot request.
+fn parse_snapshot_processors(
+    context: &mut NativeContext,
+    value: Value,
+) -> Result<Result<Vec<String>, Value>, Error> {
+    match context.kind(value) {
+        ValueKind::Boolean if value == Value::boolean(false) => Ok(Ok(Vec::new())),
+        ValueKind::Nil => Ok(Ok(Vec::new())),
+        ValueKind::Pair => {
+            let Ok(items) = context.to_list(value) else {
+                return Ok(Err(error_value(
+                    context,
+                    "neetan/argument",
+                    "snapshot must be a proper list of processor symbols",
+                )?));
+            };
+            let mut processors = Vec::with_capacity(items.len());
+            for item in items {
+                if context.kind(item) != ValueKind::Symbol {
+                    return Ok(Err(error_value(
+                        context,
+                        "neetan/argument",
+                        "snapshot processor must be a symbol",
+                    )?));
+                }
+                processors.push(context.to_symbol_name(item)?.to_owned());
+            }
+            Ok(Ok(processors))
+        }
+        _ => Ok(Err(error_value(
+            context,
+            "neetan/argument",
+            "snapshot must be a list of processor symbols",
+        )?)),
+    }
 }
 
 /// Registers the tracing natives.
@@ -657,8 +835,123 @@ pub(super) fn register_trace_natives(
         }
     })?;
 
+    let save_trace = Rc::clone(session);
+    engine.register_library_fn(internal, "%save-trace", 2..=2, move |context, args| {
+        if let Err(value) = machine_id(context, &save_trace, args[0])? {
+            return Ok(value);
+        }
+        let path = context.to_str(args[1])?.to_owned();
+        let events = match save_trace.borrow().trace_snapshot() {
+            Ok(events) => events,
+            Err(error) => return op_error_value(context, &error),
+        };
+        // Render each event with the same alist marshalling as trace-drain!, then
+        // to its `write` external form, so the artifact reads back with `read`.
+        let mut text = String::new();
+        for envelope in &events {
+            let value = envelope_value(context, envelope)?;
+            text.push_str(&context.write_to_string(value)?);
+            text.push('\n');
+        }
+        match save_trace
+            .borrow_mut()
+            .write_artifact(&path, text.as_bytes())
+        {
+            Ok(written) => artifact_alist(context, &path, Some(written_len(&written))),
+            Err(error) => op_error_value(context, &error),
+        }
+    })?;
+
+    let arm = Rc::clone(session);
+    engine.register_library_fn(internal, "%trace-arm", 8..=8, move |context, args| {
+        if let Err(value) = machine_id(context, &arm, args[0])? {
+            return Ok(value);
+        }
+        let capture = match parse_filter(context, args[1])? {
+            Ok(spec) => spec,
+            Err(value) => return Ok(value),
+        };
+        let trigger = match parse_filter(context, args[2])? {
+            Ok(spec) => spec,
+            Err(value) => return Ok(value),
+        };
+        let before = match to_count(context, args[3])? {
+            Ok(value) => value,
+            Err(value) => return Ok(value),
+        };
+        let after = match to_count(context, args[4])? {
+            Ok(value) => value,
+            Err(value) => return Ok(value),
+        };
+        let path = context.to_str(args[5])?.to_owned();
+        let max_frames = match to_count(context, args[6])? {
+            Ok(value) => value,
+            Err(value) => return Ok(value),
+        };
+        let max_ticks = match to_count(context, args[7])? {
+            Ok(value) => value,
+            Err(value) => return Ok(value),
+        };
+        if let Err(error) = arm.borrow().validate_artifact_path(&path) {
+            return op_error_value(context, &error);
+        }
+        let outcome = match arm
+            .borrow_mut()
+            .trace_capture(capture, trigger, before, after, max_frames, max_ticks)
+        {
+            Ok(outcome) => outcome,
+            Err(error) => return op_error_value(context, &error),
+        };
+        // The artifact uses the same one-datum-per-line rendering as
+        // save-trace!, and is only written once the trigger has fired. A
+        // capture ended by an overflow still writes the partially retained
+        // window before the failure is raised.
+        let mut written_path = None;
+        if outcome.triggered {
+            let mut text = String::new();
+            for envelope in &outcome.events {
+                let value = envelope_value(context, envelope)?;
+                text.push_str(&context.write_to_string(value)?);
+                text.push('\n');
+            }
+            match arm.borrow_mut().write_artifact(&path, text.as_bytes()) {
+                Ok(written) => written_path = Some(written),
+                Err(error) => return op_error_value(context, &error),
+            }
+        }
+        if outcome.failure.is_some() {
+            return op_error_value(
+                context,
+                &OpError::TraceOverflow(
+                    "trace capture exceeded its bounded payload limits".to_owned(),
+                ),
+            );
+        }
+        let bytes_value = match &written_path {
+            Some(written) => context.integer(written_len(written) as i128)?,
+            None => Value::boolean(false),
+        };
+        let triggered = Value::boolean(outcome.triggered);
+        let complete = Value::boolean(outcome.complete);
+        let events = context.integer(outcome.events.len() as i128)?;
+        let trigger_index = match outcome.trigger_index {
+            Some(index) => context.integer(index as i128)?,
+            None => Value::boolean(false),
+        };
+        make_alist(
+            context,
+            vec![
+                ("triggered", triggered),
+                ("complete", complete),
+                ("events", events),
+                ("trigger-index", trigger_index),
+                ("bytes", bytes_value),
+            ],
+        )
+    })?;
+
     let wait = Rc::clone(session);
-    engine.register_library_fn(internal, "%wait-for-event", 4..=4, move |context, args| {
+    engine.register_library_fn(internal, "%wait-for-event", 5..=5, move |context, args| {
         if let Err(value) = machine_id(context, &wait, args[0])? {
             return Ok(value);
         }
@@ -674,9 +967,13 @@ pub(super) fn register_trace_natives(
             Ok(value) => value,
             Err(value) => return Ok(value),
         };
+        let snapshot_processors = match parse_snapshot_processors(context, args[4])? {
+            Ok(processors) => processors,
+            Err(value) => return Ok(value),
+        };
         match wait
             .borrow_mut()
-            .wait_for_event(spec, max_frames, max_ticks)
+            .wait_for_event(spec, max_frames, max_ticks, snapshot_processors)
         {
             Ok(Some(envelope)) => envelope_value(context, &envelope),
             Ok(None) => Ok(Value::boolean(false)),

--- a/crates/automation/src/session.rs
+++ b/crates/automation/src/session.rs
@@ -19,6 +19,7 @@ mod lifecycle;
 mod media;
 mod run;
 mod screen;
+pub(crate) mod text;
 pub(crate) mod trace;
 
 use std::{
@@ -35,6 +36,7 @@ use common::{
 use machine_factory::{InitError, InitErrorKind, config::EmulatorConfig};
 
 use crate::{
+    capabilities::resolve_within,
     config::CommonConfig,
     media::{MediaKind, MediaMount, MediaRequest},
     protocol::{ExecutionResult, MessageProtocol, TestCaseOutcome},
@@ -319,6 +321,42 @@ impl AutomationSession {
     /// Sets the total-session budgets.
     pub fn set_budgets(&mut self, budgets: SessionBudgets) {
         self.budgets = budgets;
+    }
+
+    /// Resolves an artifact path, charges the byte budget, and writes the bytes.
+    ///
+    /// The path is confined to the session artifact root; a `..` escape reports
+    /// `neetan/path-escape`. Parent directories are created as needed.
+    pub(crate) fn write_artifact(&mut self, path: &str, bytes: &[u8]) -> Result<PathBuf, OpError> {
+        let resolved = resolve_within(&self.artifact_root, path).map_err(OpError::PathEscape)?;
+        self.charge_artifact_bytes(bytes.len() as u128)?;
+        if let Some(parent) = resolved.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                OpError::Io(format!("cannot create artifact directory: {error}"))
+            })?;
+        }
+        std::fs::write(&resolved, bytes)
+            .map_err(|error| OpError::Io(format!("cannot write artifact {path}: {error}")))?;
+        Ok(resolved)
+    }
+
+    /// Validates that an artifact path stays within the artifact root without
+    /// writing anything.
+    pub(crate) fn validate_artifact_path(&self, path: &str) -> Result<(), OpError> {
+        resolve_within(&self.artifact_root, path).map_err(OpError::PathEscape)?;
+        Ok(())
+    }
+
+    /// Charges `bytes` against the artifact-byte budget when one is set.
+    fn charge_artifact_bytes(&mut self, bytes: u128) -> Result<(), OpError> {
+        if let Some(remaining) = self.budgets.artifact_bytes.as_mut() {
+            if *remaining < bytes {
+                *remaining = 0;
+                return Err(OpError::Io("artifact byte budget exhausted".to_owned()));
+            }
+            *remaining -= bytes;
+        }
+        Ok(())
     }
 
     /// Returns the full timeline overlaying the epoch and session-total bases on

--- a/crates/automation/src/session/inspect.rs
+++ b/crates/automation/src/session/inspect.rs
@@ -242,6 +242,21 @@ impl AutomationSession {
         Ok(value)
     }
 
+    /// Peeks `length` bytes of `space` and writes them to an artifact.
+    ///
+    /// The peek is side-effect-free, so the artifact is directly usable with a
+    /// disassembler such as `ndisasm`.
+    pub fn save_memory(
+        &mut self,
+        space: &str,
+        address: u64,
+        length: u64,
+        path: &str,
+    ) -> Result<std::path::PathBuf, OpError> {
+        let bytes = self.peek_memory(space, address, length)?;
+        self.write_artifact(path, &bytes)
+    }
+
     /// Writes one register after validating the value against its width.
     pub fn write_register(
         &mut self,

--- a/crates/automation/src/session/screen.rs
+++ b/crates/automation/src/session/screen.rs
@@ -288,32 +288,6 @@ impl AutomationSession {
         self.write_artifact(output_path, &png)?;
         Ok(())
     }
-
-    /// Resolves an artifact path, charges the byte budget, and writes the bytes.
-    fn write_artifact(&mut self, path: &str, bytes: &[u8]) -> Result<PathBuf, OpError> {
-        let resolved = resolve_within(&self.artifact_root, path).map_err(OpError::PathEscape)?;
-        self.charge_artifact_bytes(bytes.len() as u128)?;
-        if let Some(parent) = resolved.parent() {
-            std::fs::create_dir_all(parent).map_err(|error| {
-                OpError::Io(format!("cannot create artifact directory: {error}"))
-            })?;
-        }
-        std::fs::write(&resolved, bytes)
-            .map_err(|error| OpError::Io(format!("cannot write artifact {path}: {error}")))?;
-        Ok(resolved)
-    }
-
-    /// Charges `bytes` against the artifact-byte budget when one is set.
-    fn charge_artifact_bytes(&mut self, bytes: u128) -> Result<(), OpError> {
-        if let Some(remaining) = self.budgets.artifact_bytes.as_mut() {
-            if *remaining < bytes {
-                *remaining = 0;
-                return Err(OpError::Io("artifact byte budget exhausted".to_owned()));
-            }
-            *remaining -= bytes;
-        }
-        Ok(())
-    }
 }
 
 /// Derives the comparison artifact name from an expected image path.

--- a/crates/automation/src/session/text.rs
+++ b/crates/automation/src/session/text.rs
@@ -1,0 +1,214 @@
+//! Read-only decoded text-surface inspection and text waiting.
+//!
+//! Text decoding is side-effect-free: it reads the current text VRAM through the
+//! machine's [`TextSurfaceInspector`] and never performs a device read. The
+//! `wait-for-text` loop drives the machine one presented frame at a time and
+//! decodes the surface after each frame, stopping at the first substring match.
+
+use common::{
+    InspectError, RunRequest, RunTarget, StopReason, TextCell, TextSurfaceInfo,
+    TextSurfaceInspector,
+};
+
+use super::{AutomationSession, INPUT_DRAIN_INTERVAL_TICKS, OpError};
+
+/// A parsed `wait-for-text` predicate.
+pub(crate) struct TextMatch {
+    /// The surface identifier to inspect.
+    pub(crate) surface: String,
+    /// A single row to scan, or `None` to scan the whole screen.
+    pub(crate) row: Option<u16>,
+    /// The substring that must appear for the wait to succeed.
+    pub(crate) contains: String,
+}
+
+/// Maps a text-inspection failure to the automation error contract.
+fn map_text_error(error: InspectError) -> OpError {
+    match error {
+        InspectError::UnknownSpace => {
+            OpError::Argument("unknown text surface identifier".to_owned())
+        }
+        InspectError::OutOfRange => OpError::Range,
+        InspectError::UnknownProcessor
+        | InspectError::UnknownRegister
+        | InspectError::NotWritable
+        | InspectError::NotPeekable
+        | InspectError::Unsupported => {
+            OpError::Unsupported("operation is not supported by this text surface".to_owned())
+        }
+    }
+}
+
+/// Renders a row of decoded cells to a UTF-8 string, collapsing full-width
+/// continuation cells and mapping unmapped codes to a space.
+fn text_cells_to_string(cells: &[TextCell]) -> String {
+    let mut output = String::with_capacity(cells.len());
+    let mut skip_continuation = false;
+    for cell in cells {
+        if skip_continuation {
+            skip_continuation = false;
+            continue;
+        }
+        match cell.unicode {
+            Some(character) => output.push(character),
+            None => output.push(' '),
+        }
+        if cell.display_width == 2 {
+            skip_continuation = true;
+        }
+    }
+    output
+}
+
+/// Renders a full decoded screen to UTF-8 rows joined by newlines, trimming
+/// trailing spaces from each row.
+fn text_screen_to_string(rows: &[Vec<TextCell>]) -> String {
+    let mut output = String::new();
+    for (index, row) in rows.iter().enumerate() {
+        if index > 0 {
+            output.push('\n');
+        }
+        let line = text_cells_to_string(row);
+        output.push_str(line.trim_end());
+    }
+    output
+}
+
+impl AutomationSession {
+    /// Returns the text inspector, or the precondition failure that blocks it.
+    fn text_inspector(&self) -> Result<&dyn TextSurfaceInspector, OpError> {
+        let machine = &self.active.as_ref().ok_or(OpError::NoMachine)?.machine;
+        machine.text_inspector().ok_or_else(|| {
+            OpError::Unsupported("machine does not support text inspection".to_owned())
+        })
+    }
+
+    /// Returns whether this machine exposes a text inspector.
+    pub fn supports_text_inspection(&self) -> bool {
+        self.text_inspector().is_ok()
+    }
+
+    /// Returns the identifiers of every inspectable text surface.
+    pub fn text_surfaces(&self) -> Result<Vec<&'static str>, OpError> {
+        let inspector = self.text_inspector()?;
+        Ok(inspector
+            .text_surfaces()
+            .iter()
+            .map(|info| info.id)
+            .collect())
+    }
+
+    /// Returns the geometry of one text surface.
+    pub fn text_surface_info(&self, surface: &str) -> Result<TextSurfaceInfo, OpError> {
+        self.text_inspector()?
+            .text_surface_info(surface)
+            .map_err(map_text_error)
+    }
+
+    /// Decodes one text cell of a surface.
+    pub fn text_cell(&self, surface: &str, row: u16, column: u16) -> Result<TextCell, OpError> {
+        self.text_inspector()?
+            .text_cell(surface, row, column)
+            .map_err(map_text_error)
+    }
+
+    /// Decodes every row of a surface, top to bottom.
+    pub fn text_screen(&self, surface: &str) -> Result<Vec<Vec<TextCell>>, OpError> {
+        self.text_inspector()?
+            .text_screen(surface)
+            .map_err(map_text_error)
+    }
+
+    /// Decodes every row of a surface to a UTF-8 line string, in order.
+    pub fn text_screen_lines(&self, surface: &str) -> Result<Vec<String>, OpError> {
+        let rows = self.text_screen(surface)?;
+        Ok(rows.iter().map(|row| text_cells_to_string(row)).collect())
+    }
+
+    /// Decodes a surface to UTF-8 rows and writes it to an artifact.
+    pub fn save_text_screen(
+        &mut self,
+        surface: &str,
+        path: &str,
+    ) -> Result<std::path::PathBuf, OpError> {
+        let rows = self.text_screen(surface)?;
+        let text = text_screen_to_string(&rows);
+        self.write_artifact(path, text.as_bytes())
+    }
+
+    /// Returns the matched text when the predicate holds on the current screen.
+    fn text_matches(&self, predicate: &TextMatch) -> Result<Option<String>, OpError> {
+        let inspector = self.text_inspector()?;
+        let haystack = match predicate.row {
+            Some(row) => {
+                let cells = inspector
+                    .text_row(&predicate.surface, row)
+                    .map_err(map_text_error)?;
+                text_cells_to_string(&cells)
+            }
+            None => {
+                let rows = inspector
+                    .text_screen(&predicate.surface)
+                    .map_err(map_text_error)?;
+                text_screen_to_string(&rows)
+            }
+        };
+        if haystack.contains(&predicate.contains) {
+            Ok(Some(haystack))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Drives the machine one frame at a time until the predicate matches or the
+    /// explicit bounds are exhausted, returning the matched text on success.
+    ///
+    /// The live text plane is decoded once up front and then after every frame,
+    /// so matching happens at frame granularity. Text that appears and vanishes
+    /// within a single frame is not observed.
+    pub(crate) fn wait_for_text(
+        &mut self,
+        predicate: TextMatch,
+        max_frames: u64,
+        max_ticks: u64,
+    ) -> Result<Option<String>, OpError> {
+        self.text_surface_info(&predicate.surface)?;
+        if let Some(text) = self.text_matches(&predicate)? {
+            return Ok(Some(text));
+        }
+        let mut presented = 0u64;
+        let mut remaining_ticks = max_ticks;
+        loop {
+            if self.is_stopped() {
+                return Ok(None);
+            }
+            if presented >= max_frames
+                || remaining_ticks == 0
+                || self.tick_budget_exhausted()
+                || self.frame_budget_exhausted()
+            {
+                return Ok(None);
+            }
+            let request = RunRequest {
+                target: RunTarget::Frames(1),
+                max_ticks: remaining_ticks,
+                audio_drain_interval_ticks: INPUT_DRAIN_INTERVAL_TICKS,
+            };
+            let outcome = self
+                .active
+                .as_mut()
+                .expect("machine present")
+                .machine
+                .run_automation(request);
+            self.consume_budget(&outcome);
+            remaining_ticks = remaining_ticks.saturating_sub(outcome.ticks);
+            presented = presented.saturating_add(outcome.frames);
+            if outcome.stop_reason == StopReason::GuestShutdown {
+                return Err(OpError::GuestShutdown);
+            }
+            if let Some(text) = self.text_matches(&predicate)? {
+                return Ok(Some(text));
+            }
+        }
+    }
+}

--- a/crates/automation/src/session/trace.rs
+++ b/crates/automation/src/session/trace.rs
@@ -7,9 +7,12 @@
 //! re-entering Scheme.
 
 use common::{
-    RunRequest, RunTarget, StopReason, TraceCatalog, TraceContext, TraceEvent, TraceEventClass,
-    TraceInterest,
-    tracing::{ApplicationTraceEnvelope, TraceDecision, TraceFailure, TraceHandle, TraceMatcher},
+    RunRequest, RunTarget, StopReason, TraceActionCatalog, TraceCatalog, TraceContext, TraceEvent,
+    TraceEventClass, TraceFieldDescriptor, TraceFieldType, TraceInterest, TraceValue,
+    tracing::{
+        ApplicationTraceEnvelope, DeviceInterest, RingCaptureStatus, TraceDecision, TraceFailure,
+        TraceHandle, TraceMatcher,
+    },
 };
 
 use super::{AutomationSession, INPUT_DRAIN_INTERVAL_TICKS, OpError};
@@ -25,6 +28,12 @@ pub(crate) enum SchemaType {
     Boolean,
     /// An exact integer or `#f` when unavailable.
     IntegerOrFalse,
+    /// A stable identifier symbol or `#f` when unavailable.
+    SymbolOrFalse,
+    /// A byte group.
+    Bytes,
+    /// A list of exact integers.
+    IntegerList,
     /// A nested association list.
     Alist,
 }
@@ -37,7 +46,23 @@ impl SchemaType {
             SchemaType::Integer => "integer",
             SchemaType::Boolean => "boolean",
             SchemaType::IntegerOrFalse => "integer-or-false",
+            SchemaType::SymbolOrFalse => "symbol-or-false",
+            SchemaType::Bytes => "bytevector",
+            SchemaType::IntegerList => "integer-list",
             SchemaType::Alist => "alist",
+        }
+    }
+
+    /// Maps a catalog field type to a schema type.
+    pub(crate) fn from_field_type(field_type: TraceFieldType) -> Self {
+        match field_type {
+            TraceFieldType::Symbol => SchemaType::Symbol,
+            TraceFieldType::Integer => SchemaType::Integer,
+            TraceFieldType::Boolean => SchemaType::Boolean,
+            TraceFieldType::IntegerOrFalse => SchemaType::IntegerOrFalse,
+            TraceFieldType::SymbolOrFalse => SchemaType::SymbolOrFalse,
+            TraceFieldType::Bytes => SchemaType::Bytes,
+            TraceFieldType::U16List => SchemaType::IntegerList,
         }
     }
 
@@ -49,12 +74,30 @@ impl SchemaType {
                 | SchemaType::Integer
                 | SchemaType::Boolean
                 | SchemaType::IntegerOrFalse
+                | SchemaType::SymbolOrFalse
+                | SchemaType::Bytes
+                | SchemaType::IntegerList
         )
     }
 
-    /// Returns whether this field carries an integer value for comparison.
+    /// Returns whether this field accepts an integer constraint.
+    ///
+    /// An integer constraint on an integer-list field matches by containment.
     fn integral(self) -> bool {
-        matches!(self, SchemaType::Integer | SchemaType::IntegerOrFalse)
+        matches!(
+            self,
+            SchemaType::Integer | SchemaType::IntegerOrFalse | SchemaType::IntegerList
+        )
+    }
+
+    /// Returns whether this field accepts a symbol value.
+    fn symbolic(self) -> bool {
+        matches!(self, SchemaType::Symbol | SchemaType::SymbolOrFalse)
+    }
+
+    /// Returns whether this field accepts a Boolean-false value for absence.
+    fn falseable(self) -> bool {
+        matches!(self, SchemaType::IntegerOrFalse | SchemaType::SymbolOrFalse)
     }
 }
 
@@ -125,6 +168,11 @@ pub(crate) const ENVELOPE_FIELDS: &[FieldSchema] = &[
     },
     FieldSchema {
         name: "data",
+        ty: SchemaType::Alist,
+        range: false,
+    },
+    FieldSchema {
+        name: "snapshot",
         ty: SchemaType::Alist,
         range: false,
     },
@@ -340,6 +388,8 @@ pub(crate) enum FilterScalar {
     Boolean(bool),
     /// An inclusive numeric range.
     Range(i128, i128),
+    /// A byte-group match.
+    Bytes(Vec<u8>),
 }
 
 /// A parsed but unvalidated declarative filter, produced by the native layer.
@@ -348,6 +398,8 @@ pub(crate) struct FilterSpec {
     pub(crate) top: Vec<(String, FilterScalar)>,
     /// The nested `data` alist, when present.
     pub(crate) data: Option<Vec<(String, FilterScalar)>>,
+    /// The nested `data.fields` alist of provider-specific field constraints.
+    pub(crate) fields: Option<Vec<(String, FilterScalar)>>,
 }
 
 /// A compiled constraint bound to a static field name.
@@ -356,6 +408,7 @@ enum Constraint {
     Integer(&'static str, i128),
     Boolean(&'static str, bool),
     Range(&'static str, i128, i128),
+    Bytes(&'static str, Vec<u8>),
 }
 
 impl Constraint {
@@ -365,19 +418,34 @@ impl Constraint {
             Constraint::Symbol(name, _)
             | Constraint::Integer(name, _)
             | Constraint::Boolean(name, _)
-            | Constraint::Range(name, ..) => name,
+            | Constraint::Range(name, ..)
+            | Constraint::Bytes(name, _) => name,
         }
     }
 
     /// Returns whether `value` satisfies this constraint.
+    ///
+    /// An integer or range constraint on an integer-list field matches when
+    /// any list element satisfies it.
     fn matches(&self, value: FieldValue<'_>) -> bool {
         match (self, value) {
             (Constraint::Symbol(_, expected), FieldValue::Symbol(actual)) => actual == expected,
             (Constraint::Integer(_, expected), FieldValue::Integer(actual)) => actual == *expected,
             (Constraint::Boolean(_, expected), FieldValue::Boolean(actual)) => actual == *expected,
+            // A `#f` constraint matches a falseable field that has no value.
+            (Constraint::Boolean(_, false), FieldValue::Absent) => true,
             (Constraint::Range(_, low, high), FieldValue::Integer(actual)) => {
                 actual >= *low && actual <= *high
             }
+            (Constraint::Bytes(_, expected), FieldValue::Bytes(actual)) => {
+                actual == expected.as_slice()
+            }
+            (Constraint::Integer(_, expected), FieldValue::U16List(actual)) => actual
+                .iter()
+                .any(|&element| i128::from(element) == *expected),
+            (Constraint::Range(_, low, high), FieldValue::U16List(actual)) => actual
+                .iter()
+                .any(|&element| i128::from(element) >= *low && i128::from(element) <= *high),
             _ => false,
         }
     }
@@ -389,6 +457,8 @@ enum FieldValue<'a> {
     Symbol(&'a str),
     Integer(i128),
     Boolean(bool),
+    Bytes(&'a [u8]),
+    U16List(&'a [u16]),
     /// The field exists for this class but has no value (`#f`).
     Absent,
 }
@@ -398,6 +468,7 @@ pub(crate) struct CompiledFilter {
     class: Option<TraceEventClass>,
     top: Vec<Constraint>,
     data: Vec<Constraint>,
+    fields: Vec<Constraint>,
     one_shot: bool,
     matched: bool,
 }
@@ -412,6 +483,27 @@ impl CompiledFilter {
             Some(class) => TraceInterest::only(class),
             None => emitted,
         }
+    }
+
+    /// Returns the device and action this filter can match, or `None` when it
+    /// can match any device.
+    ///
+    /// Restricting interest to the named device, and to the named action when
+    /// one is fixed, lets emitters skip building high-volume events for every
+    /// other device and for sibling actions of the same device.
+    fn device_interest(&self) -> Option<Vec<DeviceInterest>> {
+        if self.class != Some(TraceEventClass::Device) {
+            return None;
+        }
+        let device = self.data.iter().find_map(|constraint| match constraint {
+            Constraint::Symbol("device", value) => Some(value.clone()),
+            _ => None,
+        })?;
+        let action = self.data.iter().find_map(|constraint| match constraint {
+            Constraint::Symbol("action", value) => Some(value.clone()),
+            _ => None,
+        });
+        Some(vec![DeviceInterest { device, action }])
     }
 
     /// Returns whether an event satisfies every constraint.
@@ -433,8 +525,51 @@ impl CompiledFilter {
                 _ => return false,
             }
         }
+        for constraint in &self.fields {
+            match event_field_value(event, constraint.field()) {
+                Some(value) if constraint.matches(value) => {}
+                _ => return false,
+            }
+        }
         true
     }
+}
+
+/// The outcome of a triggered ring capture run.
+pub(crate) struct RingCaptureOutcome {
+    /// Retained envelopes in sequence order, trigger event included.
+    pub(crate) events: Vec<ApplicationTraceEnvelope>,
+    /// Whether the trigger event was seen.
+    pub(crate) triggered: bool,
+    /// Whether the post-trigger context completed.
+    pub(crate) complete: bool,
+    /// Index of the trigger event within `events`, when triggered.
+    pub(crate) trigger_index: Option<usize>,
+    /// The sticky trace failure that ended the capture, when one occurred.
+    ///
+    /// The retained context up to the failure stays available in `events`, so
+    /// a caller can persist the partial window before reporting the failure.
+    pub(crate) failure: Option<TraceFailure>,
+}
+
+/// Combines the device interest of the capture and trigger filters.
+///
+/// `None` keeps every device the interest classes cover.
+fn union_device_interest(
+    capture: &CompiledFilter,
+    trigger: &CompiledFilter,
+) -> Option<Vec<DeviceInterest>> {
+    let mut entries = Vec::new();
+    for filter in [capture, trigger] {
+        match filter.class {
+            Some(TraceEventClass::Device) => {
+                entries.extend(filter.device_interest()?);
+            }
+            Some(_) => {}
+            None => return None,
+        }
+    }
+    Some(entries)
 }
 
 impl TraceMatcher for CompiledFilter {
@@ -585,6 +720,26 @@ fn data_field<'a>(event: TraceEvent<'a>, key: &str) -> Option<FieldValue<'a>> {
     }
 }
 
+/// Resolves a provider-specific device or call field to its runtime value.
+fn event_field_value<'a>(event: TraceEvent<'a>, key: &str) -> Option<FieldValue<'a>> {
+    let fields = match event {
+        TraceEvent::Device(device) => device.fields,
+        TraceEvent::Call(call) => call.fields,
+        _ => return None,
+    };
+    let field = fields.iter().find(|field| field.name == key)?;
+    Some(match field.value {
+        TraceValue::Unsigned(value) => FieldValue::Integer(i128::from(value)),
+        TraceValue::Signed(value) => FieldValue::Integer(i128::from(value)),
+        TraceValue::Bool(value) => FieldValue::Boolean(value),
+        TraceValue::Symbol(value) => FieldValue::Symbol(value),
+        TraceValue::Bytes(value) => FieldValue::Bytes(value),
+        TraceValue::U16List(value) => FieldValue::U16List(value),
+        TraceValue::Text(_) => FieldValue::Absent,
+        _ => FieldValue::Absent,
+    })
+}
+
 /// Looks up a field descriptor in a table by name.
 fn find_field<'a>(fields: &'a [FieldSchema], name: &str) -> Option<&'a FieldSchema> {
     fields.iter().find(|field| field.name == name)
@@ -607,7 +762,7 @@ fn build_constraint(field: &FieldSchema, scalar: FilterScalar) -> Result<Constra
     }
     match scalar {
         FilterScalar::Symbol(value) => {
-            if field.ty == SchemaType::Symbol {
+            if field.ty.symbolic() {
                 Ok(Constraint::Symbol(field.name, value))
             } else {
                 Err(type_mismatch(field, "symbol"))
@@ -616,6 +771,8 @@ fn build_constraint(field: &FieldSchema, scalar: FilterScalar) -> Result<Constra
         FilterScalar::Boolean(value) => {
             if field.ty == SchemaType::Boolean {
                 Ok(Constraint::Boolean(field.name, value))
+            } else if field.ty.falseable() && !value {
+                Ok(Constraint::Boolean(field.name, false))
             } else {
                 Err(type_mismatch(field, "boolean"))
             }
@@ -642,6 +799,13 @@ fn build_constraint(field: &FieldSchema, scalar: FilterScalar) -> Result<Constra
             }
             Ok(Constraint::Range(field.name, low, high))
         }
+        FilterScalar::Bytes(value) => {
+            if field.ty == SchemaType::Bytes {
+                Ok(Constraint::Bytes(field.name, value))
+            } else {
+                Err(type_mismatch(field, "bytevector"))
+            }
+        }
     }
 }
 
@@ -667,10 +831,15 @@ fn reject_duplicate(seen: &mut Vec<&'static str>, name: &'static str) -> Result<
 }
 
 /// Compiles a declarative filter, validating it against the schema up front.
-fn compile_filter(spec: FilterSpec, one_shot: bool) -> Result<CompiledFilter, OpError> {
+fn compile_filter(
+    spec: FilterSpec,
+    one_shot: bool,
+    catalog: &TraceCatalog,
+) -> Result<CompiledFilter, OpError> {
     let mut class = None;
     let mut top = Vec::new();
     let mut data = Vec::new();
+    let mut fields = Vec::new();
     let mut seen_top: Vec<&'static str> = Vec::new();
 
     for (key, scalar) in spec.top {
@@ -698,12 +867,46 @@ fn compile_filter(spec: FilterSpec, one_shot: bool) -> Result<CompiledFilter, Op
         top.push(build_constraint(field, scalar)?);
     }
 
+    let mut device_name = None;
+    let mut action_name = None;
+    let mut provider_name = None;
     if let Some(entries) = spec.data {
         let mut seen_data: Vec<&'static str> = Vec::new();
         for (key, scalar) in entries {
             let field = resolve_data_field(class, &key)?;
             reject_duplicate(&mut seen_data, field.name)?;
+            if let FilterScalar::Symbol(value) = &scalar {
+                match field.name {
+                    "device" => device_name = Some(value.clone()),
+                    "action" => action_name = Some(value.clone()),
+                    "provider" => provider_name = Some(value.clone()),
+                    _ => {}
+                }
+            }
             data.push(build_constraint(field, scalar)?);
+        }
+    }
+
+    if let Some(entries) = spec.fields {
+        let descriptors = resolve_field_descriptors(
+            catalog,
+            device_name.as_deref(),
+            action_name.as_deref(),
+            provider_name.as_deref(),
+        )?;
+        let mut seen_fields: Vec<&'static str> = Vec::new();
+        for (key, scalar) in entries {
+            let descriptor = descriptors
+                .iter()
+                .find(|descriptor| descriptor.name == key)
+                .ok_or_else(|| OpError::Argument(format!("unknown trace filter field '{key}'")))?;
+            let field = FieldSchema {
+                name: descriptor.name,
+                ty: SchemaType::from_field_type(descriptor.value_type),
+                range: descriptor.range,
+            };
+            reject_duplicate(&mut seen_fields, field.name)?;
+            fields.push(build_constraint(&field, scalar)?);
         }
     }
 
@@ -711,9 +914,51 @@ fn compile_filter(spec: FilterSpec, one_shot: bool) -> Result<CompiledFilter, Op
         class,
         top,
         data,
+        fields,
         one_shot,
         matched: false,
     })
+}
+
+/// Resolves the provider-specific field descriptors for a device action or a
+/// call provider named in the filter's `data` block.
+fn resolve_field_descriptors(
+    catalog: &TraceCatalog,
+    device: Option<&str>,
+    action: Option<&str>,
+    provider: Option<&str>,
+) -> Result<&'static [TraceFieldDescriptor], OpError> {
+    if let Some(device) = device {
+        let action = action.ok_or_else(|| {
+            OpError::Argument("trace filter 'fields' on a device requires 'action'".to_owned())
+        })?;
+        let device_catalog = catalog
+            .devices
+            .iter()
+            .find(|entry| entry.device == device)
+            .ok_or_else(|| OpError::Argument(format!("unknown trace device '{device}'")))?;
+        let action_catalog: &TraceActionCatalog = device_catalog
+            .actions
+            .iter()
+            .find(|entry| entry.action == action)
+            .ok_or_else(|| {
+                OpError::Argument(format!(
+                    "unknown trace action '{action}' for device '{device}'"
+                ))
+            })?;
+        Ok(action_catalog.fields)
+    } else if let Some(provider) = provider {
+        let provider_catalog = catalog
+            .providers
+            .iter()
+            .find(|entry| entry.provider == provider)
+            .ok_or_else(|| OpError::Argument(format!("unknown trace provider '{provider}'")))?;
+        Ok(provider_catalog.call_fields)
+    } else {
+        Err(OpError::Argument(
+            "trace filter 'fields' requires 'device' or 'provider' in 'data'".to_owned(),
+        ))
+    }
 }
 
 /// Resolves a data-field name against the constrained class, or the union of all
@@ -767,6 +1012,14 @@ impl AutomationSession {
             .ok_or(OpError::NoMachine)
     }
 
+    /// Returns the emitted-identifier catalog of the current machine.
+    fn machine_trace_catalog(&self) -> Result<TraceCatalog, OpError> {
+        self.active
+            .as_ref()
+            .map(|active| active.machine.trace_catalog())
+            .ok_or(OpError::NoMachine)
+    }
+
     /// Assembles the parts required to build the `trace-schema` descriptor.
     pub(crate) fn trace_schema_parts(&mut self) -> Result<TraceSchemaParts, OpError> {
         let catalog = self
@@ -809,12 +1062,15 @@ impl AutomationSession {
     /// Begins continuous collection with a compiled declarative filter.
     pub(crate) fn trace_start(&mut self, spec: FilterSpec) -> Result<(), OpError> {
         let classes = self.machine_trace_classes()?;
-        let filter = compile_filter(spec, false)?;
+        let catalog = self.machine_trace_catalog()?;
+        let filter = compile_filter(spec, false, &catalog)?;
         let interest = filter.interest(classes);
+        let device_interest = filter.device_interest();
         let active = self.active.as_mut().ok_or(OpError::NoMachine)?;
         let handle = active.trace.clone();
         active.trace_failure = None;
         handle.start(filter, interest);
+        handle.set_device_interest(device_interest);
         Ok(())
     }
 
@@ -839,6 +1095,12 @@ impl AutomationSession {
         Ok(handle.drain())
     }
 
+    /// Returns all buffered events in sequence order without draining them.
+    pub fn trace_snapshot(&self) -> Result<Vec<ApplicationTraceEnvelope>, OpError> {
+        let handle = &self.active.as_ref().ok_or(OpError::NoMachine)?.trace;
+        Ok(handle.snapshot_events())
+    }
+
     /// Returns the sticky trace collector failure, if any.
     pub fn trace_failure(&self) -> Result<Option<TraceFailure>, OpError> {
         let active = self.active.as_ref().ok_or(OpError::NoMachine)?;
@@ -855,6 +1117,7 @@ impl AutomationSession {
         spec: FilterSpec,
         max_frames: u64,
         max_ticks: u64,
+        snapshot_processors: Vec<String>,
     ) -> Result<Option<ApplicationTraceEnvelope>, OpError> {
         let handle = self
             .active
@@ -867,14 +1130,157 @@ impl AutomationSession {
                 "wait-for-event is invalid while a continuous trace is active".to_owned(),
             ));
         }
+        if snapshot_processors.len() > 1 {
+            return Err(OpError::Argument(
+                "snapshot supports exactly one processor".to_owned(),
+            ));
+        }
+        let mut resolved_processors = Vec::new();
+        for processor in &snapshot_processors {
+            resolved_processors.push(self.resolve_snapshot_processor(processor)?);
+        }
         let classes = self.machine_trace_classes()?;
-        let filter = compile_filter(spec, true)?;
+        let catalog = self.machine_trace_catalog()?;
+        let filter = compile_filter(spec, true, &catalog)?;
         let interest = filter.interest(classes);
+        let device_interest = filter.device_interest();
         self.active.as_mut().expect("machine present").trace_failure = None;
         handle.start(filter, interest);
+        handle.set_device_interest(device_interest);
+        if let Some(processor) = resolved_processors.first() {
+            handle.arm_snapshot(processor);
+        }
         let result = self.drive_wait(&handle, max_frames, max_ticks);
         handle.stop();
         result
+    }
+
+    /// Validates a requested snapshot processor and returns its stable id.
+    ///
+    /// Only main-CPU HLE-dispatch events carry a snapshot; other events return
+    /// `#f`.
+    fn resolve_snapshot_processor(&mut self, id: &str) -> Result<&'static str, OpError> {
+        let machine = &mut self.active.as_mut().ok_or(OpError::NoMachine)?.machine;
+        let inspector = machine.inspector().ok_or_else(|| {
+            OpError::Unsupported("machine does not support inspection".to_owned())
+        })?;
+        inspector
+            .processors()
+            .into_iter()
+            .find(|descriptor| descriptor.id == id)
+            .map(|descriptor| descriptor.id)
+            .ok_or_else(|| OpError::Argument(format!("unknown processor '{id}'")))
+    }
+
+    /// Runs a triggered bounded ring capture to completion.
+    ///
+    /// The capture and trigger filters are compiled and validated before the
+    /// machine runs. The machine is driven until the post-trigger context is
+    /// complete or the bounds are exhausted, and the retained events are
+    /// returned in sequence order. The capture is always disarmed on return.
+    pub(crate) fn trace_capture(
+        &mut self,
+        capture_spec: FilterSpec,
+        trigger_spec: FilterSpec,
+        before: u64,
+        after: u64,
+        max_frames: u64,
+        max_ticks: u64,
+    ) -> Result<RingCaptureOutcome, OpError> {
+        let handle = self
+            .active
+            .as_ref()
+            .ok_or(OpError::NoMachine)?
+            .trace
+            .clone();
+        if handle.is_active() {
+            return Err(OpError::TraceState(
+                "trace-arm! is invalid while a continuous trace is active".to_owned(),
+            ));
+        }
+        let limits = common::tracing::TraceLimits::default();
+        let window = before.saturating_add(after).saturating_add(1);
+        if window > limits.event_capacity.get() as u64 {
+            return Err(OpError::Argument(format!(
+                "trace-arm! window of {window} events exceeds the queue capacity of {}",
+                limits.event_capacity
+            )));
+        }
+        let classes = self.machine_trace_classes()?;
+        let catalog = self.machine_trace_catalog()?;
+        let capture = compile_filter(capture_spec, false, &catalog)?;
+        let trigger = compile_filter(trigger_spec, true, &catalog)?;
+        let interest = capture.interest(classes).union(trigger.interest(classes));
+        let device_interest = union_device_interest(&capture, &trigger);
+        self.active.as_mut().expect("machine present").trace_failure = None;
+        handle.arm_ring_capture(capture, trigger, before as usize, after as usize, interest);
+        handle.set_device_interest(device_interest);
+        let drive_result = self.drive_capture(&handle, max_frames, max_ticks);
+        let capture_result = handle.take_ring_capture();
+        handle.stop();
+        let failure = drive_result?;
+        let capture_result = capture_result.ok_or_else(|| {
+            OpError::TraceState("ring capture was disarmed while running".to_owned())
+        })?;
+        Ok(RingCaptureOutcome {
+            events: capture_result.events,
+            triggered: capture_result.triggered,
+            complete: capture_result.complete,
+            trigger_index: capture_result.trigger_index,
+            failure,
+        })
+    }
+
+    /// Drives the machine in single-frame chunks until the ring capture
+    /// completes or the bounds are exhausted.
+    ///
+    /// A sticky trace failure ends the run and is returned instead of raised,
+    /// so the caller can still persist the partially retained window.
+    fn drive_capture(
+        &mut self,
+        handle: &TraceHandle,
+        max_frames: u64,
+        max_ticks: u64,
+    ) -> Result<Option<TraceFailure>, OpError> {
+        let mut presented = 0u64;
+        let mut remaining_ticks = max_ticks;
+        loop {
+            if let Some(failure) = handle.failure() {
+                self.active.as_mut().expect("machine present").trace_failure = Some(failure);
+                handle.take_failure();
+                return Ok(Some(failure));
+            }
+            if handle.ring_status() == RingCaptureStatus::Complete {
+                return Ok(None);
+            }
+            if self.is_stopped() {
+                return Ok(None);
+            }
+            if presented >= max_frames
+                || remaining_ticks == 0
+                || self.tick_budget_exhausted()
+                || self.frame_budget_exhausted()
+            {
+                return Ok(None);
+            }
+            let request = RunRequest {
+                target: RunTarget::Frames(1),
+                max_ticks: remaining_ticks,
+                audio_drain_interval_ticks: INPUT_DRAIN_INTERVAL_TICKS,
+            };
+            let outcome = self
+                .active
+                .as_mut()
+                .expect("machine present")
+                .machine
+                .run_automation(request);
+            self.consume_budget(&outcome);
+            remaining_ticks = remaining_ticks.saturating_sub(outcome.ticks);
+            presented = presented.saturating_add(outcome.frames);
+            if outcome.stop_reason == StopReason::GuestShutdown {
+                return Err(OpError::GuestShutdown);
+            }
+        }
     }
 
     /// Drives the machine in single-frame chunks until the private collector

--- a/crates/automation/tests/common/harness.rs
+++ b/crates/automation/tests/common/harness.rs
@@ -138,9 +138,16 @@ pub struct Run {
 /// Runs a committed script through the executor with a private artifact root and
 /// collects its message stream.
 pub fn run_committed_script(name: &str, timeout_seconds: u64) -> Run {
-    // Keep artifacts out of the source tree, and start from a clean root so
-    // assertions on written artifacts see only this run's output.
-    let artifact_root = std::env::temp_dir().join("neetan-auto-tests").join(name);
+    // Keep artifacts out of the source tree, and give every invocation its own
+    // clean root so concurrently running tests of the same script never clear
+    // or read each other's artifacts.
+    static INVOCATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let invocation = INVOCATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let artifact_root = std::env::temp_dir().join("neetan-auto-tests").join(format!(
+        "{}-{}-{invocation}",
+        name,
+        std::process::id()
+    ));
     let _ = std::fs::remove_dir_all(&artifact_root);
     let mut config = CommonConfig::with_defaults();
     config.timeout_seconds = timeout_seconds;

--- a/crates/automation/tests/inspection.rs
+++ b/crates/automation/tests/inspection.rs
@@ -333,3 +333,16 @@ fn pc98_inspect_script_passes_end_to_end() {
         run.termination
     );
 }
+
+#[test]
+fn pc98_text_script_passes_end_to_end() {
+    let run = run_committed_script("pc98-text.scm", 60);
+    assert!(
+        matches!(
+            run.termination,
+            automation::RunTermination::Completed(automation::ExecutionResult::Ok)
+        ),
+        "expected pc98-text.scm to complete Ok, got {:?}",
+        run.termination
+    );
+}

--- a/crates/automation/tests/scripts/pc98-capture.scm
+++ b/crates/automation/tests/scripts/pc98-capture.scm
@@ -1,0 +1,104 @@
+;; PC-98 triggered bounded ring capture through (neetan trace 1).
+(import (scheme base)
+        (neetan automation 1)
+        (neetan trace 1)
+        (neetan test 1))
+
+;; Returns #t when thunk raises an error carrying the given neetan symbol.
+(define (raises? symbol thunk)
+  (guard (condition
+          (#t (and (error-object? condition)
+                   (memq symbol (error-object-irritants condition))
+                   #t)))
+    (thunk)
+    #f))
+
+;; Returns the value for key in an alist, or #f.
+(define (field key alist)
+  (let ((entry (assq key alist)))
+    (and entry (cdr entry))))
+
+(test-suite "PC-98 triggered ring capture"
+  (with-machine (machine '((target . pc98) (model . pc9801vm)))
+
+(test-case "trace-arm! validates its arguments before running"
+  ;; Missing required keys.
+  (check-true (raises? 'neetan/argument
+    (lambda () (trace-arm! machine '((capture . ()))))))
+  ;; Unknown option key.
+  (check-true (raises? 'neetan/argument
+    (lambda ()
+      (trace-arm! machine
+        '((capture . ()) (trigger . ()) (before . 1) (after . 1)
+          (artifact . "a.scm") (bogus . 1))))))
+  ;; An unknown provider-specific field in the trigger is rejected up front.
+  (check-true (raises? 'neetan/argument
+    (lambda ()
+      (trace-arm! machine
+        '((capture . ((class . scheduled)))
+          (trigger . ((class . device)
+                      (data . ((device . neetan.dos.stdout) (action . write)
+                               (fields . ((bogus . 1)))))))
+          (before . 4) (after . 4)
+          (artifact . "never.scm"))))))
+  ;; The artifact path is confined to the artifact root before the machine
+  ;; runs.
+  (check-true (raises? 'neetan/path-escape
+    (lambda ()
+      (trace-arm! machine
+        '((capture . ((class . scheduled)))
+          (trigger . ((class . presentation)))
+          (before . 1) (after . 1)
+          (artifact . "../escape.scm")))))))
+
+(test-case "triggered capture retains the before and after windows"
+  ;; Trigger on a presentation five frames ahead, so several frames of
+  ;; scheduled events precede the trigger and saturate the pre-window.
+  (let* ((sync (wait-for-event machine '((class . presentation))))
+         (target (+ (field 'frame (field 'data sync)) 5))
+         (result (trace-arm! machine
+                   (list (cons 'capture '((class . scheduled)))
+                         (cons 'trigger
+                               (list (cons 'class 'presentation)
+                                     (cons 'data (list (cons 'frame target)))))
+                         (cons 'before 4)
+                         (cons 'after 3)
+                         (cons 'artifact "capture.scm")))))
+    (check-true (field 'triggered result))
+    (check-true (field 'complete result))
+    ;; The pre-trigger window is full, the trigger event follows it, and
+    ;; exactly `after` events complete the capture.
+    (check-equal 4 (field 'trigger-index result))
+    (check-equal 8 (field 'events result))
+    (check-true (> (field 'bytes result) 0)))
+  ;; The capture disarms itself.
+  (check-false (trace-active? machine)))
+
+(test-case "an unfired trigger keeps storage bounded and writes no artifact"
+  (let ((result (trace-arm! machine
+                  '((capture . ((class . scheduled)))
+                    (trigger . ((class . device)
+                                (data . ((device . neetan.dos.vector)
+                                         (action . set)))))
+                    (before . 2)
+                    (after . 2)
+                    (frames . 2)
+                    (artifact . "untriggered.scm")))))
+    (check-false (field 'triggered result))
+    (check-false (field 'complete result))
+    (check-false (field 'trigger-index result))
+    (check-false (field 'bytes result))
+    ;; The pre-trigger ring stays bounded no matter how long the run is.
+    (check-true (<= (field 'events result) 2)))
+  (check-false (trace-active? machine)))
+
+(test-case "trace-arm! is invalid during continuous collection"
+  (trace-start! machine '((class . scheduled)))
+  (check-true (raises? 'neetan/trace-state
+    (lambda ()
+      (trace-arm! machine
+        '((capture . ((class . scheduled)))
+          (trigger . ((class . presentation)))
+          (before . 1) (after . 1)
+          (artifact . "blocked.scm"))))))
+  (trace-stop! machine))))

--- a/crates/automation/tests/scripts/pc98-console-diagnose.scm
+++ b/crates/automation/tests/scripts/pc98-console-diagnose.scm
@@ -1,0 +1,319 @@
+;; End-to-end coverage of the semantic PC-98 HLE DOS console trace events,
+;; proven entirely from structured trace values, processor snapshots, decoded
+;; text cells, and bounded artifacts.
+;;
+;; A synthetic COM program is injected into free conventional memory and run
+;; under the booted HLE DOS. It:
+;;   clears part of a line with ESC [ K and scrolls with ESC [ M,
+;;   emits ESC [ 7 m (SGR reverse video) then a normal glyph,
+;;   emits the two-byte PC-98 graphic 0x86 0x5F,
+;;   writes a recognizable buffer through INT 21h AH=40h,
+;;   installs an INT 29h -> IRET hook through INT 21h AH=25h,
+;;   repeats the AH=40h write, which the hook now suppresses,
+;;   then issues an AH=02h write that the hook also suppresses.
+;; The clear and scroll run first so the later glyph rows stay in place for
+;; the decoded text-surface cross-check.
+(import (scheme base)
+        (neetan automation 1)
+        (neetan trace 1)
+        (neetan inspect 1)
+        (neetan mutate 1)
+        (neetan test 1))
+
+;; The synthetic program, assembled by hand. Loaded at 0x3000:0x0100, so its
+;; linear base is 0x30100. "DIAG" sits at offset 0x0160 (linear 0x30160) and
+;; the IRET byte at offset 0x0164 (linear 0x30164).
+(define program
+  #u8(#xB4 #x02             ; MOV AH,02h
+      #xB2 #x1B #xCD #x21   ; DL=ESC  INT 21h
+      #xB2 #x5B #xCD #x21   ; DL='['  INT 21h
+      #xB2 #x4B #xCD #x21   ; DL='K'  INT 21h (clear line from cursor)
+      #xB2 #x1B #xCD #x21   ; DL=ESC  INT 21h
+      #xB2 #x5B #xCD #x21   ; DL='['  INT 21h
+      #xB2 #x4D #xCD #x21   ; DL='M'  INT 21h (delete line, scrolls up)
+      #xB2 #x1B #xCD #x21   ; DL=ESC  INT 21h
+      #xB2 #x5B #xCD #x21   ; DL='['  INT 21h
+      #xB2 #x37 #xCD #x21   ; DL='7'  INT 21h
+      #xB2 #x6D #xCD #x21   ; DL='m'  INT 21h
+      #xB2 #x58 #xCD #x21   ; DL='X'  INT 21h
+      #xB2 #x86 #xCD #x21   ; DL=0x86 INT 21h (Shift-JIS lead)
+      #xB2 #x5F #xCD #x21   ; DL=0x5F INT 21h (Shift-JIS trail)
+      #xBB #x01 #x00        ; MOV BX,0001h (stdout handle)
+      #xB9 #x04 #x00        ; MOV CX,0004h (length)
+      #xBA #x60 #x01        ; MOV DX,0160h ("DIAG")
+      #xB4 #x40 #xCD #x21   ; AH=40h INT 21h (write, console route)
+      #xB8 #x29 #x25        ; MOV AX,2529h (AH=25h AL=29h)
+      #xBA #x64 #x01        ; MOV DX,0164h (IRET byte)
+      #xCD #x21             ; INT 21h (set INT 29h vector)
+      #xBB #x01 #x00        ; MOV BX,0001h (stdout handle)
+      #xB9 #x04 #x00        ; MOV CX,0004h (length)
+      #xBA #x60 #x01        ; MOV DX,0160h ("DIAG")
+      #xB4 #x40 #xCD #x21   ; AH=40h INT 21h (write, suppressed by the hook)
+      #xB4 #x02             ; MOV AH,02h
+      #xB2 #x59 #xCD #x21   ; DL='Y' INT 21h (suppressed by the hook)
+      #xEB #xFE             ; JMP $
+      #x44 #x49 #x41 #x47   ; "DIAG"
+      #xCF))               ; IRET
+
+(define program-segment #x3000)
+(define program-linear #x30100)
+(define diag-linear #x30160)
+(define iret-linear #x30164)
+
+;; Returns the value for key in an alist, or #f.
+(define (field key alist)
+  (let ((entry (assq key alist)))
+    (and entry (cdr entry))))
+
+(define (data-of event) (field 'data event))
+(define (device-of event) (field 'device (data-of event)))
+(define (action-of event) (field 'action (data-of event)))
+(define (fields-of event) (field 'fields (data-of event)))
+
+;; Returns the first item for which predicate holds, or #f.
+(define (find-first predicate items)
+  (cond ((null? items) #f)
+        ((predicate (car items)) (car items))
+        (else (find-first predicate (cdr items)))))
+
+(define (device-event? event device action)
+  (and (eq? (device-of event) device)
+       (eq? (action-of event) action)))
+
+;; Returns #t when thunk raises an error carrying the given neetan symbol.
+(define (raises? symbol thunk)
+  (guard (condition
+          (#t (and (error-object? condition)
+                   (memq symbol (error-object-irritants condition))
+                   #t)))
+    (thunk)
+    #f))
+
+;; Injects the program and points the guest at its entry.
+(define (install-program! machine)
+  (memory-write-bytevector! machine 'cpu.main.memory program-linear program)
+  (register-set! machine 'cpu.main 'cs program-segment)
+  (register-set! machine 'cpu.main 'ds program-segment)
+  (register-set! machine 'cpu.main 'es program-segment)
+  (register-set! machine 'cpu.main 'ss program-segment)
+  (register-set! machine 'cpu.main 'sp #xFFFE)
+  (register-set! machine 'cpu.main 'ip #x0100))
+
+(test-suite "PC-98 console diagnose"
+
+  (with-machine (machine '((target . pc98) (model . pc9801vm)))
+    (test-case "semantic console events proven from structured trace values"
+      (run-frames! machine 30)
+      (install-program! machine)
+      (trace-start! machine '((class . device)))
+      (run-ticks! machine 2000000)
+      (trace-stop! machine)
+
+      ;; save-trace! writes the buffered events as Scheme data and is
+      ;; non-consuming, so the same events are still drainable below.
+      (check-true (> (field 'bytes (save-trace! machine "diagnose-trace.scm")) 0))
+
+      (let ((events (trace-drain! machine)))
+        (check-true (> (length events) 0))
+
+        ;; SGR reverse video is honoured, not ignored. The escape
+        ;; carries command sgr with parameter 7 and changes the attribute.
+        (let ((escape (find-first
+                        (lambda (event)
+                          (and (device-event? event 'neetan.dos.console 'escape)
+                               (eq? 'sgr (field 'command (fields-of event)))))
+                        events)))
+          (check-true (pair? escape))
+          (check-equal 'sgr (field 'command (fields-of escape)))
+          ;; Parameters are a list of exact integers, so the workflow shape
+          ;; (member 7 parameters) from the requirements works directly.
+          (check-equal '(7) (field 'parameters (fields-of escape)))
+          (check-true (and (member 7 (field 'parameters (fields-of escape))) #t))
+          (check-true (not (= (field 'attribute-before (fields-of escape))
+                              (field 'attribute-after (fields-of escape))))))
+
+        ;; The two-byte graphic 0x86 0x5F occupies one cell and
+        ;; advances the cursor one column, not two. The trailing byte event
+        ;; consumes the pending Shift-JIS lead and moves the cursor by one.
+        (let ((trail (find-first
+                       (lambda (event)
+                         (and (device-event? event 'neetan.dos.console 'byte)
+                              (equal? 95 (field 'byte (fields-of event)))))
+                       events)))
+          (check-true (pair? trail))
+          (check-equal 134 (field 'pending-shift-jis-lead-before (fields-of trail)))
+          (check-false (field 'pending-shift-jis-lead-after (fields-of trail)))
+          (check-equal 1 (- (field 'cursor-column-after (fields-of trail))
+                            (field 'cursor-column-before (fields-of trail)))))
+        (let ((cell (find-first
+                      (lambda (event)
+                        (and (device-event? event 'neetan.dos.console 'cell-write)
+                             (equal? 11072 (field 'jis (fields-of event)))))
+                      events)))
+          (check-true (pair? cell))
+          (check-equal 1 (field 'display-width (fields-of cell)))
+          ;; Cross-check the decoded surface: the traced cell agrees with a
+          ;; side-effect-free text-cell read of the same position.
+          (let ((decoded (text-cell machine 'display.main
+                                    (field 'row (fields-of cell))
+                                    (field 'column (fields-of cell)))))
+            (check-equal 11072 (field 'raw-jis decoded))
+            (check-equal (field 'attribute (fields-of cell))
+                         (field 'attribute decoded))))
+
+        ;; An INT 29h -> IRET hook suppresses console output. The
+        ;; vector-set event records the linear target, memory confirms the IRET
+        ;; opcode there, and the following write is routed to suppressed.
+        (let ((vector (find-first
+                        (lambda (event)
+                          (device-event? event 'neetan.dos.vector 'set))
+                        events)))
+          (check-true (pair? vector))
+          (check-equal 41 (field 'vector (fields-of vector)))
+          (check-equal iret-linear (field 'linear-address (fields-of vector)))
+          (check-equal #xCF
+                       (memory-peek-unsigned machine 'cpu.main.memory
+                                             iret-linear 1 'little)))
+        ;; The post-hook AH=40h write reports the suppressed route and the
+        ;; explicit IRET-hook reason, matching the required workflow shape.
+        (let ((suppressed-write (find-first
+                                  (lambda (event)
+                                    (and (device-event? event 'neetan.dos.stdout 'write)
+                                         (eq? 'int21.40 (field 'source (fields-of event)))
+                                         (eq? 'suppressed (field 'route (fields-of event)))))
+                                  events)))
+          (check-true (pair? suppressed-write))
+          (check-equal 1 (field 'handle (fields-of suppressed-write)))
+          (check-equal 'int29-iret-hook
+                       (field 'suppression-reason (fields-of suppressed-write)))
+          (check-equal #u8(68 73 65 71) (field 'bytes (fields-of suppressed-write))))
+        ;; The AH=02h write is suppressed too. It takes no handle argument, so
+        ;; the event reports the handle as #f.
+        (let ((suppressed-byte (find-first
+                                 (lambda (event)
+                                   (and (device-event? event 'neetan.dos.stdout 'write)
+                                        (eq? 'int21.02 (field 'source (fields-of event)))
+                                        (eq? 'suppressed (field 'route (fields-of event)))))
+                                 events)))
+          (check-true (pair? suppressed-byte))
+          (check-false (field 'handle (fields-of suppressed-byte)))
+          (check-equal 'int29-iret-hook
+                       (field 'suppression-reason (fields-of suppressed-byte)))
+          (check-equal #u8(89) (field 'bytes (fields-of suppressed-byte))))
+
+        ;; The pre-hook AH=40h write carries its handle, buffer address, count,
+        ;; bytes, and the console route.
+        (let ((write (find-first
+                       (lambda (event)
+                         (and (device-event? event 'neetan.dos.stdout 'write)
+                              (eq? 'int21.40 (field 'source (fields-of event)))
+                              (eq? 'console (field 'route (fields-of event)))))
+                       events)))
+          (check-true (pair? write))
+          (check-equal 1 (field 'handle (fields-of write)))
+          (check-equal diag-linear (field 'buffer-address (fields-of write)))
+          (check-equal 4 (field 'requested-count (fields-of write)))
+          (check-equal #u8(68 73 65 71) (field 'bytes (fields-of write))))
+
+        ;; Clear and scroll report the affected region as structured events,
+        ;; distinguishing text-plane operations from pixels drawn black.
+        (let ((clear (find-first
+                       (lambda (event)
+                         (device-event? event 'neetan.dos.console 'clear))
+                       events)))
+          (check-true (pair? clear))
+          (check-true (>= (field 'region-bottom (fields-of clear))
+                          (field 'region-top (fields-of clear))))
+          (check-true (> (field 'count (fields-of clear)) 0)))
+        (let ((scroll (find-first
+                        (lambda (event)
+                          (device-event? event 'neetan.dos.console 'scroll))
+                        events)))
+          (check-true (pair? scroll))
+          (check-true (>= (field 'region-bottom (fields-of scroll))
+                          (field 'region-top (fields-of scroll))))
+          (check-equal 1 (field 'count (fields-of scroll)))
+          (check-equal 1 (field 'direction (fields-of scroll)))))
+
+      ;; Bounded artifacts land under the artifact root and a `..` path is
+      ;; rejected before anything is written.
+      (check-true (> (field 'bytes
+                            (save-memory! machine 'cpu.main.memory iret-linear 1
+                                          "diagnose-iret.bin"))
+                     0))
+      (check-true (>= (field 'bytes
+                             (save-text-screen! machine 'display.main
+                                                "diagnose-text.txt"))
+                      0))
+      (check-true (raises? 'neetan/path-escape
+                           (lambda ()
+                             (save-memory! machine 'cpu.main.memory iret-linear 1
+                                           "../escape.bin"))))
+      (check-true (raises? 'neetan/path-escape
+                           (lambda ()
+                             (save-memory! machine 'cpu.main.memory iret-linear 1
+                                           "/tmp/escape.bin"))))))
+
+  (with-machine (machine '((target . pc98) (model . pc9801vm)))
+    (test-case "a #f constraint matches a falseable field with no value"
+      (run-frames! machine 30)
+      (install-program! machine)
+      ;; The AH=40h write routes to the console before the INT 29h hook is
+      ;; installed, so its falseable suppression-reason field is absent and a
+      ;; #f constraint selects it.
+      (let ((event (wait-for-event machine
+                     '((class . device)
+                       (data . ((device . neetan.dos.stdout) (action . write)
+                                (fields . ((source . int21.40)
+                                           (suppression-reason . #f))))))
+                     '((frames . 5)))))
+        (check-true (pair? event))
+        (check-equal 'console (field 'route (fields-of event)))
+        (check-false (field 'suppression-reason (fields-of event)))))
+
+    (test-case "entry snapshot exposes the syscall registers"
+      ;; The program continues from the matched write; the vector set follows.
+      ;; The snapshot is taken at HLE dispatch entry, so it exposes the guest
+      ;; AH=25h AL=29h and DS:DX arguments of the set-vector call.
+      ;; The nested `fields` block filters on the provider-specific vector field,
+      ;; so only the INT 29h (vector 41) set is matched.
+      (let* ((event (wait-for-event machine
+                      '((class . device)
+                        (data . ((device . neetan.dos.vector) (action . set)
+                                 (fields . ((vector . 41))))))
+                      '((snapshot . (cpu.main)) (frames . 5))))
+             (registers (field 'cpu.main (field 'snapshot event))))
+        (check-true (pair? event))
+        (check-true (pair? registers))
+        (check-equal #x2529 (field 'ax registers))
+        (check-equal #x0164 (field 'dx registers))
+        (check-equal program-segment (field 'ds registers))))
+
+    (test-case "call events accept provider field filters and carry snapshots"
+      ;; The next AH=40h call is the suppressed post-hook write. The provider
+      ;; field filter selects it by function number, and the boundary call
+      ;; event itself carries the entry snapshot, so BX, CX, and DS:DX of the
+      ;; write are readable regardless of what the handler clobbers.
+      (let* ((event (wait-for-event machine
+                      '((class . call)
+                        (data . ((provider . neetan.dos)
+                                 (phase . enter)
+                                 (fields . ((function . 64))))))
+                      '((snapshot . (cpu.main)) (frames . 5))))
+             (registers (field 'cpu.main (field 'snapshot event))))
+        (check-true (pair? event))
+        (check-equal 64 (field 'function (fields-of event)))
+        (check-true (pair? registers))
+        (check-equal 1 (field 'bx registers))
+        (check-equal 4 (field 'cx registers))
+        (check-equal #x0160 (field 'dx registers))
+        (check-equal program-segment (field 'ds registers))))
+
+    (test-case "non-HLE events carry no snapshot"
+      ;; A presentation event is not an HLE dispatch, so its snapshot is #f even
+      ;; when a snapshot processor is requested.
+      (let ((event (wait-for-event machine
+                     '((class . presentation))
+                     '((snapshot . (cpu.main)) (frames . 3)))))
+        (check-true (pair? event))
+        (check-false (field 'snapshot event))))))

--- a/crates/automation/tests/scripts/pc98-text.scm
+++ b/crates/automation/tests/scripts/pc98-text.scm
@@ -1,0 +1,81 @@
+;; PC-98 decoded text-surface inspection through the public (neetan inspect 1)
+;; library. Boots the HLE machine to its "Neetan DOS" banner and reads the
+;; decoded text surface: geometry, per-cell Unicode and raw attribute, whole
+;; screen rows, and wait-for-text stopping at the first match.
+(import (scheme base)
+        (neetan automation 1)
+        (neetan inspect 1)
+        (neetan test 1))
+
+;; Returns the value for key in an alist, or #f.
+(define (field key alist)
+  (let ((entry (assq key alist)))
+    (and entry (cdr entry))))
+
+;; Returns #t when the first string contains the second.
+(define (string-contains? haystack needle)
+  (let ((hn (string-length haystack)) (nn (string-length needle)))
+    (let loop ((start 0))
+      (cond ((> (+ start nn) hn) #f)
+            ((string=? (substring haystack start (+ start nn)) needle) #t)
+            (else (loop (+ start 1)))))))
+
+(test-suite "PC-98 text surface"
+  (with-machine (machine '((target . pc98) (model . pc9801vm)))
+    (test-case "surface discovery and geometry"
+      (check-equal '(display.main) (text-surfaces machine))
+      (let ((info (text-surface-info machine 'display.main)))
+        (check-equal 'display.main (field 'id info))
+        (check-equal 25 (field 'rows info))
+        (check-equal 80 (field 'columns info))))
+
+    (test-case "decoded cell exposes Unicode and the raw attribute"
+      (run-frames! machine 30)
+      ;; The banner begins with 'N' at the top-left cell.
+      (let ((cell (text-cell machine 'display.main 0 0)))
+        (check-equal 0 (field 'row cell))
+        (check-equal 0 (field 'column cell))
+        (check-equal 78 (field 'raw-jis cell))
+        (check-equal #\N (field 'unicode cell))
+        (check-equal 1 (field 'display-width cell))
+        (check-true (exact? (field 'attribute cell)))))
+
+    (test-case "decoded screen rows read left to right"
+      (let ((rows (text-screen machine 'display.main)))
+        (check-true (pair? rows))
+        (check-equal 25 (length rows))
+        (check-true (string-contains? (car rows) "Neetan DOS"))))
+
+    (test-case "wait-for-text stops at the first match"
+      ;; The banner is already present, so the wait returns the matched text.
+      (let ((matched (wait-for-text machine 'display.main
+                       '((row . 0) (contains . "Neetan DOS")))))
+        (check-true (string? matched))
+        (check-true (string-contains? matched "Neetan DOS")))
+      ;; A bare string is shorthand for ((contains . string)).
+      (let ((matched (wait-for-text machine 'display.main "Neetan DOS")))
+        (check-true (string? matched))
+        (check-true (string-contains? matched "Neetan DOS")))
+      ;; A substring that never appears exhausts the small frame bound and
+      ;; returns #f.
+      (check-false (wait-for-text machine 'display.main
+                     '((contains . "no-such-text-anywhere"))
+                     '((frames . 2)))))
+
+    (test-case "text errors follow the argument contract"
+      ;; An unknown surface is an argument error.
+      (check-true
+        (guard (condition (#t (and (error-object? condition)
+                                   (memq 'neetan/argument
+                                         (error-object-irritants condition))
+                                   #t)))
+          (text-surface-info machine 'display.other)
+          #f))
+      ;; An out-of-range cell is a range error.
+      (check-true
+        (guard (condition (#t (and (error-object? condition)
+                                   (memq 'neetan/range
+                                         (error-object-irritants condition))
+                                   #t)))
+          (text-cell machine 'display.main 99 0)
+          #f)))))

--- a/crates/automation/tests/scripts/pc98-trace.scm
+++ b/crates/automation/tests/scripts/pc98-trace.scm
@@ -35,6 +35,20 @@
       (let ((providers (map (lambda (entry) (field 'provider entry))
                             (field 'providers schema))))
         (check-true (and (memq 'neetan.dos providers) #t)))
+      ;; The envelope discovery lists the snapshot key.
+      (let ((names (map (lambda (entry) (field 'name entry))
+                        (field 'envelope-fields schema))))
+        (check-true (and (memq 'snapshot names) #t)))
+      ;; Call providers describe their provider-specific fields.
+      (let ((provider (let loop ((entries (field 'providers schema)))
+                        (cond ((null? entries) #f)
+                              ((eq? 'neetan.dos (field 'provider (car entries)))
+                               (car entries))
+                              (else (loop (cdr entries)))))))
+        (check-true (pair? provider))
+        (check-equal '(function subfunction result)
+                     (map (lambda (entry) (field 'name entry))
+                          (field 'call-fields provider))))
       ;; Queue limits are reported.
       (check-true (> (field 'event-capacity (field 'queue-limits schema)) 0))
       (set-cdr! (assq 'schema-version schema) 99)
@@ -107,6 +121,36 @@
                          (lambda ()
                          (trace-start! machine
                            '((data . ((address . (range 100 10))))))))))
+
+(test-case "nested field filters validate against the device schema"
+  ;; A valid nested field filter on a known device and action compiles.
+  (trace-start! machine
+    '((class . device)
+      (data . ((device . neetan.dos.console) (action . cell-write)
+               (fields . ((display-width . 1)))))))
+  (trace-stop! machine)
+  ;; An unknown provider-specific field name is rejected up front.
+  (check-true (raises? 'neetan/argument
+    (lambda ()
+      (trace-start! machine
+        '((class . device)
+          (data . ((device . neetan.dos.console) (action . cell-write)
+                   (fields . ((bogus-field . 1))))))))))
+  ;; A wrong-typed field constraint (symbol where an integer is required) is
+  ;; rejected.
+  (check-true (raises? 'neetan/argument
+    (lambda ()
+      (trace-start! machine
+        '((class . device)
+          (data . ((device . neetan.dos.console) (action . cell-write)
+                   (fields . ((display-width . not-an-integer))))))))))
+  ;; A nested field block without a device (and action) to fix the schema is
+  ;; rejected.
+  (check-true (raises? 'neetan/argument
+    (lambda ()
+      (trace-start! machine
+        '((class . device)
+          (data . ((fields . ((display-width . 1)))))))))))
 
 (test-case "wait-for-event options use the argument contract"
   (check-true

--- a/crates/automation/tests/scripts/reset-restore.scm
+++ b/crates/automation/tests/scripts/reset-restore.scm
@@ -1,5 +1,10 @@
 ;; Hard reset advances the epoch and resets epoch counters.
-(import (scheme base) (neetan automation 1) (neetan test 1))
+(import (scheme base) (neetan automation 1) (neetan trace 1) (neetan test 1))
+
+;; Returns the value for key in an alist, or #f.
+(define (field key alist)
+  (let ((entry (assq key alist)))
+    (and entry (cdr entry))))
 
 (test-suite "Reset and startup restoration"
   (with-machine (machine '((model . pc9801vm)))
@@ -15,6 +20,16 @@
       (if (< (machine-frame machine) frames-before)
           (fail "machine frames should stay monotonic across reset")))
 
+    ;; Trace envelopes carry the advanced epoch after a reset.
+    (let ((event (wait-for-event machine '((class . presentation)))))
+      (if (not (= (field 'epoch event) 1))
+          (fail "trace events should carry the post-reset epoch")))
+
     (restore-startup! machine)
     (if (not (= (machine-epoch machine) 2))
-        (fail "restore should reconstruct and advance the epoch")))))
+        (fail "restore should reconstruct and advance the epoch"))
+
+    ;; Trace envelopes carry the advanced epoch after a restore too.
+    (let ((event (wait-for-event machine '((class . presentation)))))
+      (if (not (= (field 'epoch event) 2))
+          (fail "trace events should carry the post-restore epoch"))))))

--- a/crates/automation/tests/scripts/save-state.scm
+++ b/crates/automation/tests/scripts/save-state.scm
@@ -1,5 +1,5 @@
 ;; Runtime save-state capture, restore, discard, and invalidation.
-(import (scheme base) (neetan automation 1) (neetan test 1))
+(import (scheme base) (neetan automation 1) (neetan trace 1) (neetan test 1))
 
 (define (expect-symbol name thunk symbol)
   (call/cc
@@ -48,6 +48,12 @@
           (fail "restore must rewind the tick counter"))
       (if (not (= (machine-frame machine) saved-frame))
           (fail "restore must rewind the frame counter"))
+
+      ;; Trace envelopes keep the unchanged epoch after an in-run restore.
+      (let ((event (wait-for-event machine '((class . presentation)))))
+        (let ((entry (assq 'epoch event)))
+          (if (or (not entry) (not (= (cdr entry) saved-epoch)))
+              (fail "trace events should carry the unchanged epoch after restore"))))
 
       ;; Discard invalidates the opaque state.
       (discard-state! state)

--- a/crates/automation/tests/tracing.rs
+++ b/crates/automation/tests/tracing.rs
@@ -13,6 +13,47 @@ mod harness;
 use automation::{ExecutionResult, RunTermination};
 use harness::run_committed_script;
 
+/// Parses every line of a Scheme trace artifact and returns the datum count.
+///
+/// Proves the artifact reads back with `read`, covering every serialized value
+/// type the events carry.
+fn count_artifact_datums(bytes: &[u8]) -> usize {
+    let text = String::from_utf8(bytes.to_vec()).expect("trace artifact is UTF-8");
+    let mut engine = r7rs::Engine::new(r7rs::EngineConfig::default()).expect("engine");
+    let mut reader = engine
+        .reader_from_str("trace-artifact", text)
+        .expect("reader");
+    let mut count = 0;
+    while reader.read_next().expect("artifact datum parses").is_some() {
+        count += 1;
+    }
+    count
+}
+
+/// Proves the artifact round-trips at value level, not just at parse level.
+///
+/// Every line is read back with the r7rs reader and re-rendered; the external
+/// form must reproduce the written line exactly, so symbols, exact integers,
+/// bytevectors, `#f` falseables, and nested alists all survive a read.
+fn assert_artifact_round_trips(bytes: &[u8]) {
+    let text = String::from_utf8(bytes.to_vec()).expect("trace artifact is UTF-8");
+    let mut engine = r7rs::Engine::new(r7rs::EngineConfig::default()).expect("engine");
+    for line in text.lines() {
+        let mut reader = engine
+            .reader_from_str("trace-artifact-line", line.to_owned())
+            .expect("reader");
+        let datum = reader
+            .read_next()
+            .expect("artifact datum parses")
+            .expect("artifact line holds a datum");
+        assert_eq!(
+            datum.to_external(),
+            line,
+            "reading an artifact datum back must preserve every value"
+        );
+    }
+}
+
 #[test]
 fn pc98_trace_script_passes() {
     let run = run_committed_script("pc98-trace.scm", 120);
@@ -30,6 +71,114 @@ fn pc98_trace_script_passes() {
 fn pc98_trace_script_is_deterministic() {
     let first = run_committed_script("pc98-trace.scm", 120);
     let second = run_committed_script("pc98-trace.scm", 120);
+    assert!(matches!(
+        first.termination,
+        RunTermination::Completed(ExecutionResult::Ok)
+    ));
+    assert!(matches!(
+        second.termination,
+        RunTermination::Completed(ExecutionResult::Ok)
+    ));
+    assert_eq!(first.exit_code, second.exit_code);
+}
+
+/// Drives the `pc98-console-diagnose.scm` fixture, proving the semantic HLE DOS
+/// console events (SGR reverse video, the one-cell two-byte graphic, INT 29h
+/// IRET-hook suppression, clear and scroll regions) from structured trace
+/// values, an entry snapshot, a decoded text cell, and bounded artifacts, with
+/// no emulator source changed for diagnostics.
+#[test]
+fn pc98_console_diagnose_script_passes() {
+    let run = run_committed_script("pc98-console-diagnose.scm", 120);
+    assert!(
+        matches!(
+            run.termination,
+            RunTermination::Completed(ExecutionResult::Ok)
+        ),
+        "console diagnose script did not pass: {:?}",
+        run.termination
+    );
+    // The memory artifact holds the exact guest bytes: the saved byte is the
+    // IRET opcode the script installed as the INT 29h handler.
+    let iret = std::fs::read(run.artifact_root.join("diagnose-iret.bin"))
+        .expect("memory artifact written");
+    assert_eq!(iret, [0xCF]);
+    // The trace artifact reads back with `read`, one datum per event, and the
+    // read-back values reproduce the written external form exactly.
+    let trace = std::fs::read(run.artifact_root.join("diagnose-trace.scm"))
+        .expect("trace artifact written");
+    assert!(count_artifact_datums(&trace) > 0);
+    assert_artifact_round_trips(&trace);
+    // Spot-check serialized value types against the known fixture events.
+    let text = String::from_utf8(trace).expect("trace artifact is UTF-8");
+    assert!(
+        text.contains("(suppression-reason . int29-iret-hook)"),
+        "the suppressed write's symbol field must serialize"
+    );
+    assert!(
+        text.contains("#u8(68 73 65 71)"),
+        "the DIAG write's byte field must serialize"
+    );
+    assert!(
+        text.contains("(parameters 7)"),
+        "the SGR escape's integer-list field must serialize"
+    );
+}
+
+/// Drives the `pc98-capture.scm` fixture twice, proving the triggered bounded
+/// ring capture end to end: up-front validation, path confinement, the before
+/// and after windows, bounded storage without a trigger, and a byte-identical
+/// artifact across identical runs.
+#[test]
+fn pc98_capture_script_passes_and_is_deterministic() {
+    let first = run_committed_script("pc98-capture.scm", 120);
+    assert!(
+        matches!(
+            first.termination,
+            RunTermination::Completed(ExecutionResult::Ok)
+        ),
+        "capture script did not pass: {:?}",
+        first.termination
+    );
+    let artifact = first.artifact_root.join("capture.scm");
+    let first_bytes = std::fs::read(&artifact).expect("capture artifact written");
+    assert_eq!(
+        count_artifact_datums(&first_bytes),
+        8,
+        "artifact must hold one datum per retained event"
+    );
+    assert!(
+        !first.artifact_root.join("untriggered.scm").exists(),
+        "an unfired trigger must not write an artifact"
+    );
+    assert!(
+        !first.artifact_root.join("escape.scm").exists()
+            && !first
+                .artifact_root
+                .parent()
+                .expect("artifact root parent")
+                .join("escape.scm")
+                .exists(),
+        "a rejected path must not be written"
+    );
+
+    let second = run_committed_script("pc98-capture.scm", 120);
+    assert!(matches!(
+        second.termination,
+        RunTermination::Completed(ExecutionResult::Ok)
+    ));
+    let second_bytes =
+        std::fs::read(second.artifact_root.join("capture.scm")).expect("capture artifact written");
+    assert_eq!(
+        first_bytes, second_bytes,
+        "identical runs must produce identical capture artifacts"
+    );
+}
+
+#[test]
+fn pc98_console_diagnose_script_is_deterministic() {
+    let first = run_committed_script("pc98-console-diagnose.scm", 120);
+    let second = run_committed_script("pc98-console-diagnose.scm", 120);
     assert!(matches!(
         first.termination,
         RunTermination::Completed(ExecutionResult::Ok)

--- a/crates/common/src/automation.rs
+++ b/crates/common/src/automation.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     Machine,
-    inspect::MachineInspector,
+    inspect::{MachineInspector, TextSurfaceInspector},
     trace::{TraceEventClass, TraceInterest},
 };
 
@@ -34,6 +34,14 @@ pub trait AutomatedMachine: Machine {
         None
     }
 
+    /// Returns the read-only decoded text-surface inspector, when supported.
+    ///
+    /// This borrows `&self` because text decoding is side-effect-free, unlike the
+    /// register and memory inspector. The default is `None`.
+    fn text_inspector(&self) -> Option<&dyn TextSurfaceInspector> {
+        None
+    }
+
     /// Asserts the documented machine reset mechanism, returning whether a real
     /// reset was performed.
     ///
@@ -48,13 +56,89 @@ pub trait AutomatedMachine: Machine {
     fn trace_catalog(&self) -> TraceCatalog;
 }
 
+/// The value type of a provider-specific trace field.
+///
+/// This drives schema discovery and up-front filter validation. A falseable
+/// type accepts its scalar value or Boolean false, used when an event omits a
+/// field such as a handle or a suppression reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraceFieldType {
+    /// A stable symbol value.
+    Symbol,
+    /// An unsigned or signed integer value.
+    Integer,
+    /// A Boolean value.
+    Boolean,
+    /// An integer value or Boolean false.
+    IntegerOrFalse,
+    /// A symbol value or Boolean false.
+    SymbolOrFalse,
+    /// A borrowed byte group.
+    Bytes,
+    /// A group of 16-bit integers, surfaced as an exact-integer list.
+    U16List,
+}
+
+/// One provider-specific trace field and its value type.
+#[derive(Debug, Clone, Copy)]
+pub struct TraceFieldDescriptor {
+    /// Stable field name.
+    pub name: &'static str,
+    /// Value type carried by the field.
+    pub value_type: TraceFieldType,
+    /// Whether an inclusive integer-range constraint is accepted.
+    pub range: bool,
+}
+
+/// Builds a field descriptor that accepts no integer-range constraint.
+#[must_use]
+pub const fn trace_field(name: &'static str, value_type: TraceFieldType) -> TraceFieldDescriptor {
+    TraceFieldDescriptor {
+        name,
+        value_type,
+        range: false,
+    }
+}
+
+/// Builds a field descriptor that also accepts an inclusive integer-range
+/// constraint.
+#[must_use]
+pub const fn trace_field_range(
+    name: &'static str,
+    value_type: TraceFieldType,
+) -> TraceFieldDescriptor {
+    TraceFieldDescriptor {
+        name,
+        value_type,
+        range: true,
+    }
+}
+
+/// One device or call action and the provider-specific fields it carries.
+#[derive(Debug, Clone, Copy)]
+pub struct TraceActionCatalog {
+    /// Stable action identifier.
+    pub action: &'static str,
+    /// Provider-specific fields carried by this action.
+    pub fields: &'static [TraceFieldDescriptor],
+}
+
+/// Builds an action catalog entry that carries no provider-specific fields.
+#[must_use]
+pub const fn trace_action(action: &'static str) -> TraceActionCatalog {
+    TraceActionCatalog {
+        action,
+        fields: &[],
+    }
+}
+
 /// A device identifier and the action identifiers a machine emits for it.
 #[derive(Debug, Clone, Copy)]
 pub struct TraceDeviceCatalog {
     /// Stable namespaced device identifier.
     pub device: &'static str,
-    /// Stable action identifiers emitted for this device.
-    pub actions: &'static [&'static str],
+    /// Actions emitted for this device with their provider-specific fields.
+    pub actions: &'static [TraceActionCatalog],
 }
 
 /// A call provider identifier and the named interface identifiers a machine emits.
@@ -65,6 +149,8 @@ pub struct TraceProviderCatalog {
     /// Stable named-interface identifiers, empty when only numeric interfaces are
     /// used.
     pub named_interfaces: &'static [&'static str],
+    /// Provider-specific fields carried by this provider's call events.
+    pub call_fields: &'static [TraceFieldDescriptor],
 }
 
 /// The stable trace identifiers a machine actually emits.

--- a/crates/common/src/inspect.rs
+++ b/crates/common/src/inspect.rs
@@ -7,10 +7,15 @@
 //! ([`Cpu`], [`CpuZ80`], [`CpuM68000`], [`Cpu6809`]),
 //! none of which is object-safe, so the helpers are generic free functions.
 
+use alloc::vec::Vec;
+
 use crate::{Cpu, Cpu6809, CpuM68000, CpuZ80, stack_vec::StackVec};
 
 /// Maximum inspectable processors a machine exposes (dual-CPU families).
 pub const MAX_PROCESSORS: usize = 2;
+
+/// Maximum inspectable text surfaces a machine exposes.
+pub const MAX_TEXT_SURFACES: usize = 2;
 
 /// Maximum inspectable address spaces a machine exposes (main and sub, each
 /// with a memory and an I/O space).
@@ -203,6 +208,59 @@ pub trait MachineInspector {
 
     /// Writes `bytes` to `space` at `address` through the memory decode.
     fn poke_memory(&mut self, space: &str, address: u64, bytes: &[u8]) -> Result<(), InspectError>;
+}
+
+/// A bounded, stack-allocated list of text-surface descriptors.
+pub type TextSurfaceList = StackVec<TextSurfaceInfo, MAX_TEXT_SURFACES>;
+
+/// Geometry of one inspectable text surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextSurfaceInfo {
+    /// Stable surface identifier, for example `"display.main"`.
+    pub id: &'static str,
+    /// Number of text rows.
+    pub rows: u16,
+    /// Number of text columns.
+    pub columns: u16,
+}
+
+/// One decoded text-mode cell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextCell {
+    /// Zero-based row.
+    pub row: u16,
+    /// Zero-based column.
+    pub column: u16,
+    /// Raw code as stored in the character plane.
+    pub raw_jis: u16,
+    /// Decoded Unicode character, when the code maps to one.
+    pub unicode: Option<char>,
+    /// Raw attribute byte from the attribute plane.
+    pub attribute: u8,
+    /// Display width in cells, 1 for half-width and 2 for full-width.
+    pub display_width: u8,
+}
+
+/// Read-only decoded text-surface inspection surface.
+///
+/// A machine implements this on itself and returns `Some(self)` from
+/// [`crate::AutomatedMachine::text_inspector`]. Every read is side-effect-free
+/// and decodes the current text VRAM without touching device state.
+pub trait TextSurfaceInspector {
+    /// Returns the text surfaces this machine exposes.
+    fn text_surfaces(&self) -> TextSurfaceList;
+
+    /// Returns the geometry of one surface, or an error when it is unknown.
+    fn text_surface_info(&self, surface: &str) -> Result<TextSurfaceInfo, InspectError>;
+
+    /// Decodes one cell of a surface.
+    fn text_cell(&self, surface: &str, row: u16, column: u16) -> Result<TextCell, InspectError>;
+
+    /// Decodes one full row of a surface, left to right.
+    fn text_row(&self, surface: &str, row: u16) -> Result<Vec<TextCell>, InspectError>;
+
+    /// Decodes every row of a surface, top to bottom.
+    fn text_screen(&self, surface: &str) -> Result<Vec<Vec<TextCell>>, InspectError>;
 }
 
 /// Adds a byte offset to a base address for a 16-bit space, reporting overflow

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -34,7 +34,8 @@ pub mod tracing;
 pub use automation::{
     AutomatedMachine, AutomationDescriptor, AutomationDriver, AutomationTimebase,
     AutomationTimeline, InputCapabilities, RunOutcome, RunRequest, RunTarget, StopReason,
-    TraceCatalog, TraceDeviceCatalog, TraceProviderCatalog, drive_automation,
+    TraceActionCatalog, TraceCatalog, TraceDeviceCatalog, TraceFieldDescriptor, TraceFieldType,
+    TraceProviderCatalog, drive_automation, trace_action, trace_field, trace_field_range,
 };
 pub use display::{FramebufferVa, HighResCursor, TownsLayer};
 pub use dos::{
@@ -46,7 +47,8 @@ pub use input::{HostKey, KeyModifiers};
 pub use inspect::{
     AddressSpaceClass, AddressSpaceDescriptor, AddressSpaceList, ByteOrder, DescriptorTableReading,
     InspectError, MachineInspector, ProcessorDescriptor, ProcessorList, ProtectedModeState,
-    RegisterDescriptor, RegisterReading, SegmentReading,
+    RegisterDescriptor, RegisterReading, SegmentReading, TextCell, TextSurfaceInfo,
+    TextSurfaceInspector, TextSurfaceList,
 };
 pub use jis::{
     JisChar, char_to_jis, is_shift_jis_lead_byte, is_shift_jis_trail_byte, jis_slice_to_string,
@@ -58,11 +60,11 @@ pub use stack_vec::StackVec;
 pub use text_extractor::TextExtractor;
 pub use trace::{
     NoTrace, OwnedTraceCall, OwnedTraceDeviceEvent, OwnedTraceEvent, OwnedTraceField,
-    OwnedTraceValue, TRACE_SCHEMA_VERSION, TraceAccess, TraceAccessKind, TraceAccessWidth,
-    TraceAddressSpace, TraceAddressSpaceClass, TraceCall, TraceCallInterface, TraceCallPhase,
-    TraceContext, TraceDeviceEvent, TraceEvent, TraceEventClass, TraceEventKey, TraceField,
-    TraceInterest, TraceInterrupt, TraceInterruptAction, TraceInterruptKind, TracePresentation,
-    TraceRate, TraceSink, TraceValue, trace_clock, trace_id, trace_source,
+    OwnedTraceValue, ProcessorSnapshot, TRACE_SCHEMA_VERSION, TraceAccess, TraceAccessKind,
+    TraceAccessWidth, TraceAddressSpace, TraceAddressSpaceClass, TraceCall, TraceCallInterface,
+    TraceCallPhase, TraceContext, TraceDeviceEvent, TraceEvent, TraceEventClass, TraceEventKey,
+    TraceField, TraceInterest, TraceInterrupt, TraceInterruptAction, TraceInterruptKind,
+    TracePresentation, TraceRate, TraceSink, TraceValue, trace_clock, trace_id, trace_source,
 };
 
 /// Built-in V98-format PC-98 font ROM used when no external font ROM is configured.
@@ -2102,8 +2104,10 @@ pub const fn unlikely(b: bool) -> bool {
 mod tests {
     use super::{
         Bus, CpuMode, M68000AccessSize, M68000BusAccess, M68000CycleKind, M68000FunctionCode,
-        Machine, MachineModel, MediaBacking, MediaImage, SaveStateError,
+        Machine, MachineModel, SaveStateError,
     };
+    #[cfg(feature = "std")]
+    use super::{MediaBacking, MediaImage};
 
     /// A machine that implements only the required [`Machine`] methods,
     /// verifying that machines without CD-ROM, hard disk, printer, or

--- a/crates/common/src/trace.rs
+++ b/crates/common/src/trace.rs
@@ -3,6 +3,8 @@
 use alloc::{string::String, vec::Vec};
 use core::num::NonZeroU64;
 
+use crate::inspect::RegisterReading;
+
 /// Version of the public tracing event schema.
 pub const TRACE_SCHEMA_VERSION: u16 = 1;
 
@@ -94,6 +96,12 @@ pub mod trace_id {
         pub const MSX_FDC: &str = "msx.fdc";
         /// MSX video processor.
         pub const MSX_VDP: &str = "msx.vdp";
+        /// HLE DOS interrupt-vector changes.
+        pub const NEETAN_DOS_VECTOR: &str = "neetan.dos.vector";
+        /// HLE DOS console-bound stdout routing decisions.
+        pub const NEETAN_DOS_STDOUT: &str = "neetan.dos.stdout";
+        /// HLE DOS console parser and screen operations.
+        pub const NEETAN_DOS_CONSOLE: &str = "neetan.dos.console";
     }
 
     /// High-level call provider identifiers.
@@ -128,6 +136,20 @@ pub mod trace_id {
         pub const BANK: &str = "bank";
         /// A video-processor event.
         pub const EVENT: &str = "event";
+        /// An interrupt-vector set operation.
+        pub const SET: &str = "set";
+        /// A console-bound stdout write.
+        pub const WRITE: &str = "write";
+        /// A single byte entering the console parser.
+        pub const BYTE: &str = "byte";
+        /// A complete escape sequence dispatched by the console.
+        pub const ESCAPE: &str = "escape";
+        /// A decoded character cell written to text VRAM.
+        pub const CELL_WRITE: &str = "cell-write";
+        /// A console clear operation.
+        pub const CLEAR: &str = "clear";
+        /// A console scroll operation.
+        pub const SCROLL: &str = "scroll";
     }
 
     /// Named call-interface identifiers.
@@ -184,6 +206,74 @@ pub mod trace_id {
         pub const VALUE: &str = "value";
         /// Video scanline number.
         pub const SCANLINE: &str = "scanline";
+        /// Interrupt vector number.
+        pub const VECTOR: &str = "vector";
+        /// A single console input byte value.
+        pub const BYTE: &str = "byte";
+        /// Interrupt-vector offset word.
+        pub const OFFSET: &str = "offset";
+        /// Interrupt-vector linear target address.
+        pub const LINEAR_ADDRESS: &str = "linear-address";
+        /// DOS API path that produced console output.
+        pub const SOURCE: &str = "source";
+        /// File handle, or false when the API supplied no handle.
+        pub const HANDLE: &str = "handle";
+        /// Output buffer linear address, or false for a single byte.
+        pub const BUFFER_ADDRESS: &str = "buffer-address";
+        /// Requested output byte count.
+        pub const REQUESTED_COUNT: &str = "requested-count";
+        /// Console output routing decision.
+        pub const ROUTE: &str = "route";
+        /// Reason output was suppressed, or false.
+        pub const SUPPRESSION_REASON: &str = "suppression-reason";
+        /// Active INT 29h handler segment.
+        pub const INT29_SEGMENT: &str = "int29-segment";
+        /// Active INT 29h handler offset.
+        pub const INT29_OFFSET: &str = "int29-offset";
+        /// Text cell row.
+        pub const ROW: &str = "row";
+        /// Text cell column.
+        pub const COLUMN: &str = "column";
+        /// Raw JIS character value of a written cell.
+        pub const JIS: &str = "jis";
+        /// Cell display width in columns.
+        pub const DISPLAY_WIDTH: &str = "display-width";
+        /// PC-98 text attribute byte.
+        pub const ATTRIBUTE: &str = "attribute";
+        /// Dispatched escape command identifier.
+        pub const COMMAND: &str = "command";
+        /// Console parser state before a byte.
+        pub const PARSER_STATE_BEFORE: &str = "parser-state-before";
+        /// Console parser state after a byte.
+        pub const PARSER_STATE_AFTER: &str = "parser-state-after";
+        /// Console character mode before a byte.
+        pub const CHARACTER_MODE_BEFORE: &str = "character-mode-before";
+        /// Console character mode after a byte.
+        pub const CHARACTER_MODE_AFTER: &str = "character-mode-after";
+        /// Pending Shift-JIS lead byte before a byte, or false.
+        pub const PENDING_SHIFT_JIS_LEAD_BEFORE: &str = "pending-shift-jis-lead-before";
+        /// Pending Shift-JIS lead byte after a byte, or false.
+        pub const PENDING_SHIFT_JIS_LEAD_AFTER: &str = "pending-shift-jis-lead-after";
+        /// Cursor row before an operation.
+        pub const CURSOR_ROW_BEFORE: &str = "cursor-row-before";
+        /// Cursor column before an operation.
+        pub const CURSOR_COLUMN_BEFORE: &str = "cursor-column-before";
+        /// Cursor row after an operation.
+        pub const CURSOR_ROW_AFTER: &str = "cursor-row-after";
+        /// Cursor column after an operation.
+        pub const CURSOR_COLUMN_AFTER: &str = "cursor-column-after";
+        /// Text attribute before an operation.
+        pub const ATTRIBUTE_BEFORE: &str = "attribute-before";
+        /// Text attribute after an operation.
+        pub const ATTRIBUTE_AFTER: &str = "attribute-after";
+        /// Top row of an affected console region.
+        pub const REGION_TOP: &str = "region-top";
+        /// Bottom row of an affected console region.
+        pub const REGION_BOTTOM: &str = "region-bottom";
+        /// Operation count for a clear or scroll.
+        pub const COUNT: &str = "count";
+        /// Scroll direction, positive for up.
+        pub const DIRECTION: &str = "direction";
     }
 
     /// Stable scheduled-event identifiers.
@@ -653,6 +743,10 @@ pub enum TraceValue<'a> {
     Bytes(&'a [u8]),
     /// Borrowed text.
     Text(&'a str),
+    /// A stable interned identifier, surfaced to clients as a symbol.
+    Symbol(&'static str),
+    /// A borrowed group of 16-bit integers, surfaced as an integer list.
+    U16List(&'a [u16]),
 }
 
 /// A named value attached to a trace event.
@@ -923,7 +1017,11 @@ impl TraceEvent<'_> {
                 let field_size = match field.value {
                     TraceValue::Bytes(value) => value.len(),
                     TraceValue::Text(value) => value.len(),
-                    TraceValue::Unsigned(_) | TraceValue::Signed(_) | TraceValue::Bool(_) => 0,
+                    TraceValue::U16List(value) => value.len().saturating_mul(2),
+                    TraceValue::Unsigned(_)
+                    | TraceValue::Signed(_)
+                    | TraceValue::Bool(_)
+                    | TraceValue::Symbol(_) => 0,
                 };
                 size.checked_add(field_size)
             })
@@ -1006,6 +1104,10 @@ pub enum OwnedTraceValue {
     Bytes(Vec<u8>),
     /// Owned text.
     Text(String),
+    /// A stable interned identifier, surfaced to clients as a symbol.
+    Symbol(&'static str),
+    /// An owned group of 16-bit integers, surfaced as an integer list.
+    U16List(Vec<u16>),
 }
 
 /// An owned named trace value.
@@ -1072,6 +1174,8 @@ impl<'a> From<TraceValue<'a>> for OwnedTraceValue {
             TraceValue::Bool(value) => Self::Bool(value),
             TraceValue::Bytes(value) => Self::Bytes(value.to_vec()),
             TraceValue::Text(value) => Self::Text(String::from(value)),
+            TraceValue::Symbol(value) => Self::Symbol(value),
+            TraceValue::U16List(value) => Self::U16List(value.to_vec()),
         }
     }
 }
@@ -1107,6 +1211,21 @@ impl<'a> From<TraceEvent<'a>> for OwnedTraceEvent {
     }
 }
 
+/// An atomic snapshot of one processor's registers captured at the creation of
+/// a trace event.
+///
+/// Registers are read into `RegisterReading` values with the same names and
+/// semantics as the machine inspector, so a snapshot register agrees with a
+/// separate `register-ref` read of the same processor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessorSnapshot {
+    /// Stable processor identifier the snapshot was taken for.
+    pub processor: &'static str,
+    /// Every advertised register of the processor, in descriptor order,
+    /// followed by extended protected-mode registers when supported.
+    pub registers: Vec<RegisterReading>,
+}
+
 /// Consumes trace events produced by an emulated machine.
 pub trait TraceSink {
     /// Whether this sink can observe events in this monomorphization.
@@ -1124,6 +1243,20 @@ pub trait TraceSink {
     fn yield_requested(&self) -> bool {
         false
     }
+
+    /// Returns the processor a register snapshot is armed for, or `None`.
+    ///
+    /// An emitter checks this cheaply before capturing registers, so no
+    /// snapshot work happens unless a client armed one.
+    fn snapshot_request(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// Stores a register snapshot to attach to subsequently recorded events.
+    fn set_pending_snapshot(&mut self, _snapshot: ProcessorSnapshot) {}
+
+    /// Clears the pending register snapshot after a dispatch completes.
+    fn clear_pending_snapshot(&mut self) {}
 }
 
 /// A no-op trace sink eliminated through static dispatch.
@@ -1160,13 +1293,24 @@ mod tests {
                 name: "text",
                 value: TraceValue::Text("value"),
             },
+            TraceField {
+                name: "route",
+                value: TraceValue::Symbol("suppressed"),
+            },
         ];
-        let owned = OwnedTraceEvent::from(TraceEvent::Device(TraceDeviceEvent {
+        let event = TraceEvent::Device(TraceDeviceEvent {
             device: "test.device",
             action: "test",
             fields: &fields,
-        }));
+        });
 
+        // A symbol is a static identifier, so it contributes no owned bytes.
+        assert_eq!(
+            event.owned_payload_bytes(),
+            Some(bytes.len() + "value".len())
+        );
+
+        let owned = OwnedTraceEvent::from(event);
         let OwnedTraceEvent::Device(device) = owned else {
             panic!("expected device event");
         };
@@ -1177,6 +1321,10 @@ mod tests {
         assert_eq!(
             device.fields[1].value,
             OwnedTraceValue::Text(String::from("value"))
+        );
+        assert_eq!(
+            device.fields[2].value,
+            OwnedTraceValue::Symbol("suppressed")
         );
     }
 

--- a/crates/common/src/tracing.rs
+++ b/crates/common/src/tracing.rs
@@ -8,7 +8,10 @@ use std::{
     rc::Rc,
 };
 
-use crate::{OwnedTraceEvent, TraceContext, TraceEvent, TraceEventKey, TraceInterest, TraceSink};
+use crate::{
+    OwnedTraceEvent, ProcessorSnapshot, TraceContext, TraceEvent, TraceEventKey, TraceInterest,
+    TraceSink,
+};
 
 /// Default number of owned events retained by an application trace queue.
 pub const DEFAULT_TRACE_QUEUE_EVENT_CAPACITY: usize = 16_384;
@@ -129,6 +132,59 @@ pub struct ApplicationTraceEnvelope {
     pub context: TraceContext,
     /// Owned event payload.
     pub event: OwnedTraceEvent,
+    /// Processor snapshot captured when the event was created, when armed.
+    pub snapshot: Option<ProcessorSnapshot>,
+}
+
+/// Progress of an armed ring capture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RingCaptureStatus {
+    /// No ring capture is armed.
+    Idle,
+    /// Armed, waiting for the trigger event.
+    Armed,
+    /// Triggered, collecting post-trigger context.
+    Triggered,
+    /// The requested post-trigger context is complete.
+    Complete,
+}
+
+/// The retained events of a disarmed ring capture.
+pub struct RingCaptureResult {
+    /// Retained envelopes in sequence order, trigger event included.
+    pub events: Vec<ApplicationTraceEnvelope>,
+    /// Whether the trigger event was seen.
+    pub triggered: bool,
+    /// Whether the post-trigger context completed.
+    pub complete: bool,
+    /// Index of the trigger event within `events`, when triggered.
+    pub trigger_index: Option<usize>,
+}
+
+/// A bounded before-and-after capture window around a trigger event.
+struct RingCaptureState {
+    capture: Rc<RefCell<Box<dyn TraceMatcher>>>,
+    trigger: Rc<RefCell<Box<dyn TraceMatcher>>>,
+    before: usize,
+    after: usize,
+    pre: VecDeque<(ApplicationTraceEnvelope, usize)>,
+    trigger_event: Option<ApplicationTraceEnvelope>,
+    post: Vec<ApplicationTraceEnvelope>,
+    retained_payload_bytes: usize,
+    complete: bool,
+}
+
+/// One device-interest entry: a device identifier and an optional action.
+///
+/// An entry with no action covers every action of the device; an entry with an
+/// action covers only that action, so sibling high-volume actions of the same
+/// device are never built.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceInterest {
+    /// Stable device identifier.
+    pub device: String,
+    /// Stable action identifier, or `None` for every action of the device.
+    pub action: Option<String>,
 }
 
 struct TraceState {
@@ -142,6 +198,10 @@ struct TraceState {
     failure: Option<TraceFailure>,
     presentation_yield_target: Option<u64>,
     presentation_boundary_reached: bool,
+    armed_snapshot: Option<&'static str>,
+    pending_snapshot: Option<ProcessorSnapshot>,
+    device_interest: Option<Vec<DeviceInterest>>,
+    ring: Option<RingCaptureState>,
 }
 
 impl TraceState {
@@ -156,7 +216,19 @@ impl TraceState {
             return;
         }
 
-        let Some(payload_bytes) = event.owned_payload_bytes() else {
+        let Some(event_payload_bytes) = event.owned_payload_bytes() else {
+            self.latch_failure(TraceFailure::EventPayloadTooLarge {
+                capacity: self.limits.event_payload_capacity,
+            });
+            return;
+        };
+        let snapshot_bytes = self.pending_snapshot.as_ref().map_or(0, |snapshot| {
+            snapshot
+                .registers
+                .len()
+                .saturating_mul(core::mem::size_of::<u128>())
+        });
+        let Some(payload_bytes) = event_payload_bytes.checked_add(snapshot_bytes) else {
             self.latch_failure(TraceFailure::EventPayloadTooLarge {
                 capacity: self.limits.event_payload_capacity,
             });
@@ -195,6 +267,7 @@ impl TraceState {
             epoch: self.epoch,
             context,
             event: OwnedTraceEvent::from(event),
+            snapshot: self.pending_snapshot.clone(),
         });
         self.next_sequence = next_sequence;
         self.queued_payload_bytes = next_payload_bytes;
@@ -204,7 +277,101 @@ impl TraceState {
     }
 
     fn yield_requested(&self) -> bool {
-        self.matcher_yield_requested || self.failure.is_some() || self.presentation_boundary_reached
+        self.matcher_yield_requested
+            || self.failure.is_some()
+            || self.presentation_boundary_reached
+            || self.ring.as_ref().is_some_and(|ring| ring.complete)
+    }
+
+    /// Stores one matched event into the armed ring capture.
+    ///
+    /// Retention is decided before the owned payload is allocated, so events
+    /// that would fall out of an empty pre-trigger window cost nothing. The
+    /// retained window is charged against the queue byte capacity, so a ring
+    /// capture honours the same advertised limits as the continuous queue.
+    fn ring_record(&mut self, context: TraceContext, event: TraceEvent<'_>, is_trigger: bool) {
+        let retain = match &self.ring {
+            None => return,
+            Some(ring) if ring.complete => return,
+            Some(ring) => is_trigger || ring.trigger_event.is_some() || ring.before > 0,
+        };
+        if !retain {
+            return;
+        }
+
+        let Some(event_payload_bytes) = event.owned_payload_bytes() else {
+            self.latch_failure(TraceFailure::EventPayloadTooLarge {
+                capacity: self.limits.event_payload_capacity,
+            });
+            return;
+        };
+        let snapshot_bytes = self.pending_snapshot.as_ref().map_or(0, |snapshot| {
+            snapshot
+                .registers
+                .len()
+                .saturating_mul(core::mem::size_of::<u128>())
+        });
+        let payload_bytes = event_payload_bytes.saturating_add(snapshot_bytes);
+        if payload_bytes > self.limits.event_payload_capacity.get() {
+            self.latch_failure(TraceFailure::EventPayloadTooLarge {
+                capacity: self.limits.event_payload_capacity,
+            });
+            return;
+        }
+        let Some(next_sequence) = self.next_sequence.checked_add(1) else {
+            self.latch_failure(TraceFailure::SequenceExhausted);
+            return;
+        };
+
+        let over_byte_capacity = {
+            let ring = self.ring.as_mut().expect("ring capture armed");
+            if ring.trigger_event.is_none() && !is_trigger {
+                // Evict the oldest pre-window event first, so the sliding
+                // window frees its bytes before the new event is charged.
+                while ring.pre.len() >= ring.before.max(1) {
+                    let Some((_, evicted_bytes)) = ring.pre.pop_front() else {
+                        break;
+                    };
+                    ring.retained_payload_bytes =
+                        ring.retained_payload_bytes.saturating_sub(evicted_bytes);
+                }
+            }
+            ring.retained_payload_bytes.saturating_add(payload_bytes)
+                > self.limits.byte_capacity.get()
+        };
+        if over_byte_capacity {
+            self.latch_failure(TraceFailure::QueueOverflow {
+                event_capacity: self.limits.event_capacity,
+                byte_capacity: self.limits.byte_capacity,
+            });
+            return;
+        }
+
+        let envelope = ApplicationTraceEnvelope {
+            schema_version: crate::TRACE_SCHEMA_VERSION,
+            sequence: self.next_sequence,
+            epoch: self.epoch,
+            context,
+            event: OwnedTraceEvent::from(event),
+            snapshot: self.pending_snapshot.clone(),
+        };
+        self.next_sequence = next_sequence;
+
+        let ring = self.ring.as_mut().expect("ring capture armed");
+        ring.retained_payload_bytes = ring.retained_payload_bytes.saturating_add(payload_bytes);
+        if is_trigger {
+            ring.trigger_event = Some(envelope);
+            if ring.after == 0 {
+                ring.complete = true;
+            }
+        } else if ring.trigger_event.is_none() {
+            ring.pre.push_back((envelope, payload_bytes));
+        } else {
+            ring.post.push(envelope);
+            if ring.post.len() >= ring.after {
+                ring.complete = true;
+            }
+        }
     }
 }
 
@@ -229,6 +396,10 @@ impl ApplicationTraceSink {
             failure: None,
             presentation_yield_target: None,
             presentation_boundary_reached: false,
+            armed_snapshot: None,
+            pending_snapshot: None,
+            device_interest: None,
+            ring: None,
         }));
         let interest = Rc::new(Cell::new(TraceInterest::NONE));
         (
@@ -250,6 +421,39 @@ impl ApplicationTraceSink {
         };
         let decision = matcher.borrow_mut().decide(context, event);
         self.state.borrow_mut().record(context, event, decision);
+    }
+
+    /// Feeds one event to the armed ring capture, when one is armed.
+    ///
+    /// The trigger and capture filters are evaluated on the borrowed event
+    /// before any owned payload is allocated.
+    fn ring_capture(&self, context: TraceContext, event: TraceEvent<'_>) {
+        let (capture, trigger, triggered) = {
+            let state = self.state.borrow();
+            if state.failure.is_some() {
+                return;
+            }
+            let Some(ring) = &state.ring else {
+                return;
+            };
+            if ring.complete {
+                return;
+            }
+            (
+                Rc::clone(&ring.capture),
+                Rc::clone(&ring.trigger),
+                ring.trigger_event.is_some(),
+            )
+        };
+        let is_trigger =
+            !triggered && trigger.borrow_mut().decide(context, event) != TraceDecision::Ignore;
+        let is_capture = capture.borrow_mut().decide(context, event) != TraceDecision::Ignore;
+        if !is_trigger && !is_capture {
+            return;
+        }
+        self.state
+            .borrow_mut()
+            .ring_record(context, event, is_trigger);
     }
 
     /// Arms an exact presentation-boundary stop at absolute epoch `target`.
@@ -283,7 +487,21 @@ impl Default for ApplicationTraceSink {
 
 impl TraceSink for ApplicationTraceSink {
     fn interested(&self, key: TraceEventKey) -> bool {
-        self.interest.get().contains(key.class())
+        if !self.interest.get().contains(key.class()) {
+            return false;
+        }
+        if let TraceEventKey::Device { device, action } = key
+            && let Some(entries) = &self.state.borrow().device_interest
+        {
+            return entries.iter().any(|entry| {
+                entry.device == device
+                    && entry
+                        .action
+                        .as_ref()
+                        .is_none_or(|interested| interested == action)
+            });
+        }
+        true
     }
 
     fn trace(&mut self, context: TraceContext, event: TraceEvent<'_>) {
@@ -297,11 +515,24 @@ impl TraceSink for ApplicationTraceSink {
         }
         if self.interested(event.key()) {
             self.record(context, event);
+            self.ring_capture(context, event);
         }
     }
 
     fn yield_requested(&self) -> bool {
         self.state.borrow().yield_requested()
+    }
+
+    fn snapshot_request(&self) -> Option<&'static str> {
+        self.state.borrow().armed_snapshot
+    }
+
+    fn set_pending_snapshot(&mut self, snapshot: ProcessorSnapshot) {
+        self.state.borrow_mut().pending_snapshot = Some(snapshot);
+    }
+
+    fn clear_pending_snapshot(&mut self) {
+        self.state.borrow_mut().pending_snapshot = None;
     }
 }
 
@@ -329,6 +560,9 @@ impl TraceHandle {
         state.queued_payload_bytes = 0;
         state.matcher_yield_requested = false;
         state.failure = None;
+        state.armed_snapshot = None;
+        state.pending_snapshot = None;
+        state.device_interest = None;
         self.interest.set(interest);
     }
 
@@ -354,7 +588,105 @@ impl TraceHandle {
         let mut state = self.state.borrow_mut();
         state.matcher = Rc::new(RefCell::new(Box::new(IgnoreAll)));
         state.matcher_yield_requested = false;
+        state.armed_snapshot = None;
+        state.pending_snapshot = None;
+        state.device_interest = None;
+        state.ring = None;
         self.interest.set(TraceInterest::NONE);
+    }
+
+    /// Arms a bounded ring capture and clears all buffered state.
+    ///
+    /// Events matching `capture` are retained in a window of at most `before`
+    /// events preceding the first `trigger` match and `after` events following
+    /// it. Storage is bounded from this call on, and the sink requests a yield
+    /// once the post-trigger context is complete.
+    pub fn arm_ring_capture<C, T>(
+        &self,
+        capture: C,
+        trigger: T,
+        before: usize,
+        after: usize,
+        interest: TraceInterest,
+    ) where
+        C: TraceMatcher + 'static,
+        T: TraceMatcher + 'static,
+    {
+        let mut state = self.state.borrow_mut();
+        state.matcher = Rc::new(RefCell::new(Box::new(IgnoreAll)));
+        state.queue.clear();
+        state.queued_payload_bytes = 0;
+        state.matcher_yield_requested = false;
+        state.failure = None;
+        state.armed_snapshot = None;
+        state.pending_snapshot = None;
+        state.device_interest = None;
+        state.ring = Some(RingCaptureState {
+            capture: Rc::new(RefCell::new(Box::new(capture))),
+            trigger: Rc::new(RefCell::new(Box::new(trigger))),
+            before,
+            after,
+            pre: VecDeque::new(),
+            trigger_event: None,
+            post: Vec::new(),
+            retained_payload_bytes: 0,
+            complete: false,
+        });
+        self.interest.set(interest);
+    }
+
+    /// Returns the progress of the armed ring capture.
+    pub fn ring_status(&self) -> RingCaptureStatus {
+        match &self.state.borrow().ring {
+            None => RingCaptureStatus::Idle,
+            Some(ring) if ring.complete => RingCaptureStatus::Complete,
+            Some(ring) if ring.trigger_event.is_some() => RingCaptureStatus::Triggered,
+            Some(_) => RingCaptureStatus::Armed,
+        }
+    }
+
+    /// Disarms the ring capture and returns its retained events in order.
+    pub fn take_ring_capture(&self) -> Option<RingCaptureResult> {
+        let mut state = self.state.borrow_mut();
+        let ring = state.ring.take()?;
+        self.interest.set(TraceInterest::NONE);
+        let triggered = ring.trigger_event.is_some();
+        let complete = ring.complete;
+        let mut events: Vec<ApplicationTraceEnvelope> =
+            ring.pre.into_iter().map(|(envelope, _)| envelope).collect();
+        let trigger_index = ring.trigger_event.map(|event| {
+            events.push(event);
+            events.len() - 1
+        });
+        events.extend(ring.post);
+        Some(RingCaptureResult {
+            events,
+            triggered,
+            complete,
+            trigger_index,
+        })
+    }
+
+    /// Restricts device-class interest to the given device and action entries.
+    ///
+    /// `None` keeps every device the interest classes cover. High-volume
+    /// device events are skipped entirely at the emitter's interest check when
+    /// their device, or their action within a listed device, is not listed.
+    pub fn set_device_interest(&self, entries: Option<Vec<DeviceInterest>>) {
+        self.state.borrow_mut().device_interest = entries;
+    }
+
+    /// Arms an atomic register snapshot for a processor at each recorded event.
+    pub fn arm_snapshot(&self, processor: &'static str) {
+        self.state.borrow_mut().armed_snapshot = Some(processor);
+    }
+
+    /// Returns a clone of every queued event without draining the queue.
+    ///
+    /// Used to persist the buffered trace to an artifact while leaving the events
+    /// available for a later drain.
+    pub fn snapshot_events(&self) -> Vec<ApplicationTraceEnvelope> {
+        self.state.borrow().queue.iter().cloned().collect()
     }
 
     /// Restores the default matcher that ignores every event.
@@ -622,5 +954,224 @@ mod tests {
         sink.trace(context(3), access(3));
         assert_eq!(handle.queued_len(), 0);
         assert!(!handle.yield_requested());
+    }
+
+    fn device_event(device: &'static str) -> TraceEvent<'static> {
+        TraceEvent::Device(TraceDeviceEvent {
+            device,
+            action: "data",
+            fields: &[],
+        })
+    }
+
+    #[test]
+    fn device_interest_narrows_device_events() {
+        let (mut sink, handle) = ApplicationTraceSink::new(limits(8, 64, 64));
+        handle.set_matcher_with_interest(
+            |_: TraceContext, _: TraceEvent<'_>| TraceDecision::Record,
+            TraceInterest::only(TraceEventClass::Device),
+        );
+        handle.set_device_interest(Some(vec![DeviceInterest {
+            device: String::from("want.device"),
+            action: None,
+        }]));
+        assert!(sink.interested(TraceEventKey::Device {
+            device: "want.device",
+            action: "data",
+        }));
+        assert!(!sink.interested(TraceEventKey::Device {
+            device: "other.device",
+            action: "data",
+        }));
+        sink.trace(context(1), device_event("want.device"));
+        sink.trace(context(2), device_event("other.device"));
+        assert_eq!(handle.queued_len(), 1);
+        // Stopping restores interest in every device.
+        handle.stop();
+        handle.set_matcher_with_interest(
+            |_: TraceContext, _: TraceEvent<'_>| TraceDecision::Record,
+            TraceInterest::only(TraceEventClass::Device),
+        );
+        assert!(sink.interested(TraceEventKey::Device {
+            device: "other.device",
+            action: "data",
+        }));
+    }
+
+    #[test]
+    fn device_interest_narrows_to_the_named_action() {
+        let (mut sink, handle) = ApplicationTraceSink::new(limits(8, 64, 64));
+        handle.set_matcher_with_interest(
+            |_: TraceContext, _: TraceEvent<'_>| TraceDecision::Record,
+            TraceInterest::only(TraceEventClass::Device),
+        );
+        handle.set_device_interest(Some(vec![DeviceInterest {
+            device: String::from("want.device"),
+            action: Some(String::from("data")),
+        }]));
+        assert!(sink.interested(TraceEventKey::Device {
+            device: "want.device",
+            action: "data",
+        }));
+        // A sibling action of the same device is rejected at the interest
+        // check, so its high-volume events are never built.
+        assert!(!sink.interested(TraceEventKey::Device {
+            device: "want.device",
+            action: "other",
+        }));
+        sink.trace(context(1), device_event("want.device"));
+        assert_eq!(handle.queued_len(), 1);
+    }
+
+    #[test]
+    fn oversized_event_payload_failure_is_sticky() {
+        let (mut sink, handle) = ApplicationTraceSink::new(limits(8, 64, 1));
+        handle.set_matcher_with_interest(
+            |_: TraceContext, _: TraceEvent<'_>| TraceDecision::Record,
+            TraceInterest::only(TraceEventClass::Device),
+        );
+        let fields = [TraceField {
+            name: "bytes",
+            value: TraceValue::Bytes(&[1, 2, 3]),
+        }];
+        let oversized = TraceEvent::Device(TraceDeviceEvent {
+            device: "test.device",
+            action: "data",
+            fields: &fields,
+        });
+        sink.trace(context(1), oversized);
+        assert!(matches!(
+            handle.failure(),
+            Some(TraceFailure::EventPayloadTooLarge { .. })
+        ));
+        // The failure is sticky: later events are not recorded over it.
+        sink.trace(context(2), device_event("test.device"));
+        assert_eq!(handle.queued_len(), 0);
+        assert!(matches!(
+            handle.failure(),
+            Some(TraceFailure::EventPayloadTooLarge { .. })
+        ));
+        handle.take_failure().unwrap();
+    }
+
+    #[test]
+    fn ring_capture_retains_before_and_after_counts() {
+        let (mut sink, handle) = ApplicationTraceSink::new(limits(64, 1024, 64));
+        handle.arm_ring_capture(
+            |_: TraceContext, _: TraceEvent<'_>| TraceDecision::Record,
+            |_: TraceContext, event: TraceEvent<'_>| match event {
+                TraceEvent::Access(access) if access.address == 10 => TraceDecision::RecordAndYield,
+                _ => TraceDecision::Ignore,
+            },
+            3,
+            2,
+            TraceInterest::only(TraceEventClass::Access),
+        );
+        assert_eq!(handle.ring_status(), RingCaptureStatus::Armed);
+        for address in 1..=9 {
+            sink.trace(context(address), access(address));
+        }
+        assert_eq!(handle.ring_status(), RingCaptureStatus::Armed);
+        sink.trace(context(10), access(10));
+        assert_eq!(handle.ring_status(), RingCaptureStatus::Triggered);
+        assert!(!handle.yield_requested());
+        sink.trace(context(11), access(11));
+        sink.trace(context(12), access(12));
+        assert_eq!(handle.ring_status(), RingCaptureStatus::Complete);
+        assert!(handle.yield_requested());
+        // Later events are not retained once the capture is complete.
+        sink.trace(context(13), access(13));
+
+        let result = handle.take_ring_capture().unwrap();
+        assert!(result.triggered);
+        assert!(result.complete);
+        assert_eq!(result.trigger_index, Some(3));
+        assert_eq!(result.events.len(), 6);
+        let addresses: Vec<u64> = result
+            .events
+            .iter()
+            .map(|envelope| match &envelope.event {
+                OwnedTraceEvent::Access(access) => access.address,
+                _ => panic!("expected access event"),
+            })
+            .collect();
+        assert_eq!(addresses, [7, 8, 9, 10, 11, 12]);
+        assert_eq!(handle.ring_status(), RingCaptureStatus::Idle);
+        assert!(!handle.is_active());
+    }
+
+    #[test]
+    fn ring_capture_charges_retained_bytes_against_the_queue_capacity() {
+        // Each device event carries two payload bytes; the queue byte capacity
+        // of five holds at most two retained events.
+        let (mut sink, handle) = ApplicationTraceSink::new(limits(64, 5, 64));
+        handle.arm_ring_capture(
+            |_: TraceContext, _: TraceEvent<'_>| TraceDecision::Record,
+            |_: TraceContext, _: TraceEvent<'_>| TraceDecision::Ignore,
+            2,
+            2,
+            TraceInterest::only(TraceEventClass::Device),
+        );
+        let fields = [TraceField {
+            name: "bytes",
+            value: TraceValue::Bytes(&[1, 2]),
+        }];
+        let event = TraceEvent::Device(TraceDeviceEvent {
+            device: "test.device",
+            action: "data",
+            fields: &fields,
+        });
+        // The sliding pre-window stays within the byte capacity because the
+        // evicted event's bytes are freed before the new event is charged.
+        for cycle in 1..=4 {
+            sink.trace(context(cycle), event);
+        }
+        assert_eq!(handle.failure(), None);
+        let result = handle.take_ring_capture().unwrap();
+        assert_eq!(result.events.len(), 2);
+
+        // A post-trigger window that accumulates beyond the byte capacity
+        // latches the queue overflow instead of retaining unbounded storage.
+        handle.arm_ring_capture(
+            |_: TraceContext, _: TraceEvent<'_>| TraceDecision::Record,
+            |_: TraceContext, event: TraceEvent<'_>| match event {
+                TraceEvent::Access(_) => TraceDecision::RecordAndYield,
+                _ => TraceDecision::Ignore,
+            },
+            0,
+            8,
+            TraceInterest::only(TraceEventClass::Device)
+                .union(TraceInterest::only(TraceEventClass::Access)),
+        );
+        sink.trace(context(10), access(10));
+        for cycle in 11..=14 {
+            sink.trace(context(cycle), event);
+        }
+        assert!(matches!(
+            handle.failure(),
+            Some(TraceFailure::QueueOverflow { .. })
+        ));
+    }
+
+    #[test]
+    fn ring_capture_with_empty_pre_window_allocates_nothing_before_trigger() {
+        let (mut sink, handle) = ApplicationTraceSink::new(limits(64, 1024, 64));
+        handle.arm_ring_capture(
+            |_: TraceContext, _: TraceEvent<'_>| TraceDecision::Record,
+            |_: TraceContext, event: TraceEvent<'_>| match event {
+                TraceEvent::Access(access) if access.address == 5 => TraceDecision::RecordAndYield,
+                _ => TraceDecision::Ignore,
+            },
+            0,
+            1,
+            TraceInterest::only(TraceEventClass::Access),
+        );
+        sink.trace(context(1), access(1));
+        sink.trace(context(5), access(5));
+        sink.trace(context(6), access(6));
+        let result = handle.take_ring_capture().unwrap();
+        assert!(result.complete);
+        assert_eq!(result.trigger_index, Some(0));
+        assert_eq!(result.events.len(), 2);
     }
 }

--- a/crates/dos/src/console.rs
+++ b/crates/dos/src/console.rs
@@ -2,7 +2,12 @@
 
 use common::JisChar;
 
-use crate::{MemoryAccess, console_esc::EscParser, tables};
+use crate::{
+    MemoryAccess,
+    console_esc::EscParser,
+    tables,
+    trace::{DosCellWriteEvent, DosClearEvent, DosScrollEvent, DosTraceEvent, DosTraceLog},
+};
 
 const TEXT_CHAR_BASE: u32 = 0xA0000;
 const TEXT_ATTR_BASE: u32 = 0xA2000;
@@ -20,9 +25,27 @@ fn vram_attr_addr(row: u8, col: u8) -> u32 {
 /// Authoritative DOS console escape-processing state.
 pub(crate) struct Console {
     pub(crate) esc_parser: EscParser,
+    /// Transient trace log, filled only while a dispatch is armed. Excluded from
+    /// save-state.
+    pub(crate) dos_trace: DosTraceLog,
 }
 
-state_struct_codec!(Console { esc_parser });
+impl save_state::StateEncode for Console {
+    fn encode_state(&self, output: &mut Vec<u8>) {
+        save_state::StateEncode::encode_state(&self.esc_parser, output);
+    }
+}
+
+impl save_state::StateDecode for Console {
+    fn decode_state(
+        decoder: &mut save_state::StateDecoder<'_>,
+    ) -> Result<Self, save_state::StateDecodeError> {
+        Ok(Self {
+            esc_parser: save_state::StateDecode::decode_state(decoder)?,
+            dos_trace: DosTraceLog::default(),
+        })
+    }
+}
 
 impl Console {
     pub(crate) fn cursor_row(&self, memory: &dyn MemoryAccess) -> u8 {
@@ -95,11 +118,54 @@ impl Console {
         memory.write_word(vram_attr_addr(row, col), attr as u16);
     }
 
+    fn record_cell_write(&self, row: u8, col: u8, jis: JisChar, attr: u8) {
+        if self.dos_trace.cell_write_enabled.get() {
+            self.dos_trace
+                .events
+                .borrow_mut()
+                .push(DosTraceEvent::CellWrite(DosCellWriteEvent {
+                    row,
+                    column: col,
+                    jis: jis.as_u16(),
+                    display_width: jis.display_width(),
+                    attribute: attr,
+                }));
+        }
+    }
+
+    fn record_clear(&self, region_top: u8, region_bottom: u8, count: u32) {
+        if self.dos_trace.clear_enabled.get() {
+            self.dos_trace
+                .events
+                .borrow_mut()
+                .push(DosTraceEvent::Clear(DosClearEvent {
+                    region_top,
+                    region_bottom,
+                    count,
+                }));
+        }
+    }
+
+    fn record_scroll(&self, region_top: u8, region_bottom: u8, count: u8, direction: i8) {
+        if self.dos_trace.scroll_enabled.get() {
+            self.dos_trace
+                .events
+                .borrow_mut()
+                .push(DosTraceEvent::Scroll(DosScrollEvent {
+                    region_top,
+                    region_bottom,
+                    count,
+                    direction,
+                }));
+        }
+    }
+
     pub(crate) fn put_char(&self, memory: &mut dyn MemoryAccess, ch: u8) {
         let row = self.cursor_row(memory);
         let col = self.cursor_col(memory);
         let attr = self.display_attr(memory);
         self.write_cell(memory, row, col, JisChar::from_u16(ch as u16), attr);
+        self.record_cell_write(row, col, JisChar::from_u16(ch as u16), attr);
         self.advance_cursor(memory);
     }
 
@@ -117,6 +183,7 @@ impl Console {
 
         let attr = self.display_attr(memory);
         self.write_cell(memory, row, col, jis, attr);
+        self.record_cell_write(row, col, jis, attr);
         if width == 2 {
             self.write_cell(memory, row, col + 1, JisChar::from_u16(0x0000), attr);
             self.advance_cursor(memory);
@@ -232,6 +299,8 @@ impl Console {
                 memory.write_word(vram_attr_addr(row, col), clear_at as u16);
             }
         }
+
+        self.record_scroll(upper, lower, count, 1);
     }
 
     pub(crate) fn scroll_down(&self, memory: &mut dyn MemoryAccess, count: u8) {
@@ -267,6 +336,8 @@ impl Console {
                 memory.write_word(vram_attr_addr(row, col), clear_at as u16);
             }
         }
+
+        self.record_scroll(upper, lower, count, -1);
     }
 
     pub(crate) fn clear_screen(&self, memory: &mut dyn MemoryAccess) {
@@ -283,6 +354,7 @@ impl Console {
                 memory.write_word(vram_attr_addr(row, col), clear_at as u16);
             }
         }
+        self.record_clear(0, lower, (u32::from(lower) + 1) * u32::from(COLUMNS));
         self.set_cursor(memory, 0, 0);
     }
 
@@ -308,6 +380,9 @@ impl Console {
                 memory.write_word(vram_attr_addr(r, c), clear_at as u16);
             }
         }
+        let count = (u32::from(COLUMNS) - u32::from(col))
+            + u32::from(lower.saturating_sub(row)) * u32::from(COLUMNS);
+        self.record_clear(row, lower, count);
     }
 
     pub(crate) fn clear_screen_to_cursor(&self, memory: &mut dyn MemoryAccess) {
@@ -331,6 +406,8 @@ impl Console {
             memory.write_byte(addr + 1, odd);
             memory.write_word(vram_attr_addr(row, c), clear_at as u16);
         }
+        let count = u32::from(row) * u32::from(COLUMNS) + u32::from(col) + 1;
+        self.record_clear(0, row, count);
     }
 
     pub(crate) fn clear_line_from_cursor(&self, memory: &mut dyn MemoryAccess) {
@@ -346,6 +423,7 @@ impl Console {
             memory.write_byte(char_addr + 1, odd);
             memory.write_word(vram_attr_addr(row, c), clear_at as u16);
         }
+        self.record_clear(row, row, u32::from(COLUMNS) - u32::from(col));
     }
 
     pub(crate) fn clear_line_to_cursor(&self, memory: &mut dyn MemoryAccess) {
@@ -361,6 +439,7 @@ impl Console {
             memory.write_byte(char_addr + 1, odd);
             memory.write_word(vram_attr_addr(row, c), clear_at as u16);
         }
+        self.record_clear(row, row, u32::from(col) + 1);
     }
 
     pub(crate) fn clear_line(&self, memory: &mut dyn MemoryAccess) {
@@ -375,6 +454,7 @@ impl Console {
             memory.write_byte(char_addr + 1, odd);
             memory.write_word(vram_attr_addr(row, c), clear_at as u16);
         }
+        self.record_clear(row, row, u32::from(COLUMNS));
     }
 
     pub(crate) fn set_cursor_position(&self, memory: &mut dyn MemoryAccess, row: u8, col: u8) {
@@ -610,6 +690,230 @@ mod tests {
         for byte in s.bytes() {
             console.process_byte(memory, byte);
         }
+    }
+
+    fn armed_console() -> Console {
+        let console = Console::default();
+        console.dos_trace.arm(crate::trace::DosTraceInterest::all());
+        console
+    }
+
+    fn recorded_events(console: &Console) -> Vec<crate::trace::DosTraceEvent> {
+        console.dos_trace.events.borrow().clone()
+    }
+
+    #[test]
+    fn sgr_reverse_video_records_escape_transition() {
+        use crate::trace::DosTraceEvent;
+        let mut console = armed_console();
+        let mut memory = make_memory();
+        feed_str(&mut console, &mut memory, "\u{1b}[7m");
+        let events = recorded_events(&console);
+        let escape = events
+            .iter()
+            .find_map(|event| match event {
+                DosTraceEvent::ConsoleEscape(escape) if escape.command == "sgr" => Some(escape),
+                _ => None,
+            })
+            .expect("sgr escape event");
+        assert!(escape.parameters.contains(&7));
+        assert_ne!(escape.attribute_before, escape.attribute_after);
+        assert_eq!(escape.attribute_after & 0x04, 0x04);
+    }
+
+    #[test]
+    fn shift_jis_graphic_pair_records_one_cell() {
+        use crate::trace::DosTraceEvent;
+        let mut console = armed_console();
+        let mut memory = make_memory();
+        console.process_byte(&mut memory, 0x86);
+        console.process_byte(&mut memory, 0x5F);
+        let events = recorded_events(&console);
+        let cell = events
+            .iter()
+            .find_map(|event| match event {
+                DosTraceEvent::CellWrite(cell) => Some(cell),
+                _ => None,
+            })
+            .expect("cell-write event");
+        assert_eq!(cell.display_width, 1);
+        let trail = events
+            .iter()
+            .filter_map(|event| match event {
+                DosTraceEvent::ConsoleByte(byte) => Some(byte),
+                _ => None,
+            })
+            .next_back()
+            .expect("trailing byte event");
+        assert_eq!(trail.byte, 0x5F);
+        assert_eq!(trail.cursor_column_after, trail.cursor_column_before + 1);
+    }
+
+    #[test]
+    fn byte_event_records_before_and_after_state() {
+        use crate::trace::DosTraceEvent;
+        let mut console = armed_console();
+        let mut memory = make_memory();
+        console.process_byte(&mut memory, b'A');
+        let events = recorded_events(&console);
+        let byte = events
+            .iter()
+            .find_map(|event| match event {
+                DosTraceEvent::ConsoleByte(byte) => Some(byte),
+                _ => None,
+            })
+            .expect("byte event");
+        assert_eq!(byte.byte, b'A');
+        assert_eq!(byte.parser_state_before, "normal");
+        assert_eq!(byte.cursor_column_before, 0);
+        assert_eq!(byte.cursor_column_after, 1);
+    }
+
+    #[test]
+    fn clear_screen_records_region() {
+        use crate::trace::DosTraceEvent;
+        let mut console = armed_console();
+        let mut memory = make_memory();
+        feed_str(&mut console, &mut memory, "\u{1b}[2J");
+        let events = recorded_events(&console);
+        let clear = events
+            .iter()
+            .find_map(|event| match event {
+                DosTraceEvent::Clear(clear) => Some(clear),
+                _ => None,
+            })
+            .expect("clear event");
+        assert_eq!(clear.region_top, 0);
+        assert_eq!(clear.region_bottom, 24);
+        assert!(clear.count > 0);
+    }
+
+    #[test]
+    fn scroll_records_region_and_direction() {
+        use crate::trace::DosTraceEvent;
+        let mut console = armed_console();
+        let mut memory = make_memory();
+        feed_str(&mut console, &mut memory, "\u{1b}[M");
+        let events = recorded_events(&console);
+        let scroll = events
+            .iter()
+            .find_map(|event| match event {
+                DosTraceEvent::Scroll(scroll) => Some(scroll),
+                _ => None,
+            })
+            .expect("scroll event");
+        assert_eq!(scroll.region_top, 0);
+        assert_eq!(scroll.region_bottom, 24);
+        assert_eq!(scroll.count, 1);
+        assert_eq!(scroll.direction, 1);
+    }
+
+    #[test]
+    fn disabled_log_records_nothing() {
+        let mut console = Console::default();
+        let mut memory = make_memory();
+        feed_str(&mut console, &mut memory, "\u{1b}[7mABC");
+        assert!(console.dos_trace.events.borrow().is_empty());
+    }
+
+    #[test]
+    fn escape_parameters_preserve_values_above_255() {
+        use crate::trace::DosTraceEvent;
+        let mut console = armed_console();
+        let mut memory = make_memory();
+        feed_str(&mut console, &mut memory, "\u{1b}[300m");
+        let events = recorded_events(&console);
+        let escape = events
+            .iter()
+            .find_map(|event| match event {
+                DosTraceEvent::ConsoleEscape(escape) => Some(escape),
+                _ => None,
+            })
+            .expect("escape event");
+        assert_eq!(escape.parameters, [300]);
+    }
+
+    #[test]
+    fn non_csi_escape_sequences_record_escape_events() {
+        use crate::trace::DosTraceEvent;
+        let mut console = armed_console();
+        let mut memory = make_memory();
+        console.set_cursor(&mut memory, 3, 5);
+        feed_str(&mut console, &mut memory, "\u{1b})3");
+        feed_str(&mut console, &mut memory, "\u{1b}E");
+        console.process_byte(&mut memory, 0x1B);
+        console.process_byte(&mut memory, b'=');
+        console.process_byte(&mut memory, 0x20 + 7);
+        console.process_byte(&mut memory, 0x20 + 11);
+        let events = recorded_events(&console);
+        let commands: Vec<&str> = events
+            .iter()
+            .filter_map(|event| match event {
+                DosTraceEvent::ConsoleEscape(escape) => Some(escape.command),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(commands, ["graphic-mode", "next-line", "cursor-address"]);
+        let cursor_address = events
+            .iter()
+            .find_map(|event| match event {
+                DosTraceEvent::ConsoleEscape(escape) if escape.command == "cursor-address" => {
+                    Some(escape)
+                }
+                _ => None,
+            })
+            .expect("cursor-address event");
+        assert_eq!(cursor_address.parameters, [7, 11]);
+        assert_eq!(cursor_address.bytes, [0x1B, b'=', 0x27, 0x2B]);
+        assert_eq!(cursor_address.cursor_row_after, 7);
+        assert_eq!(cursor_address.cursor_column_after, 11);
+    }
+
+    #[test]
+    fn set_mode_sequences_record_escape_events() {
+        use crate::trace::DosTraceEvent;
+        let mut console = armed_console();
+        let mut memory = make_memory();
+        feed_str(&mut console, &mut memory, "\u{1b}[?7l");
+        feed_str(&mut console, &mut memory, "\u{1b}[>5h");
+        let events = recorded_events(&console);
+        let escapes: Vec<(&str, Vec<u16>, Vec<u8>)> = events
+            .iter()
+            .filter_map(|event| match event {
+                DosTraceEvent::ConsoleEscape(escape) => Some((
+                    escape.command,
+                    escape.parameters.clone(),
+                    escape.bytes.clone(),
+                )),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(escapes.len(), 2);
+        assert_eq!(escapes[0].0, "reset-mode");
+        assert_eq!(escapes[0].1, [7]);
+        assert_eq!(escapes[0].2, b"\x1b[?7l");
+        assert_eq!(escapes[1].0, "set-extended-mode");
+        assert_eq!(escapes[1].1, [5]);
+        assert_eq!(escapes[1].2, b"\x1b[>5h");
+    }
+
+    #[test]
+    fn per_action_arming_skips_sibling_console_events() {
+        use crate::trace::{DosTraceEvent, DosTraceInterest};
+        let mut console = Console::default();
+        console.dos_trace.arm(DosTraceInterest {
+            console_escape: true,
+            ..DosTraceInterest::default()
+        });
+        let mut memory = make_memory();
+        feed_str(&mut console, &mut memory, "\u{1b}[7mABC");
+        let events = recorded_events(&console);
+        assert!(!events.is_empty());
+        assert!(
+            events
+                .iter()
+                .all(|event| matches!(event, DosTraceEvent::ConsoleEscape(_)))
+        );
     }
 
     #[test]

--- a/crates/dos/src/console_esc.rs
+++ b/crates/dos/src/console_esc.rs
@@ -1,8 +1,54 @@
 //! Native ESC sequence state machine and processing.
 
+use alloc::{string::ToString, vec::Vec};
+
 use common::{is_shift_jis_lead_byte, is_shift_jis_trail_byte, shift_jis_pair_to_jis};
 
-use crate::{MemoryAccess, console::Console, tables};
+use crate::{
+    MemoryAccess,
+    console::Console,
+    tables,
+    trace::{
+        DosConsoleByteEvent, DosConsoleEscapeEvent, DosTraceEvent, character_mode,
+        parser_state_symbol,
+    },
+};
+
+/// Escape-relevant console state captured ahead of a dispatched sequence.
+struct EscapeTraceBefore {
+    attribute: u8,
+    cursor_row: u8,
+    cursor_column: u8,
+}
+
+/// Console parser and screen state captured before and after one byte.
+struct ConsoleByteState {
+    parser_state: &'static str,
+    character_mode: &'static str,
+    pending_lead: Option<u8>,
+    cursor_row: u8,
+    cursor_column: u8,
+    attribute: u8,
+}
+
+/// Maps a CSI final byte to its stable command symbol.
+fn csi_command_name(final_byte: u8) -> &'static str {
+    match final_byte {
+        b'H' | b'f' => "cursor-position",
+        b'A' => "cursor-up",
+        b'B' => "cursor-down",
+        b'C' => "cursor-right",
+        b'D' => "cursor-left",
+        b's' => "save-cursor",
+        b'u' => "restore-cursor",
+        b'J' => "erase-display",
+        b'K' => "erase-line",
+        b'L' => "insert-line",
+        b'M' => "delete-line",
+        b'm' => "sgr",
+        _ => "unknown",
+    }
+}
 
 save_state::runtime_state_enum! {
     /// Current phase of the DOS console escape-sequence parser.
@@ -81,9 +127,67 @@ impl Console {
         memory.read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_KANJI_MODE) != 0
     }
 
+    fn capture_byte_state(&self, memory: &dyn MemoryAccess) -> ConsoleByteState {
+        ConsoleByteState {
+            parser_state: parser_state_symbol(self.esc_parser.state),
+            character_mode: if self.shift_jis_mode_enabled(memory) {
+                character_mode::SHIFT_JIS
+            } else {
+                character_mode::ANK
+            },
+            pending_lead: self.pending_shift_jis_lead(memory),
+            cursor_row: self.cursor_row(memory),
+            cursor_column: self.cursor_col(memory),
+            attribute: memory.read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_DISPLAY_ATTR),
+        }
+    }
+
     /// Main entry point: feed one byte into the console output pipeline.
     /// Handles control characters, ESC sequences, and printable output.
+    ///
+    /// When the trace log is armed, this records a `byte` event with before and
+    /// after parser, cursor, and attribute state around the inner processing.
     pub(crate) fn process_byte(&mut self, memory: &mut dyn MemoryAccess, byte: u8) {
+        if !self.dos_trace.console_byte_enabled.get() {
+            self.process_byte_inner(memory, byte);
+            return;
+        }
+        let before = self.capture_byte_state(memory);
+        let index = {
+            let mut events = self.dos_trace.events.borrow_mut();
+            let index = events.len();
+            events.push(DosTraceEvent::ConsoleByte(DosConsoleByteEvent {
+                byte,
+                parser_state_before: before.parser_state,
+                parser_state_after: before.parser_state,
+                character_mode_before: before.character_mode,
+                character_mode_after: before.character_mode,
+                pending_shift_jis_lead_before: before.pending_lead,
+                pending_shift_jis_lead_after: before.pending_lead,
+                cursor_row_before: before.cursor_row,
+                cursor_column_before: before.cursor_column,
+                cursor_row_after: before.cursor_row,
+                cursor_column_after: before.cursor_column,
+                attribute_before: before.attribute,
+                attribute_after: before.attribute,
+            }));
+            index
+        };
+        self.process_byte_inner(memory, byte);
+        let after = self.capture_byte_state(memory);
+        if let Some(DosTraceEvent::ConsoleByte(event)) =
+            self.dos_trace.events.borrow_mut().get_mut(index)
+        {
+            event.parser_state_after = after.parser_state;
+            event.character_mode_after = after.character_mode;
+            event.pending_shift_jis_lead_after = after.pending_lead;
+            event.cursor_row_after = after.cursor_row;
+            event.cursor_column_after = after.cursor_column;
+            event.attribute_after = after.attribute;
+        }
+    }
+
+    fn process_byte_inner(&mut self, memory: &mut dyn MemoryAccess, byte: u8) {
         if let Some(lead) = self.pending_shift_jis_lead(memory) {
             self.clear_pending_shift_jis_lead(memory);
             if let Some(jis) = if is_shift_jis_trail_byte(byte) {
@@ -96,7 +200,7 @@ impl Console {
             }
 
             self.put_char(memory, lead);
-            self.process_byte(memory, byte);
+            self.process_byte_inner(memory, byte);
             return;
         }
 
@@ -144,20 +248,28 @@ impl Console {
                 self.esc_parser.state = EscState::GotCsi;
             }
             b'*' => {
+                let before = self.escape_trace_begin(memory);
                 self.clear_screen(memory);
+                self.escape_trace_end(memory, before, &[0x1B, b'*'], "clear-screen", &[]);
                 self.esc_parser.reset();
             }
             b'D' => {
+                let before = self.escape_trace_begin(memory);
                 self.linefeed(memory);
+                self.escape_trace_end(memory, before, &[0x1B, b'D'], "line-feed", &[]);
                 self.esc_parser.reset();
             }
             b'E' => {
+                let before = self.escape_trace_begin(memory);
                 self.carriage_return(memory);
                 self.linefeed(memory);
+                self.escape_trace_end(memory, before, &[0x1B, b'E'], "next-line", &[]);
                 self.esc_parser.reset();
             }
             b'M' => {
+                let before = self.escape_trace_begin(memory);
                 self.reverse_linefeed(memory);
+                self.escape_trace_end(memory, before, &[0x1B, b'M'], "reverse-line-feed", &[]);
                 self.esc_parser.reset();
             }
             b')' => {
@@ -195,7 +307,7 @@ impl Console {
                 if self.esc_parser.has_digit || self.esc_parser.param_count > 0 {
                     self.esc_parser.push_param();
                 }
-                self.esc_dispatch_csi(memory, byte);
+                self.dispatch_csi_traced(memory, byte);
                 self.esc_parser.reset();
             }
             _ => {
@@ -224,10 +336,24 @@ impl Console {
                 if self.esc_parser.has_digit || self.esc_parser.param_count > 0 {
                     self.esc_parser.push_param();
                 }
+                let before = self.escape_trace_begin(memory);
+                let prefix: &[u8] = if is_question { b"?" } else { b">" };
+                let command = match (is_question, byte) {
+                    (true, b'h') => "set-mode",
+                    (true, _) => "reset-mode",
+                    (false, b'h') => "set-extended-mode",
+                    (false, _) => "reset-extended-mode",
+                };
                 if is_question {
                     self.esc_dispatch_csi_question(memory, byte);
                 } else {
                     self.esc_dispatch_csi_greater(memory, byte);
+                }
+                if before.is_some() {
+                    let bytes = self.build_csi_bytes(prefix, byte);
+                    let parameters: Vec<u16> =
+                        self.esc_parser.params[..self.esc_parser.param_count].to_vec();
+                    self.escape_trace_end(memory, before, &bytes, command, &parameters);
                 }
                 self.esc_parser.reset();
             }
@@ -238,19 +364,23 @@ impl Console {
     }
 
     fn esc_process_right_paren(&mut self, memory: &mut dyn MemoryAccess, byte: u8) {
-        match byte {
+        let before = self.escape_trace_begin(memory);
+        let command = match byte {
             b'0' => {
                 // Set Shift-JIS kanji display mode.
                 memory.write_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_KANJI_MODE, 0x01);
                 memory.write_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_GRAPH_CHAR, 0x20);
+                "kanji-mode"
             }
             b'3' => {
                 // Set graphic character display mode.
                 memory.write_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_KANJI_MODE, 0x00);
                 memory.write_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_GRAPH_CHAR, 0x67);
+                "graphic-mode"
             }
-            _ => {}
-        }
+            _ => "unknown",
+        };
+        self.escape_trace_end(memory, before, &[0x1B, b')', byte], command, &[]);
         self.esc_parser.reset();
     }
 
@@ -264,8 +394,96 @@ impl Console {
         let raw_col = byte;
         let row = raw_row.saturating_sub(0x20);
         let col = raw_col.saturating_sub(0x20);
+        let before = self.escape_trace_begin(memory);
         self.set_cursor_position(memory, row, col);
+        self.escape_trace_end(
+            memory,
+            before,
+            &[0x1B, b'=', raw_row, raw_col],
+            "cursor-address",
+            &[u16::from(row), u16::from(col)],
+        );
         self.esc_parser.reset();
+    }
+
+    /// Builds the canonical byte form of the pending CSI sequence.
+    ///
+    /// `prefix` carries the private-parameter marker for `CSI ?` and `CSI >`
+    /// sequences, or is empty for a plain CSI sequence.
+    fn build_csi_bytes(&self, prefix: &[u8], final_byte: u8) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.push(0x1B);
+        bytes.push(b'[');
+        bytes.extend_from_slice(prefix);
+        for index in 0..self.esc_parser.param_count {
+            if index > 0 {
+                bytes.push(b';');
+            }
+            bytes.extend_from_slice(self.esc_parser.params[index].to_string().as_bytes());
+        }
+        bytes.push(final_byte);
+        bytes
+    }
+
+    /// Captures the escape-relevant state ahead of a dispatch when the escape
+    /// action is armed, or returns `None` so tracing costs nothing.
+    fn escape_trace_begin(&self, memory: &dyn MemoryAccess) -> Option<EscapeTraceBefore> {
+        if !self.dos_trace.console_escape_enabled.get() {
+            return None;
+        }
+        Some(EscapeTraceBefore {
+            attribute: memory.read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_DISPLAY_ATTR),
+            cursor_row: self.cursor_row(memory),
+            cursor_column: self.cursor_col(memory),
+        })
+    }
+
+    /// Records an `escape` event for a dispatched sequence when armed.
+    fn escape_trace_end(
+        &self,
+        memory: &dyn MemoryAccess,
+        before: Option<EscapeTraceBefore>,
+        bytes: &[u8],
+        command: &'static str,
+        parameters: &[u16],
+    ) {
+        let Some(before) = before else {
+            return;
+        };
+        let event = DosConsoleEscapeEvent {
+            bytes: bytes.to_vec(),
+            command,
+            parameters: parameters.to_vec(),
+            attribute_before: before.attribute,
+            attribute_after: memory.read_byte(tables::IOSYS_BASE + tables::IOSYS_OFF_DISPLAY_ATTR),
+            cursor_row_before: before.cursor_row,
+            cursor_column_before: before.cursor_column,
+            cursor_row_after: self.cursor_row(memory),
+            cursor_column_after: self.cursor_col(memory),
+        };
+        self.dos_trace
+            .events
+            .borrow_mut()
+            .push(DosTraceEvent::ConsoleEscape(event));
+    }
+
+    /// Dispatches a CSI final byte, recording an `escape` event when armed.
+    fn dispatch_csi_traced(&mut self, memory: &mut dyn MemoryAccess, final_byte: u8) {
+        let before = self.escape_trace_begin(memory);
+        if before.is_none() {
+            self.esc_dispatch_csi(memory, final_byte);
+            return;
+        }
+        let bytes = self.build_csi_bytes(&[], final_byte);
+        let parameters: Vec<u16> = self.esc_parser.params[..self.esc_parser.param_count].to_vec();
+        self.esc_dispatch_csi(memory, final_byte);
+        self.escape_trace_end(
+            memory,
+            before,
+            &bytes,
+            csi_command_name(final_byte),
+            &parameters,
+        );
     }
 
     fn esc_dispatch_csi(&mut self, memory: &mut dyn MemoryAccess, final_byte: u8) {

--- a/crates/dos/src/dos.rs
+++ b/crates/dos/src/dos.rs
@@ -5,6 +5,7 @@ use common::warn;
 use crate::{
     BufferedInputState, CpuAccess, DriveIo, MemoryAccess, NeetanDos, SegmentRegister,
     adjust_iret_ip, country, filesystem, memory, set_iret_carry, set_iret_zf, tables,
+    trace::{DosStdoutEvent, DosVectorEvent, route, source, suppression},
 };
 
 impl NeetanDos {
@@ -152,6 +153,23 @@ impl NeetanDos {
         memory: &mut dyn MemoryAccess,
     ) {
         let dl = (cpu.dx() & 0xFF) as u8;
+        if self.stdout_trace_enabled() {
+            let route = self.stdout_route(memory);
+            self.record_stdout(
+                memory,
+                DosStdoutEvent {
+                    source: source::INT21_02,
+                    handle: None,
+                    buffer_address: None,
+                    requested_count: 1,
+                    bytes: vec![dl],
+                    route: route.symbol(),
+                    suppression_reason: route.suppression_reason(),
+                    int29_segment: 0,
+                    int29_offset: 0,
+                },
+            );
+        }
         self.write_stdout_byte(memory, dl);
         cpu.set_ax((cpu.ax() & 0xFF00) | dl as u16);
     }
@@ -169,9 +187,59 @@ impl NeetanDos {
 
     /// Writes one byte through the active console output path.
     pub(crate) fn write_stdout_byte(&mut self, memory: &mut dyn MemoryAccess, byte: u8) {
-        if !self.stdout_is_nul(memory) && !int29_handler_is_iret(memory) {
+        if self.stdout_route(memory).reaches_console() {
             self.console.process_byte(memory, byte);
         }
+    }
+
+    pub(crate) fn stdout_trace_enabled(&self) -> bool {
+        self.console.dos_trace.stdout_enabled.get()
+    }
+
+    /// Decides where handle-1 console output routes. The console write path and
+    /// the trace both consume this single decision.
+    pub(crate) fn stdout_route(&self, memory: &dyn MemoryAccess) -> StdoutRoute {
+        route_for_character_device(memory, self.stdout_is_nul(memory))
+    }
+
+    /// Records a stdout routing event when the trace log is armed for it.
+    ///
+    /// The `int29_segment` and `int29_offset` fields of `event` are ignored and
+    /// filled from the live INT 29h vector.
+    pub(crate) fn record_stdout(&self, memory: &dyn MemoryAccess, event: DosStdoutEvent) {
+        let (int29_segment, int29_offset) = int29_handler_vector(memory);
+        self.console.dos_trace.push_stdout(DosStdoutEvent {
+            int29_segment,
+            int29_offset,
+            ..event
+        });
+    }
+
+    /// Records an INT 21h AH=40h stdout routing event with the buffer bytes.
+    pub(crate) fn record_stdout_write(
+        &self,
+        memory: &dyn MemoryAccess,
+        handle: u16,
+        buffer_address: u32,
+        count: u32,
+        route: StdoutRoute,
+    ) {
+        let mut bytes = vec![0u8; count as usize];
+        memory.read_block(buffer_address, &mut bytes);
+        self.record_stdout(
+            memory,
+            DosStdoutEvent {
+                source: source::INT21_40,
+                handle: Some(handle),
+                buffer_address: Some(buffer_address),
+                requested_count: count,
+                bytes,
+                route: route.symbol(),
+                suppression_reason: route.suppression_reason(),
+                int29_segment: 0,
+                int29_offset: 0,
+            },
+        );
     }
 
     /// Reads one key byte for INT 21h input functions.
@@ -311,7 +379,24 @@ impl NeetanDos {
                 }
             }
         } else {
-            self.console.process_byte(memory, dl);
+            if self.stdout_trace_enabled() {
+                let route = self.stdout_route(memory);
+                self.record_stdout(
+                    memory,
+                    DosStdoutEvent {
+                        source: source::INT21_06,
+                        handle: None,
+                        buffer_address: None,
+                        requested_count: 1,
+                        bytes: vec![dl],
+                        route: route.symbol(),
+                        suppression_reason: route.suppression_reason(),
+                        int29_segment: 0,
+                        int29_offset: 0,
+                    },
+                );
+            }
+            self.write_stdout_byte(memory, dl);
             cpu.set_ax((cpu.ax() & 0xFF00) | dl as u16);
             true
         }
@@ -497,6 +582,31 @@ impl NeetanDos {
         memory: &mut dyn MemoryAccess,
     ) {
         let start = cpu.linear_address(SegmentRegister::DS, cpu.dx());
+        if self.stdout_trace_enabled() {
+            let mut buffer = Vec::new();
+            for addr in start..start + 0xFFFFu32 {
+                let byte = memory.read_byte(addr);
+                if byte == b'$' {
+                    break;
+                }
+                buffer.push(byte);
+            }
+            let route = self.stdout_route(memory);
+            self.record_stdout(
+                memory,
+                DosStdoutEvent {
+                    source: source::INT21_09,
+                    handle: None,
+                    buffer_address: Some(start),
+                    requested_count: buffer.len() as u32,
+                    bytes: buffer,
+                    route: route.symbol(),
+                    suppression_reason: route.suppression_reason(),
+                    int29_segment: 0,
+                    int29_offset: 0,
+                },
+            );
+        }
         for addr in start..start + 0xFFFFu32 {
             let byte = memory.read_byte(addr);
             if byte == b'$' {
@@ -537,6 +647,17 @@ impl NeetanDos {
         let ivt_addr = vector * 4;
         memory.write_word(ivt_addr, cpu.dx());
         memory.write_word(ivt_addr + 2, cpu.ds());
+
+        if self.console.dos_trace.vector_enabled.get() {
+            let segment = cpu.ds();
+            let offset = cpu.dx();
+            self.console.dos_trace.push_vector(DosVectorEvent {
+                vector: vector as u8,
+                segment,
+                offset,
+                linear_address: (u32::from(segment) << 4).wrapping_add(u32::from(offset)),
+            });
+        }
     }
 
     /// AH=2Fh: Get DTA address.
@@ -1511,6 +1632,63 @@ fn int29_handler_is_iret(memory: &dyn MemoryAccess) -> bool {
     memory.read_byte((segment << 4).wrapping_add(offset)) == 0xCF
 }
 
+/// Returns the active INT 29h handler `(segment, offset)`.
+fn int29_handler_vector(memory: &dyn MemoryAccess) -> (u16, u16) {
+    const INT29_VECTOR: u32 = 0x29 * 4;
+    let offset = memory.read_word(INT29_VECTOR);
+    let segment = memory.read_word(INT29_VECTOR + 2);
+    (segment, offset)
+}
+
+/// Routing decision for console-bound output.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StdoutRoute {
+    /// Output reaches the text console.
+    Console,
+    /// The handle points at the NUL device.
+    Nul,
+    /// The handle was redirected to a file.
+    Redirected,
+    /// The guest hooked INT 29h with an IRET, so output is dropped.
+    Suppressed,
+}
+
+impl StdoutRoute {
+    /// Stable route symbol for trace events.
+    pub(crate) fn symbol(self) -> &'static str {
+        match self {
+            Self::Console => route::CONSOLE,
+            Self::Nul => route::NUL,
+            Self::Redirected => route::REDIRECTED,
+            Self::Suppressed => route::SUPPRESSED,
+        }
+    }
+
+    /// Suppression reason symbol, when output is suppressed.
+    pub(crate) fn suppression_reason(self) -> Option<&'static str> {
+        match self {
+            Self::Suppressed => Some(suppression::INT29_IRET_HOOK),
+            Self::Console | Self::Nul | Self::Redirected => None,
+        }
+    }
+
+    /// Whether bytes should reach the console parser.
+    pub(crate) fn reaches_console(self) -> bool {
+        matches!(self, Self::Console)
+    }
+}
+
+/// Decides where character-device output routes, given the device's NUL flag.
+pub(crate) fn route_for_character_device(memory: &dyn MemoryAccess, is_nul: bool) -> StdoutRoute {
+    if is_nul {
+        StdoutRoute::Nul
+    } else if int29_handler_is_iret(memory) {
+        StdoutRoute::Suppressed
+    } else {
+        StdoutRoute::Console
+    }
+}
+
 /// Normalizes a DOS path by resolving `.` and `..` components.
 /// Input/output is a byte vector like `A:\FOO\BAR\..\BAZ`.
 pub(crate) fn normalize_path(path: &[u8]) -> Vec<u8> {
@@ -1569,6 +1747,7 @@ mod tests {
             UMB_FIRST_MCB_SEGMENT,
         },
         test_support::{MockCpu, MockMemory},
+        trace::{DosTraceEvent, route, source},
     };
 
     fn prepare_dos_with_umb() -> (NeetanDos, MockMemory) {
@@ -1613,6 +1792,221 @@ mod tests {
         memory.write_byte(0x20123, 0x90);
 
         assert!(!int29_handler_is_iret(&memory));
+    }
+
+    struct StubDisk;
+
+    impl crate::DiskIo for StubDisk {
+        fn read_sectors(&mut self, _drive: u8, _lba: u32, _count: u32) -> Result<Vec<u8>, u8> {
+            Err(0xFF)
+        }
+
+        fn write_sectors(&mut self, _drive: u8, _lba: u32, _data: &[u8]) -> Result<(), u8> {
+            Err(0xFF)
+        }
+
+        fn sector_size(&self, _drive: u8) -> Option<u16> {
+            None
+        }
+
+        fn total_sectors(&self, _drive: u8) -> Option<u32> {
+            None
+        }
+
+        fn drive_geometry(&self, _drive: u8) -> Option<(u16, u8, u8)> {
+            None
+        }
+    }
+
+    const TEST_PSP: u16 = 0x2000;
+
+    fn dos_with_stdout_handle(dev_info: u16) -> (NeetanDos, MockMemory) {
+        let mut dos = NeetanDos::new();
+        let mut memory = MockMemory::with_extended_memory(0x200000, 0);
+        dos.state.current_psp = TEST_PSP;
+        let psp_base = (TEST_PSP as u32) << 4;
+        memory.write_byte(psp_base + crate::tables::PSP_OFF_JFT + 1, 1);
+        let sft_addr = dos.state.sft_entry_addr(1).unwrap();
+        memory.write_word(sft_addr + crate::tables::SFT_ENT_DEV_INFO, dev_info);
+        dos.console
+            .dos_trace
+            .arm(crate::trace::DosTraceInterest::all());
+        (dos, memory)
+    }
+
+    fn stdout_events(dos: &NeetanDos) -> Vec<crate::trace::DosStdoutEvent> {
+        dos.console
+            .dos_trace
+            .events
+            .borrow()
+            .iter()
+            .filter_map(|event| match event {
+                DosTraceEvent::Stdout(stdout) => Some(stdout.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn write_via_ah40(dos: &mut NeetanDos, memory: &mut MockMemory, payload: &[u8]) {
+        let mut cpu = MockCpu::default();
+        let buffer_offset = 0x0300u16;
+        let buffer_addr = ((TEST_PSP as u32) << 4) + u32::from(buffer_offset);
+        for (index, &byte) in payload.iter().enumerate() {
+            memory.write_byte(buffer_addr + index as u32, byte);
+        }
+        cpu.ds = TEST_PSP;
+        cpu.set_ax(0x4000);
+        cpu.set_bx(1);
+        cpu.set_cx(payload.len() as u16);
+        cpu.set_dx(buffer_offset);
+        dos.int21h_40h_write(&mut cpu, memory, &mut StubDisk);
+    }
+
+    #[test]
+    fn int21h_25h_records_vector_event() {
+        let dos = NeetanDos::new();
+        let mut memory = MockMemory::with_extended_memory(0x200000, 0);
+        dos.console
+            .dos_trace
+            .arm(crate::trace::DosTraceInterest::all());
+        let mut cpu = MockCpu::default();
+        cpu.set_ax(0x2529);
+        cpu.ds = 0x2000;
+        cpu.set_dx(0x0123);
+
+        dos.int21h_25h_set_interrupt_vector(&cpu, &mut memory);
+
+        assert_eq!(memory.read_word(0x29 * 4), 0x0123);
+        assert_eq!(memory.read_word(0x29 * 4 + 2), 0x2000);
+        let events = dos.console.dos_trace.events.borrow();
+        let vector = events
+            .iter()
+            .find_map(|event| match event {
+                DosTraceEvent::Vector(vector) => Some(vector.clone()),
+                _ => None,
+            })
+            .expect("vector event");
+        assert_eq!(vector.vector, 0x29);
+        assert_eq!(vector.segment, 0x2000);
+        assert_eq!(vector.offset, 0x0123);
+        assert_eq!(vector.linear_address, 0x20123);
+    }
+
+    #[test]
+    fn int21h_40h_records_exact_bytes_and_console_route() {
+        let (mut dos, mut memory) =
+            dos_with_stdout_handle(crate::tables::SFT_DEVINFO_CHAR_DEVICE_COMMON);
+
+        write_via_ah40(&mut dos, &mut memory, b"HELLO");
+
+        let events = stdout_events(&dos);
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(event.source, source::INT21_40);
+        assert_eq!(event.handle, Some(1));
+        assert_eq!(
+            event.buffer_address,
+            Some(((TEST_PSP as u32) << 4) + 0x0300)
+        );
+        assert_eq!(event.requested_count, 5);
+        assert_eq!(event.bytes, b"HELLO");
+        assert_eq!(event.route, route::CONSOLE);
+        assert_eq!(event.suppression_reason, None);
+    }
+
+    #[test]
+    fn int21h_40h_nul_destination_reports_nul_route() {
+        let (mut dos, mut memory) = dos_with_stdout_handle(
+            crate::tables::SFT_DEVINFO_CHAR_DEVICE_COMMON | crate::tables::SFT_DEVINFO_NUL,
+        );
+
+        write_via_ah40(&mut dos, &mut memory, b"GONE");
+
+        let events = stdout_events(&dos);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].route, route::NUL);
+        assert_eq!(events[0].suppression_reason, None);
+    }
+
+    #[test]
+    fn int21h_40h_iret_hook_reports_suppressed_route() {
+        let (mut dos, mut memory) =
+            dos_with_stdout_handle(crate::tables::SFT_DEVINFO_CHAR_DEVICE_COMMON);
+        memory.write_word(0x29 * 4, 0x0123);
+        memory.write_word(0x29 * 4 + 2, 0x3000);
+        memory.write_byte(0x30123, 0xCF);
+
+        write_via_ah40(&mut dos, &mut memory, b"LOST");
+
+        let events = stdout_events(&dos);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].route, route::SUPPRESSED);
+        assert_eq!(
+            events[0].suppression_reason,
+            Some(crate::trace::suppression::INT29_IRET_HOOK)
+        );
+        assert_eq!(events[0].int29_segment, 0x3000);
+        assert_eq!(events[0].int29_offset, 0x0123);
+        assert_eq!(events[0].bytes, b"LOST");
+    }
+
+    #[test]
+    fn int21h_40h_redirected_stdout_reports_redirected_route() {
+        let (mut dos, mut memory) = dos_with_stdout_handle(0x0000);
+
+        write_via_ah40(&mut dos, &mut memory, b"FILE");
+
+        let events = stdout_events(&dos);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].route, route::REDIRECTED);
+        assert_eq!(events[0].suppression_reason, None);
+        assert_eq!(events[0].bytes, b"FILE");
+    }
+
+    #[test]
+    fn int21h_02h_reports_no_handle() {
+        let (mut dos, mut memory) =
+            dos_with_stdout_handle(crate::tables::SFT_DEVINFO_CHAR_DEVICE_COMMON);
+        let mut cpu = MockCpu::default();
+        cpu.set_ax(0x0200);
+        cpu.set_dx(u16::from(b'A'));
+
+        dos.int21h_02h_display_character(&mut cpu, &mut memory);
+
+        let events = stdout_events(&dos);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].source, source::INT21_02);
+        // AH=02h takes no handle argument, so the event reports none.
+        assert_eq!(events[0].handle, None);
+        assert_eq!(events[0].bytes, b"A");
+        assert_eq!(events[0].route, route::CONSOLE);
+    }
+
+    #[test]
+    fn int21h_06h_iret_hook_suppresses_output_like_ah02() {
+        let (mut dos, mut memory) =
+            dos_with_stdout_handle(crate::tables::SFT_DEVINFO_CHAR_DEVICE_COMMON);
+        memory.write_word(0x29 * 4, 0x0123);
+        memory.write_word(0x29 * 4 + 2, 0x3000);
+        memory.write_byte(0x30123, 0xCF);
+        let mut cpu = MockCpu::default();
+        cpu.set_ax(0x0600);
+        cpu.set_dx(u16::from(b'Z'));
+
+        dos.int21h_06h_direct_console_io(&mut cpu, &mut memory);
+
+        let events = stdout_events(&dos);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].source, source::INT21_06);
+        assert_eq!(events[0].handle, None);
+        assert_eq!(events[0].route, route::SUPPRESSED);
+        assert_eq!(
+            events[0].suppression_reason,
+            Some(crate::trace::suppression::INT29_IRET_HOOK)
+        );
+        assert_eq!(events[0].bytes, b"Z");
+        // The suppressed byte must not reach the console parser.
+        assert_eq!(memory.read_byte(0xA0000), 0x00);
     }
 
     #[test]

--- a/crates/dos/src/file_io.rs
+++ b/crates/dos/src/file_io.rs
@@ -4,6 +4,7 @@ use common::warn;
 
 use crate::{
     CpuAccess, DiskIo, DosState, DriveIo, MemoryAccess, NeetanDos, SegmentRegister,
+    dos::{StdoutRoute, route_for_character_device},
     filesystem::{
         self, FatHandleMetadata, ReadDirEntrySource, ReadDirectory, fat_dir,
         fat_file::FatFileCursor, find_matching_read_entry, find_read_entry, iso9660, split_path,
@@ -704,7 +705,12 @@ impl NeetanDos {
 
             let dev_info = memory.read_word(sft_addr + tables::SFT_ENT_DEV_INFO);
             if dev_info & tables::SFT_DEVINFO_CHAR != 0 {
-                if dev_info & tables::SFT_DEVINFO_NUL != 0 {
+                let is_nul = dev_info & tables::SFT_DEVINFO_NUL != 0;
+                if self.stdout_trace_enabled() {
+                    let route = route_for_character_device(memory, is_nul);
+                    self.record_stdout_write(memory, handle, buf_addr, count, route);
+                }
+                if is_nul {
                     return Ok(count as u16);
                 }
                 // Device write: send to console
@@ -713,6 +719,12 @@ impl NeetanDos {
                     self.write_stdout_byte(memory, byte);
                 }
                 return Ok(count as u16);
+            }
+
+            // A standard output handle pointing at a regular file means the
+            // guest redirected console output.
+            if (handle == 1 || handle == 2) && self.stdout_trace_enabled() {
+                self.record_stdout_write(memory, handle, buf_addr, count, StdoutRoute::Redirected);
             }
 
             // File write

--- a/crates/dos/src/interrupt/int29.rs
+++ b/crates/dos/src/interrupt/int29.rs
@@ -3,12 +3,31 @@
 //! Outputs the character in AL directly to the console, bypassing normal
 //! DOS I/O buffering.
 
-use crate::{CpuAccess, MemoryAccess, NeetanDos};
+use crate::{
+    CpuAccess, MemoryAccess, NeetanDos,
+    trace::{DosStdoutEvent, route, source},
+};
 
 impl NeetanDos {
     /// INT 29h: Fast console output. Character is in AL.
     pub(crate) fn int29h(&mut self, cpu: &mut dyn CpuAccess, memory: &mut dyn MemoryAccess) {
         let al = (cpu.ax() & 0xFF) as u8;
+        if self.stdout_trace_enabled() {
+            self.record_stdout(
+                memory,
+                DosStdoutEvent {
+                    source: source::INT29,
+                    handle: None,
+                    buffer_address: None,
+                    requested_count: 1,
+                    bytes: vec![al],
+                    route: route::CONSOLE,
+                    suppression_reason: None,
+                    int29_segment: 0,
+                    int29_offset: 0,
+                },
+            );
+        }
         self.console.process_byte(memory, al);
     }
 }

--- a/crates/dos/src/lib.rs
+++ b/crates/dos/src/lib.rs
@@ -84,6 +84,7 @@ mod state;
 pub mod tables;
 #[cfg(test)]
 mod test_support;
+pub mod trace;
 
 use std::collections::BTreeMap;
 
@@ -93,7 +94,10 @@ pub use common::{
     SegmentRegister,
 };
 
-use crate::memory::memory_manager::MemoryManager;
+use crate::{
+    memory::memory_manager::MemoryManager,
+    trace::{DosTraceKind, DosTraceSink},
+};
 
 /// Information about a discovered drive for CDS/DPB/DAUA population.
 struct DriveInfo {
@@ -1330,7 +1334,10 @@ impl NeetanDos {
         memory: &mut dyn MemoryAccess,
         device: &mut (impl DiskIo + CdromIo),
         cursor: &mut impl CursorAccess,
+        trace: &mut impl DosTraceSink,
     ) -> bool {
+        self.arm_trace_log(trace);
+
         let hardware = cursor.read();
         let iosys = read_iosys_cursor(memory);
         if iosys != self.last_cursor {
@@ -1345,7 +1352,36 @@ impl NeetanDos {
         let iosys = read_iosys_cursor(memory);
         cursor.write(iosys);
         self.last_cursor = iosys;
+
+        self.drain_trace_log(trace);
         result
+    }
+
+    /// Arms the transient trace log with the sink's per-action interests,
+    /// statically compiled out for a disabled sink.
+    fn arm_trace_log<S: DosTraceSink>(&self, trace: &S) {
+        if S::ENABLED {
+            self.console.dos_trace.arm(trace::DosTraceInterest {
+                vector: trace.wants(DosTraceKind::Vector),
+                stdout: trace.wants(DosTraceKind::Stdout),
+                console_byte: trace.wants(DosTraceKind::ConsoleByte),
+                console_escape: trace.wants(DosTraceKind::ConsoleEscape),
+                cell_write: trace.wants(DosTraceKind::CellWrite),
+                clear: trace.wants(DosTraceKind::Clear),
+                scroll: trace.wants(DosTraceKind::Scroll),
+            });
+        }
+    }
+
+    /// Drains the events captured during a dispatch into the sink, statically
+    /// compiled out for a disabled sink.
+    fn drain_trace_log<S: DosTraceSink>(&self, trace: &mut S) {
+        if S::ENABLED {
+            let events = self.console.dos_trace.finish();
+            for event in &events {
+                trace.emit(event);
+            }
+        }
     }
 
     fn dispatch_inner(

--- a/crates/dos/src/trace.rs
+++ b/crates/dos/src/trace.rs
@@ -1,0 +1,352 @@
+//! DOS-facing trace facade and transient event log.
+//!
+//! The HLE DOS console records semantic events into an interior-mutable log on
+//! [`crate::console::Console`] while a dispatch runs. The machine bus arms the
+//! log through [`DosTraceSink::wants`] and drains it at the dispatch boundary,
+//! forwarding each event to its own generic trace sink. This keeps the `dos`
+//! crate free of any host trace type, and a no-op sink costs a single bool
+//! check per potential event.
+
+use alloc::vec::Vec;
+use core::cell::{Cell, RefCell};
+
+use crate::console_esc::EscState;
+
+/// Console output routing decisions.
+pub mod route {
+    /// Output reached the text console.
+    pub const CONSOLE: &str = "console";
+    /// Output was routed to the NUL device.
+    pub const NUL: &str = "nul";
+    /// Output was redirected to a file handle.
+    pub const REDIRECTED: &str = "redirected";
+    /// Output was suppressed before reaching the console.
+    pub const SUPPRESSED: &str = "suppressed";
+}
+
+/// DOS API paths that produce console-bound output.
+pub mod source {
+    /// INT 21h AH=02h display character.
+    pub const INT21_02: &str = "int21.02";
+    /// INT 21h AH=06h direct console output.
+    pub const INT21_06: &str = "int21.06";
+    /// INT 21h AH=09h display string.
+    pub const INT21_09: &str = "int21.09";
+    /// INT 21h AH=40h write to handle.
+    pub const INT21_40: &str = "int21.40";
+    /// INT 29h fast console output.
+    pub const INT29: &str = "int29";
+}
+
+/// Reasons console output was suppressed.
+pub mod suppression {
+    /// The active INT 29h handler begins with an `IRET`.
+    pub const INT29_IRET_HOOK: &str = "int29-iret-hook";
+}
+
+/// Stable console character-mode symbols.
+pub mod character_mode {
+    /// Single-byte ANK mode.
+    pub const ANK: &str = "ank";
+    /// Shift-JIS kanji mode.
+    pub const SHIFT_JIS: &str = "shift-jis";
+}
+
+/// Maps the console parser state to its stable symbol.
+pub(crate) const fn parser_state_symbol(state: EscState) -> &'static str {
+    match state {
+        EscState::Normal => "normal",
+        EscState::GotEsc => "escape",
+        EscState::GotCsi => "csi",
+        EscState::GotCsiQuestion => "csi-question",
+        EscState::GotCsiGreater => "csi-greater",
+        EscState::GotEscRightParen => "esc-right-paren",
+        EscState::GotEscEqual => "esc-equal",
+        EscState::GotEscEqualRow => "esc-equal-row",
+    }
+}
+
+/// The interest category of a DOS trace event, one per device action.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum DosTraceKind {
+    /// An interrupt-vector change.
+    Vector,
+    /// A console-bound stdout routing decision.
+    Stdout,
+    /// A byte entering the console parser.
+    ConsoleByte,
+    /// A dispatched console escape sequence.
+    ConsoleEscape,
+    /// A written character cell.
+    CellWrite,
+    /// A console clear operation.
+    Clear,
+    /// A console scroll operation.
+    Scroll,
+}
+
+/// The per-action arming state of the DOS trace log for one dispatch.
+#[derive(Clone, Copy, Default)]
+pub struct DosTraceInterest {
+    /// Whether vector events are wanted.
+    pub vector: bool,
+    /// Whether stdout events are wanted.
+    pub stdout: bool,
+    /// Whether console byte events are wanted.
+    pub console_byte: bool,
+    /// Whether console escape events are wanted.
+    pub console_escape: bool,
+    /// Whether cell-write events are wanted.
+    pub cell_write: bool,
+    /// Whether clear events are wanted.
+    pub clear: bool,
+    /// Whether scroll events are wanted.
+    pub scroll: bool,
+}
+
+impl DosTraceInterest {
+    /// Returns interest in every DOS trace event.
+    #[must_use]
+    pub const fn all() -> Self {
+        Self {
+            vector: true,
+            stdout: true,
+            console_byte: true,
+            console_escape: true,
+            cell_write: true,
+            clear: true,
+            scroll: true,
+        }
+    }
+}
+
+/// An interrupt-vector set operation.
+#[derive(Clone)]
+pub struct DosVectorEvent {
+    /// Interrupt vector number.
+    pub vector: u8,
+    /// New handler segment.
+    pub segment: u16,
+    /// New handler offset.
+    pub offset: u16,
+    /// New handler linear target address.
+    pub linear_address: u32,
+}
+
+/// A console-bound stdout routing decision.
+#[derive(Clone)]
+pub struct DosStdoutEvent {
+    /// DOS API path that produced the output.
+    pub source: &'static str,
+    /// File handle, when the API used one.
+    pub handle: Option<u16>,
+    /// Output buffer linear address, when the API supplied one.
+    pub buffer_address: Option<u32>,
+    /// Requested output byte count.
+    pub requested_count: u32,
+    /// Output bytes.
+    pub bytes: Vec<u8>,
+    /// Routing decision.
+    pub route: &'static str,
+    /// Reason output was suppressed, when applicable.
+    pub suppression_reason: Option<&'static str>,
+    /// Active INT 29h handler segment.
+    pub int29_segment: u16,
+    /// Active INT 29h handler offset.
+    pub int29_offset: u16,
+}
+
+/// One byte entering the console parser with before and after state.
+#[derive(Clone)]
+pub struct DosConsoleByteEvent {
+    /// The byte.
+    pub byte: u8,
+    /// Parser state before the byte.
+    pub parser_state_before: &'static str,
+    /// Parser state after the byte.
+    pub parser_state_after: &'static str,
+    /// Character mode before the byte.
+    pub character_mode_before: &'static str,
+    /// Character mode after the byte.
+    pub character_mode_after: &'static str,
+    /// Pending Shift-JIS lead byte before the byte.
+    pub pending_shift_jis_lead_before: Option<u8>,
+    /// Pending Shift-JIS lead byte after the byte.
+    pub pending_shift_jis_lead_after: Option<u8>,
+    /// Cursor row before the byte.
+    pub cursor_row_before: u8,
+    /// Cursor column before the byte.
+    pub cursor_column_before: u8,
+    /// Cursor row after the byte.
+    pub cursor_row_after: u8,
+    /// Cursor column after the byte.
+    pub cursor_column_after: u8,
+    /// Text attribute before the byte.
+    pub attribute_before: u8,
+    /// Text attribute after the byte.
+    pub attribute_after: u8,
+}
+
+/// A complete escape sequence dispatched by the console.
+#[derive(Clone)]
+pub struct DosConsoleEscapeEvent {
+    /// Canonical escape sequence bytes.
+    pub bytes: Vec<u8>,
+    /// Dispatched command identifier.
+    pub command: &'static str,
+    /// Numeric command parameters, preserved without truncation.
+    pub parameters: Vec<u16>,
+    /// Text attribute before the sequence.
+    pub attribute_before: u8,
+    /// Text attribute after the sequence.
+    pub attribute_after: u8,
+    /// Cursor row before the sequence.
+    pub cursor_row_before: u8,
+    /// Cursor column before the sequence.
+    pub cursor_column_before: u8,
+    /// Cursor row after the sequence.
+    pub cursor_row_after: u8,
+    /// Cursor column after the sequence.
+    pub cursor_column_after: u8,
+}
+
+/// A decoded character cell written to text VRAM.
+#[derive(Clone)]
+pub struct DosCellWriteEvent {
+    /// Cell row.
+    pub row: u8,
+    /// Cell column.
+    pub column: u8,
+    /// Raw JIS character value.
+    pub jis: u16,
+    /// Cell display width in columns.
+    pub display_width: u8,
+    /// Cell attribute.
+    pub attribute: u8,
+}
+
+/// A console clear operation.
+#[derive(Clone)]
+pub struct DosClearEvent {
+    /// Top row of the affected region.
+    pub region_top: u8,
+    /// Bottom row of the affected region.
+    pub region_bottom: u8,
+    /// Number of cells cleared.
+    pub count: u32,
+}
+
+/// A console scroll operation.
+#[derive(Clone)]
+pub struct DosScrollEvent {
+    /// Top row of the affected region.
+    pub region_top: u8,
+    /// Bottom row of the affected region.
+    pub region_bottom: u8,
+    /// Number of rows scrolled.
+    pub count: u8,
+    /// Scroll direction, positive when scrolling up.
+    pub direction: i8,
+}
+
+/// A semantic DOS trace event captured during a dispatch.
+#[derive(Clone)]
+pub enum DosTraceEvent {
+    /// An interrupt-vector change.
+    Vector(DosVectorEvent),
+    /// A stdout routing decision.
+    Stdout(DosStdoutEvent),
+    /// A byte entering the console parser.
+    ConsoleByte(DosConsoleByteEvent),
+    /// A dispatched escape sequence.
+    ConsoleEscape(DosConsoleEscapeEvent),
+    /// A written character cell.
+    CellWrite(DosCellWriteEvent),
+    /// A clear operation.
+    Clear(DosClearEvent),
+    /// A scroll operation.
+    Scroll(DosScrollEvent),
+}
+
+/// Receives semantic DOS trace events forwarded at the dispatch boundary.
+///
+/// A statically disabled sink sets [`DosTraceSink::ENABLED`] to `false`, which
+/// lets the dispatch boundary skip arming and draining the log entirely.
+pub trait DosTraceSink {
+    /// Whether this sink can observe events in this monomorphization.
+    const ENABLED: bool = true;
+
+    /// Returns whether the sink wants events of this category.
+    fn wants(&self, kind: DosTraceKind) -> bool {
+        let _ = kind;
+        false
+    }
+
+    /// Consumes one drained event.
+    fn emit(&mut self, event: &DosTraceEvent) {
+        let _ = event;
+    }
+}
+
+/// A no-op DOS trace sink eliminated through static dispatch.
+pub struct NoDosTrace;
+
+impl DosTraceSink for NoDosTrace {
+    const ENABLED: bool = false;
+}
+
+/// Interior-mutable event log filled by the console during a dispatch.
+///
+/// The per-action enable flags live in plain [`Cell`]s so each interest check
+/// is a single bool load without touching the event vec's borrow state.
+#[derive(Clone, Default)]
+pub(crate) struct DosTraceLog {
+    pub(crate) vector_enabled: Cell<bool>,
+    pub(crate) stdout_enabled: Cell<bool>,
+    pub(crate) console_byte_enabled: Cell<bool>,
+    pub(crate) console_escape_enabled: Cell<bool>,
+    pub(crate) cell_write_enabled: Cell<bool>,
+    pub(crate) clear_enabled: Cell<bool>,
+    pub(crate) scroll_enabled: Cell<bool>,
+    pub(crate) events: RefCell<Vec<DosTraceEvent>>,
+}
+
+impl DosTraceLog {
+    /// Arms the log for a dispatch and clears any residual events.
+    pub(crate) fn arm(&self, interest: DosTraceInterest) {
+        self.vector_enabled.set(interest.vector);
+        self.stdout_enabled.set(interest.stdout);
+        self.console_byte_enabled.set(interest.console_byte);
+        self.console_escape_enabled.set(interest.console_escape);
+        self.cell_write_enabled.set(interest.cell_write);
+        self.clear_enabled.set(interest.clear);
+        self.scroll_enabled.set(interest.scroll);
+        self.events.borrow_mut().clear();
+    }
+
+    /// Disarms the log and returns the events captured during the dispatch.
+    pub(crate) fn finish(&self) -> Vec<DosTraceEvent> {
+        self.vector_enabled.set(false);
+        self.stdout_enabled.set(false);
+        self.console_byte_enabled.set(false);
+        self.console_escape_enabled.set(false);
+        self.cell_write_enabled.set(false);
+        self.clear_enabled.set(false);
+        self.scroll_enabled.set(false);
+        core::mem::take(&mut *self.events.borrow_mut())
+    }
+
+    /// Records a vector event when armed.
+    pub(crate) fn push_vector(&self, event: DosVectorEvent) {
+        if self.vector_enabled.get() {
+            self.events.borrow_mut().push(DosTraceEvent::Vector(event));
+        }
+    }
+
+    /// Records a stdout event when armed.
+    pub(crate) fn push_stdout(&self, event: DosStdoutEvent) {
+        if self.stdout_enabled.get() {
+            self.events.borrow_mut().push(DosTraceEvent::Stdout(event));
+        }
+    }
+}

--- a/crates/machine_60/src/machine.rs
+++ b/crates/machine_60/src/machine.rs
@@ -113,7 +113,7 @@ const PC60_TRACE_CATALOG: common::TraceCatalog = common::TraceCatalog {
     scheduled: common::trace_id::scheduled::PC60,
     devices: &[common::TraceDeviceCatalog {
         device: common::trace_id::device::PC60_FDC,
-        actions: &[common::trace_id::action::READ],
+        actions: &[common::trace_action(common::trace_id::action::READ)],
     }],
     providers: &[],
 };

--- a/crates/machine_88/src/machine.rs
+++ b/crates/machine_88/src/machine.rs
@@ -125,7 +125,7 @@ const PC88_TRACE_CATALOG: common::TraceCatalog = common::TraceCatalog {
     scheduled: common::trace_id::scheduled::PC88,
     devices: &[common::TraceDeviceCatalog {
         device: common::trace_id::device::PC88_FDC,
-        actions: &[common::trace_id::action::READ],
+        actions: &[common::trace_action(common::trace_id::action::READ)],
     }],
     providers: &[],
 };

--- a/crates/machine_88va/src/machine.rs
+++ b/crates/machine_88va/src/machine.rs
@@ -124,7 +124,7 @@ const PC88VA_TRACE_CATALOG: common::TraceCatalog = common::TraceCatalog {
     scheduled: common::trace_id::scheduled::PC88VA,
     devices: &[common::TraceDeviceCatalog {
         device: common::trace_id::device::PC88VA_FDC,
-        actions: &[common::trace_id::action::READ],
+        actions: &[common::trace_action(common::trace_id::action::READ)],
     }],
     providers: &[],
 };

--- a/crates/machine_98/src/bus.rs
+++ b/crates/machine_98/src/bus.rs
@@ -5,6 +5,7 @@
 
 mod bios;
 mod dos_adapter;
+mod dos_trace;
 mod fdc;
 mod fdd_hle;
 mod graphics;

--- a/crates/machine_98/src/bus/bios.rs
+++ b/crates/machine_98/src/bus/bios.rs
@@ -17,14 +17,58 @@ mod pmode;
 mod serial_rs232c;
 mod timer;
 
-use common::{Cpu, CpuAccess, SegmentRegister, warn};
+use common::{Cpu, CpuAccess, ProcessorSnapshot, RegisterReading, SegmentRegister, warn};
 use device::upd765a_fdc::{UPD765_PLATFORM_STANDARD, Upd765aFdc};
 
 use super::{
     Pc9801Bus,
     dos_adapter::{DosCpuAccess, DosCursorAccess, DosDiskIo, DosMemoryAccess},
+    dos_trace::DosTraceBridge,
 };
 use crate::{TraceSink, memory::Pc9801Memory};
+
+/// Captures the x86 registers into an atomic processor snapshot.
+///
+/// The base registers are read with the same helpers the machine inspector
+/// uses, so a snapshot register agrees with a separate `register-ref` read.
+/// A processor with protected-mode support appends its 32-bit general
+/// registers, the `fs` and `gs` selectors, `eip`, `eflags`, and the control
+/// registers.
+fn capture_x86_snapshot(processor: &'static str, cpu: &impl Cpu) -> ProcessorSnapshot {
+    let descriptors = common::inspect::x86_registers();
+    let mut registers = Vec::with_capacity(descriptors.len());
+    for descriptor in descriptors {
+        let value = common::inspect::x86_read(cpu, descriptor.name).unwrap_or(0);
+        registers.push(RegisterReading {
+            name: descriptor.name,
+            value,
+        });
+    }
+    if let Some(state) = cpu.protected_mode_state() {
+        registers.extend(state.general);
+        for segment in &state.segments {
+            if matches!(segment.name, "fs" | "gs") {
+                registers.push(RegisterReading {
+                    name: segment.name,
+                    value: u128::from(segment.selector),
+                });
+            }
+        }
+        registers.push(RegisterReading {
+            name: "eip",
+            value: u128::from(state.eip),
+        });
+        registers.push(RegisterReading {
+            name: "eflags",
+            value: u128::from(state.eflags),
+        });
+        registers.extend(state.control);
+    }
+    ProcessorSnapshot {
+        processor,
+        registers,
+    }
+}
 
 const PIT_CLOCK_8MHZ_LINEAGE: u32 = 1_996_800;
 const PAGE_PRESENT: u32 = 0x01;
@@ -232,6 +276,19 @@ impl<T: TraceSink> Pc9801Bus<T> {
             0x1F => self.hle_int1fh(cpu),
             0x20..=0x2A | 0x2F | 0x33 | 0x67 | 0xDC | 0xE7 | 0xEE | 0xEF | 0xFD | 0xFE => {
                 if let Some(mut neetan_dos) = self.dos.take() {
+                    // Capture the guest registers at dispatch entry so the
+                    // boundary call events and every event emitted during the
+                    // HLE handler carry an atomic snapshot. The handler runs to
+                    // completion as one CPU step, so a post-return snapshot
+                    // would show clobbered registers.
+                    let trace_cycle = self.current_cycle;
+                    let trace_clock_hz = self.clocks.cpu_clock_hz;
+                    if T::ENABLED
+                        && let Some(processor) = self.tracer.snapshot_request()
+                    {
+                        let snapshot = capture_x86_snapshot(processor, &*cpu);
+                        self.tracer.set_pending_snapshot(snapshot);
+                    }
                     self.trace_call(
                         common::trace_id::provider::NEETAN_DOS,
                         common::TraceCallInterface::Interrupt(u32::from(vector)),
@@ -257,15 +314,23 @@ impl<T: TraceSink> Pc9801Bus<T> {
                             ide: &mut self.ide,
                         };
                         let mut cursor_access = DosCursorAccess(&mut self.gdc_master.state);
+                        let mut dos_trace = DosTraceBridge {
+                            sink: &mut self.tracer,
+                            cycle: trace_cycle,
+                            clock_hz: trace_clock_hz,
+                        };
                         neetan_dos.dispatch(
                             vector,
                             &mut cpu_access,
                             &mut mem_access,
                             &mut disk_io,
                             &mut cursor_access,
+                            &mut dos_trace,
                         );
                         cpu_access.ax()
                     };
+                    // The exit call event still carries the entry snapshot, so
+                    // the syscall arguments stay visible on either boundary.
                     self.trace_call(
                         common::trace_id::provider::NEETAN_DOS,
                         common::TraceCallInterface::Interrupt(u32::from(vector)),
@@ -274,6 +339,9 @@ impl<T: TraceSink> Pc9801Bus<T> {
                         common::TraceCallPhase::Exit,
                         Some(u64::from(result)),
                     );
+                    if T::ENABLED {
+                        self.tracer.clear_pending_snapshot();
+                    }
                     self.dos = Some(neetan_dos);
                 }
             }

--- a/crates/machine_98/src/bus/dos_trace.rs
+++ b/crates/machine_98/src/bus/dos_trace.rs
@@ -1,0 +1,314 @@
+//! Bridge from the DOS trace facade to the generic machine trace sink.
+//!
+//! The bridge implements `dos::trace::DosTraceSink` on top of any `TraceSink`,
+//! translating each semantic DOS event into a `neetan.dos.*` device event. It
+//! is generic over the sink type, so an untraced build monomorphizes `wants` to
+//! a constant `false` and emits nothing.
+
+use common::{
+    StackVec, TraceContext, TraceDeviceEvent, TraceEvent, TraceEventKey, TraceField, TraceSink,
+    TraceValue, trace_id,
+};
+use dos::trace::{
+    DosCellWriteEvent, DosClearEvent, DosConsoleByteEvent, DosConsoleEscapeEvent, DosScrollEvent,
+    DosStdoutEvent, DosTraceEvent, DosTraceKind, DosTraceSink, DosVectorEvent,
+};
+
+/// The maximum number of fields any single DOS device event carries.
+const MAX_FIELDS: usize = 16;
+
+/// Forwards DOS trace events to a generic trace sink as device events.
+pub(super) struct DosTraceBridge<'a, T: TraceSink> {
+    pub(super) sink: &'a mut T,
+    pub(super) cycle: u64,
+    pub(super) clock_hz: u32,
+}
+
+impl<T: TraceSink> DosTraceBridge<'_, T> {
+    fn emit(&mut self, device: &'static str, action: &'static str, fields: &[TraceField<'_>]) {
+        self.sink.trace(
+            TraceContext::main_cpu(self.cycle, Some(u64::from(self.clock_hz))),
+            TraceEvent::Device(TraceDeviceEvent {
+                device,
+                action,
+                fields,
+            }),
+        );
+    }
+}
+
+/// Represents an optional unsigned field as a value or Boolean false.
+fn optional_unsigned(value: Option<u64>) -> TraceValue<'static> {
+    match value {
+        Some(value) => TraceValue::Unsigned(value),
+        None => TraceValue::Bool(false),
+    }
+}
+
+/// Represents an optional symbol field as a symbol or Boolean false.
+fn optional_symbol(value: Option<&'static str>) -> TraceValue<'static> {
+    match value {
+        Some(value) => TraceValue::Symbol(value),
+        None => TraceValue::Bool(false),
+    }
+}
+
+fn field<'a>(name: &'static str, value: TraceValue<'a>) -> TraceField<'a> {
+    TraceField { name, value }
+}
+
+fn unsigned(name: &'static str, value: u64) -> TraceField<'static> {
+    field(name, TraceValue::Unsigned(value))
+}
+
+impl<T: TraceSink> DosTraceSink for DosTraceBridge<'_, T> {
+    const ENABLED: bool = T::ENABLED;
+
+    fn wants(&self, kind: DosTraceKind) -> bool {
+        if !T::ENABLED {
+            return false;
+        }
+        let (device, action) = match kind {
+            DosTraceKind::Vector => (trace_id::device::NEETAN_DOS_VECTOR, trace_id::action::SET),
+            DosTraceKind::Stdout => (trace_id::device::NEETAN_DOS_STDOUT, trace_id::action::WRITE),
+            DosTraceKind::ConsoleByte => {
+                (trace_id::device::NEETAN_DOS_CONSOLE, trace_id::action::BYTE)
+            }
+            DosTraceKind::ConsoleEscape => (
+                trace_id::device::NEETAN_DOS_CONSOLE,
+                trace_id::action::ESCAPE,
+            ),
+            DosTraceKind::CellWrite => (
+                trace_id::device::NEETAN_DOS_CONSOLE,
+                trace_id::action::CELL_WRITE,
+            ),
+            DosTraceKind::Clear => (
+                trace_id::device::NEETAN_DOS_CONSOLE,
+                trace_id::action::CLEAR,
+            ),
+            DosTraceKind::Scroll => (
+                trace_id::device::NEETAN_DOS_CONSOLE,
+                trace_id::action::SCROLL,
+            ),
+        };
+        self.sink
+            .interested(TraceEventKey::Device { device, action })
+    }
+
+    fn emit(&mut self, event: &DosTraceEvent) {
+        match event {
+            DosTraceEvent::Vector(event) => self.emit_vector(event),
+            DosTraceEvent::Stdout(event) => self.emit_stdout(event),
+            DosTraceEvent::ConsoleByte(event) => self.emit_console_byte(event),
+            DosTraceEvent::ConsoleEscape(event) => self.emit_console_escape(event),
+            DosTraceEvent::CellWrite(event) => self.emit_cell_write(event),
+            DosTraceEvent::Clear(event) => self.emit_clear(event),
+            DosTraceEvent::Scroll(event) => self.emit_scroll(event),
+        }
+    }
+}
+
+impl<T: TraceSink> DosTraceBridge<'_, T> {
+    fn emit_vector(&mut self, event: &DosVectorEvent) {
+        let fields = [
+            unsigned(trace_id::field::VECTOR, u64::from(event.vector)),
+            unsigned(trace_id::field::SEGMENT, u64::from(event.segment)),
+            unsigned(trace_id::field::OFFSET, u64::from(event.offset)),
+            unsigned(
+                trace_id::field::LINEAR_ADDRESS,
+                u64::from(event.linear_address),
+            ),
+        ];
+        self.emit(
+            trace_id::device::NEETAN_DOS_VECTOR,
+            trace_id::action::SET,
+            &fields,
+        );
+    }
+
+    fn emit_stdout(&mut self, event: &DosStdoutEvent) {
+        let fields = [
+            field(trace_id::field::SOURCE, TraceValue::Symbol(event.source)),
+            field(
+                trace_id::field::HANDLE,
+                optional_unsigned(event.handle.map(u64::from)),
+            ),
+            field(
+                trace_id::field::BUFFER_ADDRESS,
+                optional_unsigned(event.buffer_address.map(u64::from)),
+            ),
+            unsigned(
+                trace_id::field::REQUESTED_COUNT,
+                u64::from(event.requested_count),
+            ),
+            field(trace_id::field::BYTES, TraceValue::Bytes(&event.bytes)),
+            field(trace_id::field::ROUTE, TraceValue::Symbol(event.route)),
+            field(
+                trace_id::field::SUPPRESSION_REASON,
+                optional_symbol(event.suppression_reason),
+            ),
+            unsigned(
+                trace_id::field::INT29_SEGMENT,
+                u64::from(event.int29_segment),
+            ),
+            unsigned(trace_id::field::INT29_OFFSET, u64::from(event.int29_offset)),
+        ];
+        self.emit(
+            trace_id::device::NEETAN_DOS_STDOUT,
+            trace_id::action::WRITE,
+            &fields,
+        );
+    }
+
+    fn emit_console_byte(&mut self, event: &DosConsoleByteEvent) {
+        let mut fields = StackVec::<TraceField<'_>, MAX_FIELDS>::new();
+        fields.push(unsigned(trace_id::field::BYTE, u64::from(event.byte)));
+        fields.push(field(
+            trace_id::field::PARSER_STATE_BEFORE,
+            TraceValue::Symbol(event.parser_state_before),
+        ));
+        fields.push(field(
+            trace_id::field::PARSER_STATE_AFTER,
+            TraceValue::Symbol(event.parser_state_after),
+        ));
+        fields.push(field(
+            trace_id::field::CHARACTER_MODE_BEFORE,
+            TraceValue::Symbol(event.character_mode_before),
+        ));
+        fields.push(field(
+            trace_id::field::CHARACTER_MODE_AFTER,
+            TraceValue::Symbol(event.character_mode_after),
+        ));
+        fields.push(field(
+            trace_id::field::PENDING_SHIFT_JIS_LEAD_BEFORE,
+            optional_unsigned(event.pending_shift_jis_lead_before.map(u64::from)),
+        ));
+        fields.push(field(
+            trace_id::field::PENDING_SHIFT_JIS_LEAD_AFTER,
+            optional_unsigned(event.pending_shift_jis_lead_after.map(u64::from)),
+        ));
+        fields.push(unsigned(
+            trace_id::field::CURSOR_ROW_BEFORE,
+            u64::from(event.cursor_row_before),
+        ));
+        fields.push(unsigned(
+            trace_id::field::CURSOR_COLUMN_BEFORE,
+            u64::from(event.cursor_column_before),
+        ));
+        fields.push(unsigned(
+            trace_id::field::CURSOR_ROW_AFTER,
+            u64::from(event.cursor_row_after),
+        ));
+        fields.push(unsigned(
+            trace_id::field::CURSOR_COLUMN_AFTER,
+            u64::from(event.cursor_column_after),
+        ));
+        fields.push(unsigned(
+            trace_id::field::ATTRIBUTE_BEFORE,
+            u64::from(event.attribute_before),
+        ));
+        fields.push(unsigned(
+            trace_id::field::ATTRIBUTE_AFTER,
+            u64::from(event.attribute_after),
+        ));
+        self.emit(
+            trace_id::device::NEETAN_DOS_CONSOLE,
+            trace_id::action::BYTE,
+            &fields,
+        );
+    }
+
+    fn emit_console_escape(&mut self, event: &DosConsoleEscapeEvent) {
+        let fields = [
+            field(trace_id::field::BYTES, TraceValue::Bytes(&event.bytes)),
+            field(trace_id::field::COMMAND, TraceValue::Symbol(event.command)),
+            field(
+                trace_id::field::PARAMETERS,
+                TraceValue::U16List(&event.parameters),
+            ),
+            unsigned(
+                trace_id::field::ATTRIBUTE_BEFORE,
+                u64::from(event.attribute_before),
+            ),
+            unsigned(
+                trace_id::field::ATTRIBUTE_AFTER,
+                u64::from(event.attribute_after),
+            ),
+            unsigned(
+                trace_id::field::CURSOR_ROW_BEFORE,
+                u64::from(event.cursor_row_before),
+            ),
+            unsigned(
+                trace_id::field::CURSOR_COLUMN_BEFORE,
+                u64::from(event.cursor_column_before),
+            ),
+            unsigned(
+                trace_id::field::CURSOR_ROW_AFTER,
+                u64::from(event.cursor_row_after),
+            ),
+            unsigned(
+                trace_id::field::CURSOR_COLUMN_AFTER,
+                u64::from(event.cursor_column_after),
+            ),
+        ];
+        self.emit(
+            trace_id::device::NEETAN_DOS_CONSOLE,
+            trace_id::action::ESCAPE,
+            &fields,
+        );
+    }
+
+    fn emit_cell_write(&mut self, event: &DosCellWriteEvent) {
+        let fields = [
+            unsigned(trace_id::field::ROW, u64::from(event.row)),
+            unsigned(trace_id::field::COLUMN, u64::from(event.column)),
+            unsigned(trace_id::field::JIS, u64::from(event.jis)),
+            unsigned(
+                trace_id::field::DISPLAY_WIDTH,
+                u64::from(event.display_width),
+            ),
+            unsigned(trace_id::field::ATTRIBUTE, u64::from(event.attribute)),
+        ];
+        self.emit(
+            trace_id::device::NEETAN_DOS_CONSOLE,
+            trace_id::action::CELL_WRITE,
+            &fields,
+        );
+    }
+
+    fn emit_clear(&mut self, event: &DosClearEvent) {
+        let fields = [
+            unsigned(trace_id::field::REGION_TOP, u64::from(event.region_top)),
+            unsigned(
+                trace_id::field::REGION_BOTTOM,
+                u64::from(event.region_bottom),
+            ),
+            unsigned(trace_id::field::COUNT, u64::from(event.count)),
+        ];
+        self.emit(
+            trace_id::device::NEETAN_DOS_CONSOLE,
+            trace_id::action::CLEAR,
+            &fields,
+        );
+    }
+
+    fn emit_scroll(&mut self, event: &DosScrollEvent) {
+        let fields = [
+            unsigned(trace_id::field::REGION_TOP, u64::from(event.region_top)),
+            unsigned(
+                trace_id::field::REGION_BOTTOM,
+                u64::from(event.region_bottom),
+            ),
+            unsigned(trace_id::field::COUNT, u64::from(event.count)),
+            field(
+                trace_id::field::DIRECTION,
+                TraceValue::Signed(i64::from(event.direction)),
+            ),
+        ];
+        self.emit(
+            trace_id::device::NEETAN_DOS_CONSOLE,
+            trace_id::action::SCROLL,
+            &fields,
+        );
+    }
+}

--- a/crates/machine_98/src/machine.rs
+++ b/crates/machine_98/src/machine.rs
@@ -227,38 +227,180 @@ impl<C: Pc98RuntimeCpu> common::AutomatedMachine
         Some(self)
     }
 
+    fn text_inspector(&self) -> Option<&dyn common::TextSurfaceInspector> {
+        Some(self)
+    }
+
     fn trace_catalog(&self) -> common::TraceCatalog {
         PC98_TRACE_CATALOG
     }
 }
 
 /// Stable trace identifiers emitted by the PC-98 bus.
+use common::TraceFieldType::{Bytes, Integer, IntegerOrFalse, Symbol, SymbolOrFalse, U16List};
+
+/// Field schema for the `neetan.dos`, BIOS, and extension-ROM call providers.
+///
+/// Enter events carry `function` and `subfunction`. `result` is present only
+/// on exit events, so a `result` constraint matches exit phases alone.
+const PC98_PROVIDER_CALL_FIELDS: &[common::TraceFieldDescriptor] = &[
+    common::trace_field_range(common::trace_id::field::FUNCTION, Integer),
+    common::trace_field_range(common::trace_id::field::SUBFUNCTION, Integer),
+    common::trace_field_range(common::trace_id::field::RESULT, Integer),
+];
+
+/// Field schema for the `neetan.dos.vector` `set` action.
+const DOS_VECTOR_SET_FIELDS: &[common::TraceFieldDescriptor] = &[
+    common::trace_field_range(common::trace_id::field::VECTOR, Integer),
+    common::trace_field(common::trace_id::field::SEGMENT, Integer),
+    common::trace_field(common::trace_id::field::OFFSET, Integer),
+    common::trace_field_range(common::trace_id::field::LINEAR_ADDRESS, Integer),
+];
+
+/// Field schema for the `neetan.dos.stdout` `write` action.
+const DOS_STDOUT_WRITE_FIELDS: &[common::TraceFieldDescriptor] = &[
+    common::trace_field(common::trace_id::field::SOURCE, Symbol),
+    common::trace_field(common::trace_id::field::HANDLE, IntegerOrFalse),
+    common::trace_field(common::trace_id::field::BUFFER_ADDRESS, IntegerOrFalse),
+    common::trace_field(common::trace_id::field::REQUESTED_COUNT, Integer),
+    common::trace_field(common::trace_id::field::BYTES, Bytes),
+    common::trace_field(common::trace_id::field::ROUTE, Symbol),
+    common::trace_field(common::trace_id::field::SUPPRESSION_REASON, SymbolOrFalse),
+    common::trace_field(common::trace_id::field::INT29_SEGMENT, Integer),
+    common::trace_field(common::trace_id::field::INT29_OFFSET, Integer),
+];
+
+/// Field schema for the `neetan.dos.console` `byte` action.
+const DOS_CONSOLE_BYTE_FIELDS: &[common::TraceFieldDescriptor] = &[
+    common::trace_field_range(common::trace_id::field::BYTE, Integer),
+    common::trace_field(common::trace_id::field::PARSER_STATE_BEFORE, Symbol),
+    common::trace_field(common::trace_id::field::PARSER_STATE_AFTER, Symbol),
+    common::trace_field(common::trace_id::field::CHARACTER_MODE_BEFORE, Symbol),
+    common::trace_field(common::trace_id::field::CHARACTER_MODE_AFTER, Symbol),
+    common::trace_field(
+        common::trace_id::field::PENDING_SHIFT_JIS_LEAD_BEFORE,
+        IntegerOrFalse,
+    ),
+    common::trace_field(
+        common::trace_id::field::PENDING_SHIFT_JIS_LEAD_AFTER,
+        IntegerOrFalse,
+    ),
+    common::trace_field(common::trace_id::field::CURSOR_ROW_BEFORE, Integer),
+    common::trace_field(common::trace_id::field::CURSOR_COLUMN_BEFORE, Integer),
+    common::trace_field(common::trace_id::field::CURSOR_ROW_AFTER, Integer),
+    common::trace_field(common::trace_id::field::CURSOR_COLUMN_AFTER, Integer),
+    common::trace_field(common::trace_id::field::ATTRIBUTE_BEFORE, Integer),
+    common::trace_field(common::trace_id::field::ATTRIBUTE_AFTER, Integer),
+];
+
+/// Field schema for the `neetan.dos.console` `escape` action.
+const DOS_CONSOLE_ESCAPE_FIELDS: &[common::TraceFieldDescriptor] = &[
+    common::trace_field(common::trace_id::field::BYTES, Bytes),
+    common::trace_field(common::trace_id::field::COMMAND, Symbol),
+    common::trace_field(common::trace_id::field::PARAMETERS, U16List),
+    common::trace_field(common::trace_id::field::ATTRIBUTE_BEFORE, Integer),
+    common::trace_field(common::trace_id::field::ATTRIBUTE_AFTER, Integer),
+    common::trace_field(common::trace_id::field::CURSOR_ROW_BEFORE, Integer),
+    common::trace_field(common::trace_id::field::CURSOR_COLUMN_BEFORE, Integer),
+    common::trace_field(common::trace_id::field::CURSOR_ROW_AFTER, Integer),
+    common::trace_field(common::trace_id::field::CURSOR_COLUMN_AFTER, Integer),
+];
+
+/// Field schema for the `neetan.dos.console` `cell-write` action.
+const DOS_CONSOLE_CELL_WRITE_FIELDS: &[common::TraceFieldDescriptor] = &[
+    common::trace_field(common::trace_id::field::ROW, Integer),
+    common::trace_field(common::trace_id::field::COLUMN, Integer),
+    common::trace_field_range(common::trace_id::field::JIS, Integer),
+    common::trace_field(common::trace_id::field::DISPLAY_WIDTH, Integer),
+    common::trace_field(common::trace_id::field::ATTRIBUTE, Integer),
+];
+
+/// Field schema for the `neetan.dos.console` `clear` action.
+const DOS_CONSOLE_CLEAR_FIELDS: &[common::TraceFieldDescriptor] = &[
+    common::trace_field(common::trace_id::field::REGION_TOP, Integer),
+    common::trace_field(common::trace_id::field::REGION_BOTTOM, Integer),
+    common::trace_field(common::trace_id::field::COUNT, Integer),
+];
+
+/// Field schema for the `neetan.dos.console` `scroll` action.
+const DOS_CONSOLE_SCROLL_FIELDS: &[common::TraceFieldDescriptor] = &[
+    common::trace_field(common::trace_id::field::REGION_TOP, Integer),
+    common::trace_field(common::trace_id::field::REGION_BOTTOM, Integer),
+    common::trace_field(common::trace_id::field::COUNT, Integer),
+    common::trace_field(common::trace_id::field::DIRECTION, Integer),
+];
+
 const PC98_TRACE_CATALOG: common::TraceCatalog = common::TraceCatalog {
     controllers: &[common::trace_id::controller::PC98_PIC],
     scheduled: common::trace_id::scheduled::PC98,
-    devices: &[common::TraceDeviceCatalog {
-        device: common::trace_id::device::PC98_FDC,
-        actions: &[
-            common::trace_id::action::SEEK,
-            common::trace_id::action::READ,
-        ],
-    }],
+    devices: &[
+        common::TraceDeviceCatalog {
+            device: common::trace_id::device::PC98_FDC,
+            actions: &[
+                common::trace_action(common::trace_id::action::SEEK),
+                common::trace_action(common::trace_id::action::READ),
+            ],
+        },
+        common::TraceDeviceCatalog {
+            device: common::trace_id::device::NEETAN_DOS_VECTOR,
+            actions: &[common::TraceActionCatalog {
+                action: common::trace_id::action::SET,
+                fields: DOS_VECTOR_SET_FIELDS,
+            }],
+        },
+        common::TraceDeviceCatalog {
+            device: common::trace_id::device::NEETAN_DOS_STDOUT,
+            actions: &[common::TraceActionCatalog {
+                action: common::trace_id::action::WRITE,
+                fields: DOS_STDOUT_WRITE_FIELDS,
+            }],
+        },
+        common::TraceDeviceCatalog {
+            device: common::trace_id::device::NEETAN_DOS_CONSOLE,
+            actions: &[
+                common::TraceActionCatalog {
+                    action: common::trace_id::action::BYTE,
+                    fields: DOS_CONSOLE_BYTE_FIELDS,
+                },
+                common::TraceActionCatalog {
+                    action: common::trace_id::action::ESCAPE,
+                    fields: DOS_CONSOLE_ESCAPE_FIELDS,
+                },
+                common::TraceActionCatalog {
+                    action: common::trace_id::action::CELL_WRITE,
+                    fields: DOS_CONSOLE_CELL_WRITE_FIELDS,
+                },
+                common::TraceActionCatalog {
+                    action: common::trace_id::action::CLEAR,
+                    fields: DOS_CONSOLE_CLEAR_FIELDS,
+                },
+                common::TraceActionCatalog {
+                    action: common::trace_id::action::SCROLL,
+                    fields: DOS_CONSOLE_SCROLL_FIELDS,
+                },
+            ],
+        },
+    ],
     providers: &[
         common::TraceProviderCatalog {
             provider: common::trace_id::provider::NEETAN_DOS,
             named_interfaces: &[common::trace_id::interface::BOOT],
+            call_fields: PC98_PROVIDER_CALL_FIELDS,
         },
         common::TraceProviderCatalog {
             provider: common::trace_id::provider::PC98_BIOS,
             named_interfaces: &[],
+            call_fields: PC98_PROVIDER_CALL_FIELDS,
         },
         common::TraceProviderCatalog {
             provider: common::trace_id::provider::PC98_FDD_640K,
             named_interfaces: &[common::trace_id::interface::EXTENSION_ROM],
+            call_fields: PC98_PROVIDER_CALL_FIELDS,
         },
         common::TraceProviderCatalog {
             provider: common::trace_id::provider::PC98_SASI,
             named_interfaces: &[common::trace_id::interface::EXTENSION_ROM],
+            call_fields: PC98_PROVIDER_CALL_FIELDS,
         },
     ],
 };
@@ -366,6 +508,122 @@ impl<C: Pc98RuntimeCpu> common::MachineInspector
             "cpu.main.io" => Err(common::InspectError::NotWritable),
             _ => Err(common::InspectError::UnknownSpace),
         }
+    }
+}
+
+/// The single decoded text surface exposed by the PC-98.
+const PC98_TEXT_SURFACE: &str = "display.main";
+
+/// Text rows on the PC-98 console.
+///
+/// The geometry is fixed to the 80x25 layout the HLE DOS console uses. A guest
+/// that programs the GDC for 20-row or 40-column text is not reflected here.
+const PC98_TEXT_ROWS: u16 = 25;
+
+/// Text columns on the PC-98 console.
+const PC98_TEXT_COLUMNS: u16 = 80;
+
+/// Byte offset of the attribute plane inside the text VRAM.
+const PC98_TEXT_ATTRIBUTE_PLANE: usize = 0x2000;
+
+/// Decodes one PC-98 text cell from the raw text VRAM slice.
+fn decode_pc98_text_cell(vram: &[u8], row: u16, column: u16) -> common::TextCell {
+    let cell_index = (row as usize * PC98_TEXT_COLUMNS as usize + column as usize) * 2;
+    let even = vram.get(cell_index).copied().unwrap_or(0);
+    let odd = vram.get(cell_index + 1).copied().unwrap_or(0);
+    let attribute = vram
+        .get(PC98_TEXT_ATTRIBUTE_PLANE + cell_index)
+        .copied()
+        .unwrap_or(0);
+    let jis = common::JisChar::from_vram_bytes(even, odd);
+    common::TextCell {
+        row,
+        column,
+        raw_jis: jis.as_u16(),
+        unicode: common::jis_to_char(jis),
+        attribute,
+        display_width: jis.display_width(),
+    }
+}
+
+impl<C: Pc98RuntimeCpu> common::TextSurfaceInspector
+    for Pc98Machine<C, common::tracing::ApplicationTraceSink>
+{
+    fn text_surfaces(&self) -> common::TextSurfaceList {
+        let mut surfaces = common::TextSurfaceList::new();
+        surfaces.push(common::TextSurfaceInfo {
+            id: PC98_TEXT_SURFACE,
+            rows: PC98_TEXT_ROWS,
+            columns: PC98_TEXT_COLUMNS,
+        });
+        surfaces
+    }
+
+    fn text_surface_info(
+        &self,
+        surface: &str,
+    ) -> Result<common::TextSurfaceInfo, common::InspectError> {
+        match surface {
+            PC98_TEXT_SURFACE => Ok(common::TextSurfaceInfo {
+                id: PC98_TEXT_SURFACE,
+                rows: PC98_TEXT_ROWS,
+                columns: PC98_TEXT_COLUMNS,
+            }),
+            _ => Err(common::InspectError::UnknownSpace),
+        }
+    }
+
+    fn text_cell(
+        &self,
+        surface: &str,
+        row: u16,
+        column: u16,
+    ) -> Result<common::TextCell, common::InspectError> {
+        if surface != PC98_TEXT_SURFACE {
+            return Err(common::InspectError::UnknownSpace);
+        }
+        if row >= PC98_TEXT_ROWS || column >= PC98_TEXT_COLUMNS {
+            return Err(common::InspectError::OutOfRange);
+        }
+        Ok(decode_pc98_text_cell(self.bus.text_vram(), row, column))
+    }
+
+    fn text_row(
+        &self,
+        surface: &str,
+        row: u16,
+    ) -> Result<Vec<common::TextCell>, common::InspectError> {
+        if surface != PC98_TEXT_SURFACE {
+            return Err(common::InspectError::UnknownSpace);
+        }
+        if row >= PC98_TEXT_ROWS {
+            return Err(common::InspectError::OutOfRange);
+        }
+        let vram = self.bus.text_vram();
+        let mut cells = Vec::with_capacity(PC98_TEXT_COLUMNS as usize);
+        for column in 0..PC98_TEXT_COLUMNS {
+            cells.push(decode_pc98_text_cell(vram, row, column));
+        }
+        Ok(cells)
+    }
+
+    fn text_screen(
+        &self,
+        surface: &str,
+    ) -> Result<Vec<Vec<common::TextCell>>, common::InspectError> {
+        if surface != PC98_TEXT_SURFACE {
+            return Err(common::InspectError::UnknownSpace);
+        }
+        let vram = self.bus.text_vram();
+        let mut rows = Vec::with_capacity(PC98_TEXT_ROWS as usize);
+        for row in 0..PC98_TEXT_ROWS {
+            let mut cells = Vec::with_capacity(PC98_TEXT_COLUMNS as usize);
+            for column in 0..PC98_TEXT_COLUMNS {
+                cells.push(decode_pc98_text_cell(vram, row, column));
+            }
+            rows.push(cells);
+        }
+        Ok(rows)
     }
 }
 
@@ -993,6 +1251,53 @@ mod save_state_tests {
         machine.run_for(257);
         machine.restore_state(&snapshot).unwrap();
         assert_eq!(machine.capture_state().unwrap(), snapshot);
+    }
+
+    #[test]
+    fn trace_catalog_declares_the_dos_devices_with_their_actions() {
+        let expectations: &[(&str, &[&str])] = &[
+            (common::trace_id::device::NEETAN_DOS_VECTOR, &["set"]),
+            (common::trace_id::device::NEETAN_DOS_STDOUT, &["write"]),
+            (
+                common::trace_id::device::NEETAN_DOS_CONSOLE,
+                &["byte", "escape", "cell-write", "clear", "scroll"],
+            ),
+        ];
+        for (device, actions) in expectations {
+            let catalog = PC98_TRACE_CATALOG
+                .devices
+                .iter()
+                .find(|entry| entry.device == *device)
+                .unwrap_or_else(|| panic!("catalog must declare {device}"));
+            for action in *actions {
+                let declared = catalog
+                    .actions
+                    .iter()
+                    .find(|entry| entry.action == *action)
+                    .unwrap_or_else(|| panic!("{device} must declare action {action}"));
+                assert!(
+                    !declared.fields.is_empty(),
+                    "{device} action {action} must describe its fields"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn trace_catalog_declares_provider_call_fields() {
+        for provider in PC98_TRACE_CATALOG.providers {
+            let names: Vec<&str> = provider
+                .call_fields
+                .iter()
+                .map(|descriptor| descriptor.name)
+                .collect();
+            assert_eq!(
+                names,
+                ["function", "subfunction", "result"],
+                "{} must describe its call fields",
+                provider.provider
+            );
+        }
     }
 
     #[test]

--- a/crates/machine_at/src/machine.rs
+++ b/crates/machine_at/src/machine.rs
@@ -121,7 +121,7 @@ const AT_TRACE_CATALOG: common::TraceCatalog = common::TraceCatalog {
     scheduled: common::trace_id::scheduled::AT,
     devices: &[common::TraceDeviceCatalog {
         device: common::trace_id::device::AT_FDC,
-        actions: &[common::trace_id::action::READ],
+        actions: &[common::trace_action(common::trace_id::action::READ)],
     }],
     providers: &[],
 };

--- a/crates/machine_fm7/src/machine.rs
+++ b/crates/machine_fm7/src/machine.rs
@@ -137,7 +137,7 @@ const FM7_TRACE_CATALOG: common::TraceCatalog = common::TraceCatalog {
     scheduled: common::trace_id::scheduled::FM7,
     devices: &[common::TraceDeviceCatalog {
         device: common::trace_id::device::FM7_FDC,
-        actions: &[common::trace_id::action::READ],
+        actions: &[common::trace_action(common::trace_id::action::READ)],
     }],
     providers: &[],
 };

--- a/crates/machine_msx/src/machine.rs
+++ b/crates/machine_msx/src/machine.rs
@@ -113,15 +113,15 @@ const MSX_TRACE_CATALOG: common::TraceCatalog = common::TraceCatalog {
     devices: &[
         common::TraceDeviceCatalog {
             device: common::trace_id::device::MSX_SLOT,
-            actions: &[common::trace_id::action::SELECT],
+            actions: &[common::trace_action(common::trace_id::action::SELECT)],
         },
         common::TraceDeviceCatalog {
             device: common::trace_id::device::MSX_MAPPER,
-            actions: &[common::trace_id::action::BANK],
+            actions: &[common::trace_action(common::trace_id::action::BANK)],
         },
         common::TraceDeviceCatalog {
             device: common::trace_id::device::MSX_FDC,
-            actions: &[common::trace_id::action::READ],
+            actions: &[common::trace_action(common::trace_id::action::READ)],
         },
     ],
     providers: &[],

--- a/crates/machine_towns/src/machine.rs
+++ b/crates/machine_towns/src/machine.rs
@@ -214,14 +214,14 @@ const TOWNS_TRACE_CATALOG: common::TraceCatalog = common::TraceCatalog {
         common::TraceDeviceCatalog {
             device: common::trace_id::device::TOWNS_CDROM,
             actions: &[
-                common::trace_id::action::INTERRUPT,
-                common::trace_id::action::STATUS,
-                common::trace_id::action::COMMAND,
+                common::trace_action(common::trace_id::action::INTERRUPT),
+                common::trace_action(common::trace_id::action::STATUS),
+                common::trace_action(common::trace_id::action::COMMAND),
             ],
         },
         common::TraceDeviceCatalog {
             device: common::trace_id::device::TOWNS_FDC,
-            actions: &[common::trace_id::action::READ],
+            actions: &[common::trace_action(common::trace_id::action::READ)],
         },
     ],
     providers: &[],

--- a/crates/machine_x1/src/machine.rs
+++ b/crates/machine_x1/src/machine.rs
@@ -113,7 +113,7 @@ const X1_TRACE_CATALOG: common::TraceCatalog = common::TraceCatalog {
     scheduled: common::trace_id::scheduled::X1,
     devices: &[common::TraceDeviceCatalog {
         device: common::trace_id::device::X1_FDC,
-        actions: &[common::trace_id::action::READ],
+        actions: &[common::trace_action(common::trace_id::action::READ)],
     }],
     providers: &[],
 };

--- a/crates/machine_x68k/src/machine.rs
+++ b/crates/machine_x68k/src/machine.rs
@@ -126,7 +126,7 @@ const X68K_TRACE_CATALOG: common::TraceCatalog = common::TraceCatalog {
     scheduled: common::trace_id::scheduled::X68K,
     devices: &[common::TraceDeviceCatalog {
         device: common::trace_id::device::X68K_FDC,
-        actions: &[common::trace_id::action::READ],
+        actions: &[common::trace_action(common::trace_id::action::READ)],
     }],
     providers: &[],
 };

--- a/crates/r7rs/src/native/context.rs
+++ b/crates/r7rs/src/native/context.rs
@@ -158,6 +158,15 @@ impl NativeContext<'_> {
             .ok_or_else(|| type_error("string", value, self.heap))
     }
 
+    /// Renders a value to its `write` external representation.
+    ///
+    /// The text matches the `write` procedure, so it reads back with `read`. This
+    /// lets a host serialize Scheme data to an artifact and reload it later without
+    /// a bespoke serializer.
+    pub fn write_to_string(&self, value: Value) -> Result<String, Error> {
+        crate::printer::write_value(self.heap, value, crate::printer::RuntimeWriteMode::Write)
+    }
+
     /// Borrows the name of a symbol argument.
     ///
     /// The slice is valid for the callback activation. Callers that need to

--- a/doc/scheme/inspect.md
+++ b/doc/scheme/inspect.md
@@ -34,3 +34,35 @@ handle from [`(neetan automation 1)`](automation.md).
 - `(memory-peek-unsigned machine space address width byte-order)` -> integer.
   Reads a `width`-byte unsigned value. `byte-order` is `little`, `big`, or
   `native` (the address-space descriptor's order).
+- `(save-memory! machine space address length path)` -> alist with `path` and
+  `bytes`. Writes `length` exact guest bytes beneath the artifact root, ready
+  for tools such as `ndisasm`. Path traversal and absolute paths raise
+  `neetan/path-escape`.
+
+## Text surfaces
+
+Decoded text-mode inspection without knowing the physical text VRAM layout or
+performing JIS decoding in Scheme. Reads are side-effect-free and never render
+a framebuffer. On the PC-98 the main surface is `display.main`.
+
+- `(text-surfaces machine)` -> list of symbols. The inspectable text surfaces.
+- `(text-surface-info machine surface)` -> alist. Keys `id`, `rows`, and
+  `columns`.
+- `(text-cell machine surface row column)` -> alist. One decoded cell with
+  `row`, `column`, `raw-jis`, `unicode` (a character, or `#f` when the code has
+  no mapping), `attribute` (the raw hardware attribute byte), and
+  `display-width` (1 or 2 columns).
+- `(text-screen machine surface)` -> list of strings. Every row decoded to
+  text, top to bottom. Use `text-cell` when raw attributes matter, for example
+  to check reverse video separately from the glyphs.
+- `(wait-for-text machine surface predicate)` /
+  `(wait-for-text machine surface predicate options)` -> string or `#f`. Runs
+  the machine until the decoded surface matches, returning the matched text.
+  The predicate is a bare string, shorthand for `((contains . string))`, or an
+  alist with a required `contains` string and an optional `row`; options are
+  `frames` (default `120`) and `ticks`. The live text plane is sampled once up
+  front and then at each frame boundary, so text appearing and vanishing
+  within a single frame is not observed.
+- `(save-text-screen! machine surface path)` -> alist with `path` and `bytes`.
+  Writes the decoded rows beneath the artifact root, one line per row. Path
+  traversal and absolute paths raise `neetan/path-escape`.

--- a/doc/scheme/trace.md
+++ b/doc/scheme/trace.md
@@ -16,7 +16,10 @@ every target emits every class. Every procedure takes a `machine` handle from
 - `(trace-schema machine)` -> alist. The discovery descriptor: `schema-version`,
   `queue-limits`, `envelope-fields`, `classes`, `supported-classes`,
   `address-spaces`, `controllers`, `scheduled`, `devices`, and `providers`. It
-  also reports which numeric fields accept `(range minimum maximum)`.
+  also reports which numeric fields accept `(range minimum maximum)`. Each
+  device entry lists its actions as alists with `action` and `fields`, where
+  every field descriptor carries `name`, `type`, and `range`. Providers list
+  their `call-fields` the same way.
 
 ## Continuous collection
 
@@ -25,6 +28,27 @@ every target emits every class. Every procedure takes a `machine` handle from
   supported events. Missing keys are wildcards; scalars match with `equal?`;
   `(range minimum maximum)` is an inclusive numeric range on range-capable
   fields. Invalid keys, types, or ranges fail before machine execution.
+
+  A device filter's `data` block may carry a nested `fields` alist constraining
+  the provider-specific fields the schema declares for the named `device` and
+  `action`, or for the named call `provider`. Constraints may be symbols,
+  integers, booleans, bytevectors, ranges, or `#f` to match a falseable field
+  with no value. An integer or range constraint on an `integer-list` field
+  (such as escape `parameters`) matches when any list element satisfies it:
+
+  ```scheme
+  (wait-for-event machine
+    '((class . device)
+      (data . ((device . neetan.dos.stdout)
+               (action . write)
+               (fields . ((source . int21.40)
+                          (handle . 1)))))))
+  ```
+
+  Unknown field names and wrong value types are rejected before the machine
+  runs. Naming a specific device narrows collection so other high-volume
+  device events are never built, and naming an `action` too narrows it
+  further, so sibling actions of the same device are also never built.
 - `(trace-active? machine)` -> boolean. Whether continuous collection is on.
 - `(trace-stop! machine)` -> unspecified. Stops collection without discarding
   buffered events or the failure report.
@@ -41,15 +65,73 @@ every target emits every class. Every procedure takes a `machine` handle from
 - `(wait-for-event machine filter)` / `(wait-for-event machine filter options)`
   -> event alist or `#f`. A standalone one-shot: runs the machine until the
   first event matching `filter`, then returns it, or `#f` when a bound is
-  exhausted. Options keys `frames` (default `120`) and `ticks`. It is invalid
-  while `trace-active?` is true (raises `neetan/trace-state`).
+  exhausted. Options keys `frames` (default `120`), `ticks`, and `snapshot` (a
+  list holding one processor symbol, for example `(snapshot . (cpu.main))`). It
+  is invalid while `trace-active?` is true (raises `neetan/trace-state`).
+
+  With `snapshot`, the returned event carries a `snapshot` key mapping the
+  processor to its register alist. The registers are captured at HLE dispatch
+  entry, before the handler can clobber them, so events emitted during an HLE
+  call expose the guest's syscall arguments. The boundary `call` events carry
+  the same entry snapshot on both the `enter` and `exit` phases. Events
+  outside an HLE dispatch marshal `snapshot` as `#f`.
+
+## Artifacts
+
+- `(save-trace! machine path)` -> alist with `path` and `bytes`. Writes the
+  buffered events beneath the artifact root as Scheme data, one event datum per
+  line in the `trace-drain!` alist shape, reading back with `read`. Byte fields
+  are `#u8(...)` literals and integers are exact. Non-consuming; the buffer
+  stays drainable. Note that `wait-for-event` drains the buffer when it
+  matches, so a `save-trace!` right after a one-shot wait writes an empty
+  artifact. Path traversal and absolute paths raise `neetan/path-escape`.
+
+## Triggered ring capture
+
+- `(trace-arm! machine spec)` -> alist. Runs a bounded before-and-after capture
+  around a trigger event. `spec` is an alist with required keys `capture` and
+  `trigger` (declarative filters as for `trace-start!`), `before` and `after`
+  (event counts), and `artifact` (output path), plus optional `frames` and
+  `ticks` run bounds:
+
+  ```scheme
+  (trace-arm! machine
+    '((capture . ((class . access)))
+      (trigger . ((class . device)
+                  (data . ((device . neetan.dos.stdout)
+                           (action . write)))))
+      (before . 512)
+      (after . 512)
+      (artifact . "stdout-context.scm")))
+  ```
+
+  Events matching `capture` are kept in a window of at most `before` events
+  preceding the first `trigger` match and `after` events following it. Storage
+  is bounded from the moment of arming: the window is limited to the queue
+  event capacity (`before + after + 1` beyond it is rejected up front) and the
+  retained payload bytes are charged against the queue byte capacity, so a
+  ring capture honours the same `queue-limits` the schema advertises. Both
+  filters are evaluated in Rust before any owned payload is allocated, and the
+  machine stops as soon as the post-trigger context is complete. Once the
+  trigger has fired the retained events are written to `artifact` in the
+  `save-trace!` format. Filter and path validation happen before the machine
+  runs, and the capture always disarms on return.
+
+  The result alist carries `triggered`, `complete`, `events`, `trigger-index`
+  (`#f` until triggered), and `bytes` (`#f` when no artifact was written). It
+  is invalid while `trace-active?` is true (raises `neetan/trace-state`). An
+  oversized event payload or an exhausted byte capacity raises
+  `neetan/trace-overflow` with the sticky failure available from
+  `trace-failure`; when the trigger had already fired, the partially retained
+  window is still written to `artifact` before the failure is raised.
 
 ## Event shape
 
 Every normalized event is an alist with keys `schema-version`, `sequence`,
 `epoch`, `tick`, `source`, `clock-domain`, `clock-cycle`, `clock-rate`, `class`,
-and `data`. `clock-rate` is `#f` or an alist with `numerator` and `denominator`.
-The required `data` keys by `class` are:
+`data`, and `snapshot` (`#f` unless a register snapshot was armed and the event
+was emitted during an HLE dispatch). `clock-rate` is `#f` or an alist with
+`numerator` and `denominator`. The required `data` keys by `class` are:
 
 - `access`: `space`, `space-class`, `operation`, `address`, `width` (bits),
   `value` (`#f` when unavailable), and `handled?`.
@@ -60,6 +142,14 @@ The required `data` keys by `class` are:
 - `device`: `device`, `action`, and `fields`.
 - `call`: `provider`, `interface` (an alist with `kind` and `value`), `phase`,
   and `fields`.
+
+For the HLE DOS devices, `neetan.dos.stdout` reports `handle` as `#f` for the
+DOS APIs that take no handle argument (`int21.02`, `int21.06`, `int21.09`, and
+`int29`); only `int21.40` carries a real handle. `neetan.dos.console` `escape`
+events cover both CSI sequences and the complete non-CSI sequences
+(`clear-screen`, `line-feed`, `next-line`, `reverse-line-feed`, `kanji-mode`,
+`graphic-mode`, `cursor-address`, and the `set-mode` family), and their
+`parameters` field is a list of exact integers.
 
 A continuous or one-shot overflow raises `neetan/trace-overflow` on the active
 run; the buffer keeps the earliest complete events.


### PR DESCRIPTION
Adds more commands to the inspect and trace libraries of the automation crate. These features were found to be helpful, when we debugged a problem with the HLE DOS and the text rendering. This should allow Scheme based automation tests to fully debug problems in the emulation of games. We use S-Expression for serializing trace data, since those can easily read by Scheme scripts back.